### PR TITLE
Change Posthog client lib to be a singleton for shared state and bump…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.0
+
+- We will include the last screen that you set in the capture events now.
+  This will require users to user `Posthog().capture()` instead of `Posthog.capture()`
+
 ## 1.9.3
 
 - Bug fix for android identify method

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    Posthog.screen(
+    Posthog().screen(
       screenName: 'Example Screen',
     );
     return MaterialApp(
@@ -48,7 +48,7 @@ class MyApp extends StatelessWidget {
           child: FlatButton(
             child: Text('TRACK ACTION WITH POSTHOG'),
             onPressed: () {
-              Posthog.capture(
+              Posthog().capture(
                 eventName: 'ButtonClicked',
                 properties: {
                   'foo': 'bar',

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -34,7 +34,9 @@ class Posthog {
     Map<String, dynamic> properties,
     Map<String, dynamic> options,
   }) {
-    properties['\$screen_name'] = this.currentScreen;
+    if (!properties.containsKey('\$screen_name')) {
+      properties['\$screen_name'] = this.currentScreen;
+    }
     return _posthog.capture(
       eventName: eventName,
       properties: properties,

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -9,7 +9,15 @@ export 'package:posthog_flutter/src/posthog_default_options.dart';
 class Posthog {
   static PosthogPlatform get _posthog => PosthogPlatform.instance;
 
-  static Future<void> identify({
+  static final Posthog _instance = Posthog._internal();
+
+  factory Posthog() {
+    return _instance;
+  }
+
+  String currentScreen;
+
+  Future<void> identify({
     @required userId,
     Map<String, dynamic> properties,
     Map<String, dynamic> options,
@@ -21,11 +29,12 @@ class Posthog {
     );
   }
 
-  static Future<void> capture({
+  Future<void> capture({
     @required String eventName,
     Map<String, dynamic> properties,
     Map<String, dynamic> options,
   }) {
+    properties['\$screen_name'] = this.currentScreen;
     return _posthog.capture(
       eventName: eventName,
       properties: properties,
@@ -33,11 +42,14 @@ class Posthog {
     );
   }
 
-  static Future<void> screen({
+  Future<void> screen({
     @required String screenName,
     Map<String, dynamic> properties,
     Map<String, dynamic> options,
   }) {
+    if (screenName != '/') {
+      this.currentScreen = screenName;
+    }
     return _posthog.screen(
       screenName: screenName,
       properties: properties,
@@ -45,7 +57,7 @@ class Posthog {
     );
   }
 
-  static Future<void> alias({
+  Future<void> alias({
     @required String alias,
     Map<String, dynamic> options,
   }) {
@@ -55,23 +67,23 @@ class Posthog {
     );
   }
 
-  static Future<String> get getAnonymousId {
+  Future<String> get getAnonymousId {
     return _posthog.getAnonymousId;
   }
 
-  static Future<void> reset() {
+  Future<void> reset() {
     return _posthog.reset();
   }
 
-  static Future<void> disable() {
+  Future<void> disable() {
     return _posthog.disable();
   }
 
-  static Future<void> enable() {
+  Future<void> enable() {
     return _posthog.enable();
   }
 
-  static Future<void> debug(bool enabled) {
+  Future<void> debug(bool enabled) {
     if (Platform.isAndroid) {
       throw Exception('Debug flag cannot be dynamically set on Android.\n'
           'Add to AndroidManifest and avoid calling this method when Platform.isAndroid.');
@@ -80,7 +92,9 @@ class Posthog {
     return _posthog.debug(enabled);
   }
 
-  static Future<void> setContext(Map<String, dynamic> context) {
+  Future<void> setContext(Map<String, dynamic> context) {
     return _posthog.setContext(context);
   }
+
+  Posthog._internal();
 }

--- a/lib/src/posthog_observer.dart
+++ b/lib/src/posthog_observer.dart
@@ -13,7 +13,7 @@ class PosthogObserver extends RouteObserver<PageRoute<dynamic>> {
   void _sendScreenView(PageRoute<dynamic> route) {
     final String screenName = nameExtractor(route.settings);
     if (screenName != null) {
-      Posthog.screen(screenName: screenName);
+      Posthog().screen(screenName: screenName);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: posthog_flutter
 description: Flutter implementation of Posthog client for iOS, Android and Web
-version: 1.9.3
+version: 1.10.0
 homepage: https://www.posthog.com
 repository: https://github.com/posthog/posthog-flutter
 issue_tracker: https://github.com/posthog/posthog-flutter/issues


### PR DESCRIPTION
… version v1.10.0

This will require users to user `Posthog().capture()` instead of `Posthog.capture()`

The reason why the change is if a user wants to set the current `.screen` and then have that be included in future `.capture` events, especially where they may be calling `.capture` without knowing what screen the user is on. In order to do this we need to keep some state in the Posthog client and we only want one, so singleton it is!