### PR TITLE
feat: Add enable and disable to web implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To use this plugin, add `posthog_flutter` as a [dependency in your pubspec.yaml 
 | `alias`          | X       | X   | X   |
 | `getAnonymousId` | X       | X   | X   |
 | `reset`          | X       | X   | X   |
-| `disable`        | X       | X   |     |
-| `enable`         | X       | X   |     |
+| `disable`        | X       | X   | X   |
+| `enable`         | X       | X   | X   |
 | `debug`          | X\*     | X   | X   |
 | `setContext`     | X       | X   |     |
 

--- a/lib/src/posthog_web.dart
+++ b/lib/src/posthog_web.dart
@@ -51,6 +51,12 @@ class PosthogWeb {
           call.arguments['debug'],
         ]);
         break;
+      case 'enable':
+        analytics.callMethod('opt_in_capturing');
+        break;
+      case 'disable':
+        analytics.callMethod('opt_out_capturing');
+        break;
       default:
         throw PlatformException(
           code: 'Unimplemented',


### PR DESCRIPTION
# Changes
This PR adds support for `enable` and `disable` for Flutter Web.

# Implementation
Following the existing implementation the calls will be delegated to the Javascript Client Library. `enable` maps to `opt_in_capturing` and disable to `opt_out_capturing`.



This Change does not belog to an open issue. But seemed like a pretty easy addition to me.