### PR TITLE
chore: add unregister method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- add unregister method ([#86](https://github.com/PostHog/posthog-flutter/pull/86))
+
 ## 4.0.1
 
 - Fix passing optional values to the JS SDK ([#84](https://github.com/PostHog/posthog-flutter/pull/84))

--- a/android/src/main/kotlin/com/posthog/posthog_flutter/PosthogFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/posthog/posthog_flutter/PosthogFlutterPlugin.kt
@@ -120,6 +120,9 @@ class PosthogFlutterPlugin : FlutterPlugin, MethodCallHandler {
             "register" -> {
                 register(call, result)
             }
+            "unregister" -> {
+                unregister(call, result)
+            }
             "debug" -> {
                 debug(call, result)
             }
@@ -287,5 +290,13 @@ class PosthogFlutterPlugin : FlutterPlugin, MethodCallHandler {
         }
     }
 
-
+    private fun unregister(call: MethodCall, result: Result) {
+        try {
+            val key: String = call.argument("key")!!
+            PostHog.unregister(key)
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
 }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -212,7 +212,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -108,6 +108,12 @@ class _MyAppState extends State<MyApp> {
                   ),
                   ElevatedButton(
                     onPressed: () async {
+                      await _posthogFlutterPlugin.unregister("foo");
+                    },
+                    child: const Text("Unregister"),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
                       await _posthogFlutterPlugin.group(
                           groupType: "theType",
                           groupKey: "theKey",

--- a/ios/Classes/PosthogFlutterPlugin.swift
+++ b/ios/Classes/PosthogFlutterPlugin.swift
@@ -80,6 +80,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             group(call, result: result)
         case "register":
             register(call, result: result)
+        case "unregister":
+            unregister(call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -277,6 +279,20 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
            let value = args["value"]
         {
             PostHogSDK.shared.register([key: value])
+            result(nil)
+        } else {
+            _badArgumentError(result: result)
+        }
+    }
+
+    private func unregister(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        if let args = call.arguments as? [String: Any],
+           let key = args["key"] as? String
+        {
+            PostHogSDK.shared.unregister(key)
             result(nil)
         } else {
             _badArgumentError(result: result)

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -85,6 +85,10 @@ class Posthog {
     return _posthog.register(key, value);
   }
 
+  Future<void> unregister(String key) {
+    return _posthog.unregister(key);
+  }
+
   Future<bool> isFeatureEnabled(String key) {
     return _posthog.isFeatureEnabled(key);
   }

--- a/lib/src/posthog_flutter_io.dart
+++ b/lib/src/posthog_flutter_io.dart
@@ -193,6 +193,16 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     }
   }
 
+  @override
+  Future<void> unregister(String key) async {
+    try {
+      return await _methodChannel
+          .invokeMethod('unregister', {'key': key});
+    } on PlatformException catch (exception) {
+      _printIfDebug('Exeption on unregister: $exception');
+    }
+  }
+
   void _printIfDebug(String message) {
     if (kDebugMode) {
       print(message);

--- a/lib/src/posthog_flutter_io.dart
+++ b/lib/src/posthog_flutter_io.dart
@@ -196,8 +196,7 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   @override
   Future<void> unregister(String key) async {
     try {
-      return await _methodChannel
-          .invokeMethod('unregister', {'key': key});
+      return await _methodChannel.invokeMethod('unregister', {'key': key});
     } on PlatformException catch (exception) {
       _printIfDebug('Exeption on unregister: $exception');
     }

--- a/lib/src/posthog_flutter_platform_interface.dart
+++ b/lib/src/posthog_flutter_platform_interface.dart
@@ -75,7 +75,7 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
   }
 
   Future<void> unregister(String key) {
-    throw UnimplementedError('register() has not been implemented.');
+    throw UnimplementedError('unregister() has not been implemented.');
   }
 
   Future<bool> isFeatureEnabled(String key) {

--- a/lib/src/posthog_flutter_platform_interface.dart
+++ b/lib/src/posthog_flutter_platform_interface.dart
@@ -74,6 +74,10 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
     throw UnimplementedError('register() has not been implemented.');
   }
 
+  Future<void> unregister(String key) {
+    throw UnimplementedError('register() has not been implemented.');
+  }
+
   Future<bool> isFeatureEnabled(String key) {
     throw UnimplementedError('isFeatureEnabled() has not been implemented.');
   }

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -81,8 +81,13 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
       return featureFlag;
     case 'register':
       final properties = {call.arguments['key']: call.arguments['value']};
-      analytics.callMethod('register', [
+      analytics .callMethod('register', [
         JsObject.jsify(properties),
+      ]);
+      break;
+    case 'unregister':
+      analytics.callMethod('unregister', [
+        call.arguments['key'],
       ]);
       break;
     default:

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -81,7 +81,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
       return featureFlag;
     case 'register':
       final properties = {call.arguments['key']: call.arguments['value']};
-      analytics .callMethod('register', [
+      analytics.callMethod('register', [
         JsObject.jsify(properties),
       ]);
       break;


### PR DESCRIPTION
## :bulb: Motivation and Context
Add `unregister` method.

Follow up https://posthog.slack.com/archives/C04MZFDA5KK/p1709027632605249
the user didn't need to `reset`, but could `register` and `unregister` something.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
