### PR TITLE
fix: const defaultHost was renamed to DEFAULT_HOST and broke the Android build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: const `defaultHost` was renamed to `DEFAULT_HOST` and broke the Android build ([#96](https://github.com/PostHog/posthog-flutter/issues/96))
+- fix: const `defaultHost` was renamed to `DEFAULT_HOST` and broke the Android build ([#98](https://github.com/PostHog/posthog-flutter/issues/98))
 
 ## 4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: const `defaultHost` was renamed to `DEFAULT_HOST` and broke the Android build ([#96](https://github.com/PostHog/posthog-flutter/issues/96))
+
 ## 4.4.0
 
 - chore: Allow overriding the route filtering using a ctor param `routeFilter` ([#95](https://github.com/PostHog/posthog-flutter/pull/95))

--- a/android/src/main/kotlin/com/posthog/posthog_flutter/PosthogFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/posthog/posthog_flutter/PosthogFlutterPlugin.kt
@@ -41,7 +41,7 @@ class PosthogFlutterPlugin : FlutterPlugin, MethodCallHandler {
                 return
             }
 
-            val host = bundle.getString("com.posthog.posthog.POSTHOG_HOST", PostHogConfig.defaultHost)
+            val host = bundle.getString("com.posthog.posthog.POSTHOG_HOST", PostHogConfig.DEFAULT_HOST)
             val trackApplicationLifecycleEvents = bundle.getBoolean("com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS", false)
             val enableDebug = bundle.getBoolean("com.posthog.posthog.DEBUG", false)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/PostHog/posthog-flutter/issues/96


## :green_heart: How did you test it?
CI is green

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
