### PR TITLE
chore: Allow overriding the route filtering using a ctor param `routeFilter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         working-directory: ./example
         run: flutter pub get
 
+      - name: Test
+        run: flutter test
+
       - name: Build iOS
         working-directory: ./example
         run: flutter build ios --simulator --no-codesign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Next
 
-- Allow overriding the route filtering usint a ctor param `routeFilter` ([#95](https://github.com/PostHog/posthog-flutter/pull/95))
+- chore: Allow overriding the route filtering using a ctor param `routeFilter` ([#95](https://github.com/PostHog/posthog-flutter/pull/95))
+
+```dart
+bool myRouteFilter(Route<dynamic>? route) =>
+        route is PageRoute || route is OverlayRoute;
+final observer = PosthogObserver(routeFilter: myRouteFilter);
+```
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Allow tracking non `PageRoute` screens using the `PosthogObserver` ([#108](
+
 ## 4.3.0
 
 - add PrivacyInfo ([#94](https://github.com/PostHog/posthog-flutter/pull/94))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Allow tracking non `PageRoute` screens using the `PosthogObserver` ([#95](https://github.com/PostHog/posthog-flutter/pull/95))
+- Allow overriding the route filtering usint a ctor param `routeFilter` ([#95](https://github.com/PostHog/posthog-flutter/pull/95))
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Allow tracking non `PageRoute` screens using the `PosthogObserver` ([#108](
+- Allow tracking non `PageRoute` screens using the `PosthogObserver` ([#95](https://github.com/PostHog/posthog-flutter/pull/95))
 
 ## 4.3.0
 

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -122,9 +122,4 @@ class Posthog {
   }
 
   Posthog._internal();
-
-  // @internal
-  // void overridePostHogForTesting(PosthogFlutterPlatformInterface posthog) {
-  //   PosthogFlutterPlatformInterface.instance = posthog;
-  // }
 }

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -4,7 +4,7 @@ class Posthog {
   static PosthogFlutterPlatformInterface get _posthog =>
       PosthogFlutterPlatformInterface.instance;
 
-  static final Posthog _instance = Posthog._internal();
+  static final _instance = Posthog._internal();
 
   factory Posthog() {
     return _instance;
@@ -122,4 +122,9 @@ class Posthog {
   }
 
   Posthog._internal();
+
+  // @internal
+  // void overridePostHogForTesting(PosthogFlutterPlatformInterface posthog) {
+  //   PosthogFlutterPlatformInterface.instance = posthog;
+  // }
 }

--- a/lib/src/posthog_observer.dart
+++ b/lib/src/posthog_observer.dart
@@ -13,7 +13,7 @@ String? defaultNameExtractor(RouteSettings settings) => settings.name;
 
 bool defaultPostHogRouteFilter(Route<dynamic>? route) => route is PageRoute;
 
-class PosthogObserver extends RouteObserver<PageRoute<dynamic>> {
+class PosthogObserver extends RouteObserver<ModalRoute<dynamic>> {
   PosthogObserver(
       {ScreenNameExtractor nameExtractor = defaultNameExtractor,
       PostHogRouteFilter routeFilter = defaultPostHogRouteFilter})

--- a/lib/src/posthog_observer.dart
+++ b/lib/src/posthog_observer.dart
@@ -12,39 +12,44 @@ class PosthogObserver extends RouteObserver<PageRoute<dynamic>> {
 
   final ScreenNameExtractor _nameExtractor;
 
-  void _sendScreenView(PageRoute<dynamic> route) {
-    String? screenName = _nameExtractor(route.settings);
-    if (screenName != null) {
+  bool _isTrackeableRoute(String? name) {
+    return name != null && name.trim().isNotEmpty;
+  }
+
+  void _sendScreenView(Route<dynamic>? route) {
+    if (route == null) {
+      return;
+    }
+
+    var screenName = _nameExtractor(route.settings);
+    if (_isTrackeableRoute(screenName)) {
       // if the screen name is the root route, we send it as root ("/") instead of only "/"
       if (screenName == '/') {
         screenName = 'root (\'/\')';
       }
 
-      Posthog().screen(screenName: screenName);
+      Posthog().screen(screenName: screenName!);
     }
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    if (route is PageRoute) {
-      _sendScreenView(route);
-    }
+
+    _sendScreenView(route);
   }
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    if (newRoute is PageRoute) {
-      _sendScreenView(newRoute);
-    }
+
+    _sendScreenView(newRoute);
   }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-    if (previousRoute is PageRoute && route is PageRoute) {
-      _sendScreenView(previousRoute);
-    }
+
+    _sendScreenView(previousRoute);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:
-  flutter_lints: ^2.0.0
+  flutter_lints: ^3.0.0
+  flutter_test:
+    sdk: flutter
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/posthog_flutter_platform_interface_fake.dart
+++ b/test/posthog_flutter_platform_interface_fake.dart
@@ -1,0 +1,13 @@
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+
+class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
+  String? screenName;
+
+  @override
+  Future<void> screen({
+    required String screenName,
+    Map<String, Object>? properties,
+  }) async {
+    this.screenName = screenName;
+  }
+}

--- a/test/posthog_observer_test.dart
+++ b/test/posthog_observer_test.dart
@@ -38,7 +38,6 @@ void main() {
     final sut = getSut();
     sut.didPush(currentRoute, null);
 
-    // expectAsync0(() => expect(fake.screenName, 'Current Route'));
     expect(fake.screenName, 'Current Route');
   });
 

--- a/test/posthog_observer_test.dart
+++ b/test/posthog_observer_test.dart
@@ -1,0 +1,82 @@
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/posthog.dart';
+import 'package:posthog_flutter/src/posthog_flutter_io.dart';
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+import 'package:posthog_flutter/src/posthog_observer.dart';
+
+import 'posthog_flutter_platform_interface_fake.dart';
+
+void main() {
+  PageRoute<dynamic> route(RouteSettings? settings) => PageRouteBuilder<void>(
+        pageBuilder: (_, __, ___) => Container(),
+        settings: settings,
+      );
+
+  final fake = PosthogFlutterPlatformFake();
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    PosthogFlutterPlatformInterface.instance = fake;
+  });
+
+  tearDown(() {
+    fake.screenName = null;
+    PosthogFlutterPlatformInterface.instance = PosthogFlutterIO();
+  });
+
+  PosthogObserver getSut(
+      {ScreenNameExtractor nameExtractor = defaultNameExtractor}) {
+    return PosthogObserver(nameExtractor: nameExtractor);
+  }
+
+  test('returns current route name', () {
+    final currentRoute = route(const RouteSettings(name: 'Current Route'));
+
+    final sut = getSut();
+    sut.didPush(currentRoute, null);
+
+    // expectAsync0(() => expect(fake.screenName, 'Current Route'));
+    expect(fake.screenName, 'Current Route');
+  });
+
+  test('returns overriden route name', () {
+    final currentRoute = route(const RouteSettings(name: 'Current Route'));
+
+    String? nameExtractor(RouteSettings settings) => 'overriden';
+
+    final sut = getSut(nameExtractor: nameExtractor);
+    sut.didPush(currentRoute, null);
+
+    expect(fake.screenName, 'overriden');
+  });
+
+  test('returns overriden root route name', () {
+    final currentRoute = route(const RouteSettings(name: '/'));
+
+    final sut = getSut();
+    sut.didPush(currentRoute, null);
+
+    expect(fake.screenName, 'root (\'/\')');
+  });
+
+  test('does not capture not named routes', () {
+    final currentRoute = route(const RouteSettings(name: null));
+
+    final sut = getSut();
+    sut.didPush(currentRoute, null);
+
+    expect(fake.screenName, null);
+  });
+
+  test('does not capture blank routes', () {
+    final currentRoute = route(const RouteSettings(name: '  '));
+
+    final sut = getSut();
+    sut.didPush(currentRoute, null);
+
+    expect(fake.screenName, null);
+  });
+}


### PR DESCRIPTION
## :bulb: Motivation and Context
https://twitter.com/luke_pighetti/status/1774906968886366545


## :green_heart: How did you test it?
Using a fake `PosthogFlutterPlatformInterface`, it was the easiest way to test it and not break or add any public APIs

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
