### PR TITLE
feat: Update posthog-flutter to support wasm-builds

### DIFF
--- a/lib/posthog_flutter_web.dart
+++ b/lib/posthog_flutter_web.dart
@@ -2,7 +2,8 @@
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:js';
+import 'dart:js_interop';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -25,6 +26,6 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) async {
-    return handleWebMethodCall(call, context);
+    return handleWebMethodCall(call, globalContext);
   }
 }

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -11,8 +11,8 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
           call.arguments['userPropertiesSetOnce'] ?? {};
       analytics.callMethodVarArgs('identify'.toJS, [
         call.arguments['userId'],
-        userProperties.toJSBox,
-        userPropertiesSetOnce.toJSBox,
+        userProperties.jsify(),
+        userPropertiesSetOnce.jsify(),
       ]);
       break;
     case 'capture':
@@ -29,7 +29,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
 
       analytics.callMethodVarArgs('capture'.toJS, [
         '\$screen'.toJS,
-        properties.toJSBox,
+        properties.jsify(),
       ]);
       break;
     case 'alias':
@@ -84,7 +84,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
     case 'register':
       final properties = {call.arguments['key']: call.arguments['value']};
       analytics.callMethodVarArgs('register'.toJS, [
-        properties.toJSBox,
+        properties.jsify(),
       ]);
       break;
     case 'unregister':

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -6,8 +6,8 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
   final JSObject analytics = context.getProperty('posthog'.toJS)!;
   switch (call.method) {
     case 'identify':
-      final Map userProperties = call.arguments['userProperties'] ?? {};
-      final Map userPropertiesSetOnce =
+      final userProperties = call.arguments['userProperties'] ?? {};
+      final userPropertiesSetOnce =
           call.arguments['userPropertiesSetOnce'] ?? {};
       analytics.callMethodVarArgs('identify'.toJS, [
         call.arguments['userId'],
@@ -23,7 +23,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
       ]);
       break;
     case 'screen':
-      final Map properties = call.arguments['properties'] ?? {};
+      final properties = call.arguments['properties'] ?? {};
       final screenName = call.arguments['screenName'];
       properties['\$screen_name'] = screenName;
 

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -6,30 +6,30 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
   final JSObject analytics = context.getProperty('posthog'.toJS)!;
   switch (call.method) {
     case 'identify':
-      final userProperties = call.arguments['userProperties'] ?? {};
-      final userPropertiesSetOnce =
+      final Map userProperties = call.arguments['userProperties'] ?? {};
+      final Map userPropertiesSetOnce =
           call.arguments['userPropertiesSetOnce'] ?? {};
       analytics.callMethodVarArgs('identify'.toJS, [
         call.arguments['userId'],
-        userProperties,
-        jsify(userPropertiesSetOnce),
+        userProperties.toJSBox,
+        userPropertiesSetOnce.toJSBox,
       ]);
       break;
     case 'capture':
       final properties = call.arguments['properties'] ?? {};
       analytics.callMethodVarArgs('capture'.toJS, [
         call.arguments['eventName'],
-        jsify(properties),
+        properties.jsify(),
       ]);
       break;
     case 'screen':
-      final properties = call.arguments['properties'] ?? {};
+      final Map properties = call.arguments['properties'] ?? {};
       final screenName = call.arguments['screenName'];
       properties['\$screen_name'] = screenName;
 
       analytics.callMethodVarArgs('capture'.toJS, [
         '\$screen'.toJS,
-        jsify(properties),
+        properties.toJSBox,
       ]);
       break;
     case 'alias':
@@ -39,13 +39,13 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
       break;
     case 'distinctId':
       final distinctId = analytics.callMethod('get_distinct_id'.toJS);
-      return distinctId;
+      return distinctId?.dartify();
     case 'reset':
       analytics.callMethod('reset'.toJS);
       break;
     case 'debug':
       analytics.callMethodVarArgs('debug'.toJS, [
-        call.arguments['debug'],
+        call.arguments['debug'].toJS,
       ]);
       break;
     case 'isFeatureEnabled':
@@ -56,9 +56,9 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
       return isFeatureEnabled;
     case 'group':
       analytics.callMethodVarArgs('group'.toJS, [
-        call.arguments['groupType'],
-        call.arguments['groupKey'],
-        jsify(call.arguments['groupProperties'] ?? {}),
+        call.arguments['groupType'].toJS,
+        call.arguments['groupKey'].toJS,
+        (call.arguments['groupProperties'] ?? {}).jsify(),
       ]);
       break;
     case 'reloadFeatureFlags':
@@ -72,24 +72,24 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
       break;
     case 'getFeatureFlag':
       final featureFlag = analytics.callMethodVarArgs('getFeatureFlag'.toJS, [
-        call.arguments['key'],
+        call.arguments['key'].toJS,
       ]);
       return featureFlag;
     case 'getFeatureFlagPayload':
       final featureFlag =
           analytics.callMethodVarArgs('getFeatureFlagPayload'.toJS, [
-        call.arguments['key'],
+        call.arguments['key'].toJS,
       ]);
-      return featureFlag;
+      return featureFlag?.dartify();
     case 'register':
       final properties = {call.arguments['key']: call.arguments['value']};
       analytics.callMethodVarArgs('register'.toJS, [
-        jsify(properties),
+        properties.toJSBox,
       ]);
       break;
     case 'unregister':
       analytics.callMethodVarArgs('unregister'.toJS, [
-        call.arguments['key'],
+        call.arguments['key'].toJS,
       ]);
       break;
     case 'flush':
@@ -103,8 +103,4 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
             "The posthog plugin for web doesn't implement the method '${call.method}'",
       );
   }
-}
-
-JSAny jsify(dynamic any) {
-  return any as JSAny;
 }

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -1,25 +1,25 @@
-import 'dart:js';
-
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'package:flutter/services.dart';
 
-Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
-  final analytics = JsObject.fromBrowserObject(context['posthog']);
+Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
+  final JSObject analytics = context.getProperty('posthog'.toJS)!;
   switch (call.method) {
     case 'identify':
       final userProperties = call.arguments['userProperties'] ?? {};
       final userPropertiesSetOnce =
           call.arguments['userPropertiesSetOnce'] ?? {};
-      analytics.callMethod('identify', [
+      analytics.callMethodVarArgs('identify'.toJS, [
         call.arguments['userId'],
-        JsObject.jsify(userProperties),
-        JsObject.jsify(userPropertiesSetOnce),
+        userProperties,
+        jsify(userPropertiesSetOnce),
       ]);
       break;
     case 'capture':
       final properties = call.arguments['properties'] ?? {};
-      analytics.callMethod('capture', [
+      analytics.callMethodVarArgs('capture'.toJS, [
         call.arguments['eventName'],
-        JsObject.jsify(properties),
+        jsify(properties),
       ]);
       break;
     case 'screen':
@@ -27,66 +27,68 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
       final screenName = call.arguments['screenName'];
       properties['\$screen_name'] = screenName;
 
-      analytics.callMethod('capture', [
-        '\$screen',
-        JsObject.jsify(properties),
+      analytics.callMethodVarArgs('capture'.toJS, [
+        '\$screen'.toJS,
+        jsify(properties),
       ]);
       break;
     case 'alias':
-      analytics.callMethod('alias', [
+      analytics.callMethodVarArgs('alias'.toJS, [
         call.arguments['alias'],
       ]);
       break;
     case 'distinctId':
-      final distinctId = analytics.callMethod('get_distinct_id');
+      final distinctId = analytics.callMethod('get_distinct_id'.toJS);
       return distinctId;
     case 'reset':
-      analytics.callMethod('reset');
+      analytics.callMethod('reset'.toJS);
       break;
     case 'debug':
-      analytics.callMethod('debug', [
+      analytics.callMethodVarArgs('debug'.toJS, [
         call.arguments['debug'],
       ]);
       break;
     case 'isFeatureEnabled':
-      final isFeatureEnabled = analytics.callMethod('isFeatureEnabled', [
+      final isFeatureEnabled =
+          analytics.callMethodVarArgs('isFeatureEnabled'.toJS, [
         call.arguments['key'],
       ]);
       return isFeatureEnabled;
     case 'group':
-      analytics.callMethod('group', [
+      analytics.callMethodVarArgs('group'.toJS, [
         call.arguments['groupType'],
         call.arguments['groupKey'],
-        JsObject.jsify(call.arguments['groupProperties'] ?? {}),
+        jsify(call.arguments['groupProperties'] ?? {}),
       ]);
       break;
     case 'reloadFeatureFlags':
-      analytics.callMethod('reloadFeatureFlags');
+      analytics.callMethod('reloadFeatureFlags'.toJS);
       break;
     case 'enable':
-      analytics.callMethod('opt_in_capturing');
+      analytics.callMethod('opt_in_capturing'.toJS);
       break;
     case 'disable':
-      analytics.callMethod('opt_out_capturing');
+      analytics.callMethod('opt_out_capturing'.toJS);
       break;
     case 'getFeatureFlag':
-      final featureFlag = analytics.callMethod('getFeatureFlag', [
+      final featureFlag = analytics.callMethodVarArgs('getFeatureFlag'.toJS, [
         call.arguments['key'],
       ]);
       return featureFlag;
     case 'getFeatureFlagPayload':
-      final featureFlag = analytics.callMethod('getFeatureFlagPayload', [
+      final featureFlag =
+          analytics.callMethodVarArgs('getFeatureFlagPayload'.toJS, [
         call.arguments['key'],
       ]);
       return featureFlag;
     case 'register':
       final properties = {call.arguments['key']: call.arguments['value']};
-      analytics.callMethod('register', [
-        JsObject.jsify(properties),
+      analytics.callMethodVarArgs('register'.toJS, [
+        jsify(properties),
       ]);
       break;
     case 'unregister':
-      analytics.callMethod('unregister', [
+      analytics.callMethodVarArgs('unregister'.toJS, [
         call.arguments['key'],
       ]);
       break;
@@ -101,4 +103,8 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
             "The posthog plugin for web doesn't implement the method '${call.method}'",
       );
   }
+}
+
+JSAny jsify(dynamic any) {
+  return any as JSAny;
 }

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -10,7 +10,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
       final userPropertiesSetOnce =
           call.arguments['userPropertiesSetOnce'] ?? {};
       analytics.callMethodVarArgs('identify'.toJS, [
-        call.arguments['userId'],
+        (call.arguments['userId'] as String).toJS,
         userProperties.jsify(),
         userPropertiesSetOnce.jsify(),
       ]);
@@ -18,7 +18,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
     case 'capture':
       final properties = call.arguments['properties'] ?? {};
       analytics.callMethodVarArgs('capture'.toJS, [
-        call.arguments['eventName'],
+        (call.arguments['eventName'] as String).toJS,
         properties.jsify(),
       ]);
       break;
@@ -34,7 +34,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
       break;
     case 'alias':
       analytics.callMethodVarArgs('alias'.toJS, [
-        call.arguments['alias'],
+        (call.arguments['alias'] as String).toJS,
       ]);
       break;
     case 'distinctId':
@@ -51,7 +51,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JSObject context) async {
     case 'isFeatureEnabled':
       final isFeatureEnabled =
           analytics.callMethodVarArgs('isFeatureEnabled'.toJS, [
-        call.arguments['key'],
+        (call.arguments['key'] as String).toJS,
       ]);
       return isFeatureEnabled;
     case 'group':


### PR DESCRIPTION
This is a potential PR for WASM-Support in posthog-flutter.

## :bulb: Motivation and Context
Enables wasm-builds in web as it uses dart:js_interop instead of dart:js.
Also the new functions give a little bit more type safety.

Closes https://github.com/PostHog/posthog-flutter/issues/112

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
