### PR TITLE
Bump major version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+- Adds basic feature flags support with `isFeatureEnabled` and `reloadFeatureFlags`
+
 ## 2.0.3
 
 - Bugfixes with flutter web and identify call https://github.com/PostHog/posthog-flutter/pull/16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: posthog_flutter
 description: Flutter implementation of Posthog client for iOS, Android and Web
-version: 2.0.4
+version: 3.0.0
 homepage: https://www.posthog.com
 repository: https://github.com/posthog/posthog-flutter
 issue_tracker: https://github.com/posthog/posthog-flutter/issues


### PR DESCRIPTION
Release for version 3.0.0 that includes feature flags thanks to https://github.com/PostHog/posthog-flutter/pull/21 !