### PR TITLE
don't mutate properties or options

### DIFF
--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -33,15 +33,18 @@ class Posthog {
     Map<String, dynamic>? properties,
     Map<String, dynamic>? options,
   }) {
-    if (properties != null &&
-        !properties.containsKey('\$screen_name') &&
+    final _properties = properties == null ? null : {...properties};
+    final _options = options == null ? null : {...options};
+
+    if (_properties != null &&
+        !_properties.containsKey('\$screen_name') &&
         this.currentScreen != null) {
-      properties['\$screen_name'] = this.currentScreen;
+      _properties['\$screen_name'] = this.currentScreen;
     }
     return _posthog.capture(
       eventName: eventName,
-      properties: properties,
-      options: options,
+      properties: _properties,
+      options: _options,
     );
   }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was sending an analytics payload to multiple providers, Posthog was mutating the properties map and adding in `$screen_name`


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
