### PR TITLE
Fix an issue in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    Posthog().screen(
-      screenName: 'Example Screen',
-    );
     return MaterialApp(
+      navigatorObservers: [
+        // The PosthogObserver records screen views
+        PosthogObserver(),
+      ],
       home: Scaffold(
         appBar: AppBar(
           title: Text('Posthog example app'),
@@ -62,9 +63,6 @@ class MyApp extends StatelessWidget {
           ),
         ),
       ),
-      navigatorObservers: [
-        PosthogObserver(),
-      ],
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,10 +31,10 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    Posthog().screen(
-      screenName: 'Example Screen',
-    );
     return MaterialApp(
+      navigatorObservers: [
+        PosthogObserver(),
+      ],
       home: Scaffold(
         appBar: AppBar(
           title: Text('Posthog example app'),
@@ -121,9 +121,6 @@ class MyApp extends StatelessWidget {
           ],
         ),
       ),
-      navigatorObservers: [
-        PosthogObserver(),
-      ],
     );
   }
 }


### PR DESCRIPTION
Calls like `Posthog().screen(screenName: 'Example Screen');` should not be done in a widgets build method since the build method is potentially called multiple times. Therefore, this could lead to wrongly recorded analytics with too many screen views. Additionally, the `PosthogObserver` is already recording that exact screen view.

In this specific example, it might actually be acceptable, though, since it's the root widget. However, an example shouldn't be this nuanced, so it's better to remove it.