### PR TITLE
Fix version constraint in `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: posthog_flutter
-description: Flutter implementation of Posthog client for iOS, Android and Web
+description: Flutter implementation of PostHog client for iOS, Android and Web
 version: 3.1.0
 homepage: https://www.posthog.com
 repository: https://github.com/posthog/posthog-flutter
@@ -8,14 +8,13 @@ documentation: https://github.com/posthog/posthog-flutter#readme
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=1.10.0'
+  flutter: '>=2.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Dart version is set to 2.12, which shipped in Flutter 2.0 ([src](https://developers.googleblog.com/2021/03/announcing-flutter-2.html)).

It's a good practice to keep these two in sync.