### PR TITLE
Unable to identify users with Posthog.identify

### DIFF
--- a/android/src/main/java/com/posthog/posthog_flutter/PosthogFlutterPlugin.java
+++ b/android/src/main/java/com/posthog/posthog_flutter/PosthogFlutterPlugin.java
@@ -13,7 +13,6 @@ import android.util.Log;
 import com.posthog.android.PostHog;
 import com.posthog.android.PostHogContext;
 import com.posthog.android.Properties;
-import com.posthog.android.Traits;
 import com.posthog.android.Options;
 import com.posthog.android.Middleware;
 import com.posthog.android.payloads.BasePayload;
@@ -147,9 +146,9 @@ public class PosthogFlutterPlugin implements MethodCallHandler, FlutterPlugin {
   private void identify(MethodCall call, Result result) {
     try {
       String userId = call.argument("userId");
-      HashMap<String, Object> traitsData = call.argument("traits");
+      HashMap<String, Object> propertiesData = call.argument("properties");
       HashMap<String, Object> options = call.argument("options");
-      this.callIdentify(userId, traitsData, options);
+      this.callIdentify(userId, propertiesData, options);
       result.success(true);
     } catch (Exception e) {
       result.error("PosthogFlutterException", e.getLocalizedMessage(), null);

--- a/lib/src/posthog_method_channel.dart
+++ b/lib/src/posthog_method_channel.dart
@@ -7,13 +7,13 @@ const MethodChannel _channel = MethodChannel('posthogflutter');
 
 class PosthogMethodChannel extends PosthogPlatform {
   Future<void> identify({
-    @required distinctId,
+    @required userId,
     Map<String, dynamic> properties,
     Map<String, dynamic> options,
   }) async {
     try {
       await _channel.invokeMethod('identify', {
-        'distinctId': distinctId,
+        'userId': userId,
         'properties': properties ?? {},
         'options': options ?? PosthogDefaultOptions.instance.options ?? {},
       });


### PR DESCRIPTION
Fix method signature mismatch between `Posthog.identify` and `PosthogMethodChannel.identify` which prevented `Posthog.identify` from calling respective platform channels. See relevant below:
```
Class 'PosthogMethodChannel' has no instance method 'identify' with matching arguments.
Receiver: Instance of 'PosthogMethodChannel'
Tried calling: identify(options: null, properties: _LinkedHashMap len:0, userId: "nloHwQNA4wYTxoh44wL5xL4jmWv2")
Found: identify({dynamic distinctId, Map<String, dynamic> properties, Map<String, dynamic> options}) => Future<void>
```

Also fixes related error on Android-specific platform implementation which uses the deprecated `trait` field instead of `properties` causing the following error:
```
I/flutter (14566): PlatformException(PosthogFlutterException, Attempt to invoke virtual method 'java.util.Set java.util.HashMap.entrySet()' on a null object reference, null)
```