### PR TITLE
chore: refactor root screen recording and do not mutate properties when calling capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+- Record the root view as `root ("/")` instead of not recording at all [#70](https://github.com/PostHog/posthog-flutter/pull/70)
+- Do not mutate the given properties when calling capture [#70](https://github.com/PostHog/posthog-flutter/pull/70)
+  - Thanks @lukepighetti for the [PR](https://github.com/PostHog/posthog-flutter/pull/66)!
+
 ## 4.0.0-alpha.2
 
 - Internal changes only

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       navigatorObservers: [
-        // The PosthogObserver records screen views
+        // The PosthogObserver records screen views automatically
         PosthogObserver(),
       ],
       home: Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,6 +25,10 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorObservers: [
+        // The PosthogObserver records screen views automatically
+        PosthogObserver()
+      ],
       home: Scaffold(
         appBar: AppBar(
           title: const Text('PostHog Flutter App'),
@@ -52,7 +56,7 @@ class _MyAppState extends State<MyApp> {
                             "foo": "bar",
                           });
                         },
-                        child: const Text("Capture Screen"),
+                        child: const Text("Capture Screen manually"),
                       ),
                       ElevatedButton(
                         onPressed: () {

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -27,15 +27,17 @@ class Posthog {
     required String eventName,
     Map<String, Object>? properties,
   }) {
+    final propertiesCopy = properties == null ? null : {...properties};
+
     final currentScreen = _currentScreen;
-    if (properties != null &&
-        !properties.containsKey('\$screen_name') &&
+    if (propertiesCopy != null &&
+        !propertiesCopy.containsKey('\$screen_name') &&
         currentScreen != null) {
-      properties['\$screen_name'] = currentScreen;
+      propertiesCopy['\$screen_name'] = currentScreen;
     }
     return _posthog.capture(
       eventName: eventName,
-      properties: properties,
+      properties: propertiesCopy,
     );
   }
 
@@ -43,9 +45,8 @@ class Posthog {
     required String screenName,
     Map<String, Object>? properties,
   }) {
-    if (screenName != '/') {
-      _currentScreen = screenName;
-    }
+    _currentScreen = screenName;
+
     return _posthog.screen(
       screenName: screenName,
       properties: properties,

--- a/lib/src/posthog_observer.dart
+++ b/lib/src/posthog_observer.dart
@@ -13,8 +13,13 @@ class PosthogObserver extends RouteObserver<PageRoute<dynamic>> {
   final ScreenNameExtractor _nameExtractor;
 
   void _sendScreenView(PageRoute<dynamic> route) {
-    final String? screenName = _nameExtractor(route.settings);
+    String? screenName = _nameExtractor(route.settings);
     if (screenName != null) {
+      // if the screen name is the root route, we send it as root ("/") instead of only "/"
+      if (screenName == '/') {
+        screenName = 'root ("/")';
+      }
+
       Posthog().screen(screenName: screenName);
     }
   }


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-flutter/pull/66
Capture the root screen view


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
