### PR TITLE
fix: resolve issue with premature image disposal causing black replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next
 
-## 4.9.0
+## 4.9.1
 
-- fix: blank screen when viewing session replay recordings ([#138](https://github.com/PostHog/posthog-flutter/pull/138))
+- fix: blank screen when viewing session replay recordings ([#139](https://github.com/PostHog/posthog-flutter/pull/139))
 
 ## 4.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.9.0
 
+- fix: blank screen when viewing session replay recordings ([#138](https://github.com/PostHog/posthog-flutter/pull/138))
+
+## 4.9.0
+
 - feat: add getter for current session identifier ([#134](https://github.com/PostHog/posthog-flutter/pull/134))
 
 ## 4.8.0

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,8 +12,8 @@ Future<void> main() async {
   config.captureApplicationLifecycleEvents = false;
   config.host = 'https://us.i.posthog.com';
   config.sessionReplay = true;
-  config.sessionReplayConfig.maskAllTexts = true;
-  config.sessionReplayConfig.maskAllImages = true;
+  config.sessionReplayConfig.maskAllTexts = false;
+  config.sessionReplayConfig.maskAllImages = false;
   config.sessionReplayConfig.throttleDelay = const Duration(milliseconds: 1000);
   config.flushAt = 1;
   await Posthog().setup(config);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,8 +12,8 @@ Future<void> main() async {
   config.captureApplicationLifecycleEvents = false;
   config.host = 'https://us.i.posthog.com';
   config.sessionReplay = true;
-  config.sessionReplayConfig.maskAllTexts = false;
-  config.sessionReplayConfig.maskAllImages = false;
+  config.sessionReplayConfig.maskAllTexts = true;
+  config.sessionReplayConfig.maskAllImages = true;
   config.sessionReplayConfig.throttleDelay = const Duration(milliseconds: 1000);
   config.flushAt = 1;
   await Posthog().setup(config);

--- a/lib/src/replay/mask/image_mask_painter.dart
+++ b/lib/src/replay/mask/image_mask_painter.dart
@@ -30,7 +30,6 @@ class ImageMaskPainter {
       (image.width * pixelRatio).round(),
       (image.height * pixelRatio).round(),
     );
-    image.dispose();
     return maskedImage;
   }
 }

--- a/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -55,7 +55,7 @@ class ScreenshotCapturer {
     _views[renderObject] = statusView;
   }
 
-  Future<Uint8List?> getImageBytes(ui.Image img) async {
+  Future<Uint8List?> _getImageBytes(ui.Image img) async {
     final ByteData? byteData =
         await img.toByteData(format: ui.ImageByteFormat.png);
     if (byteData == null || byteData.lengthInBytes == 0) {
@@ -99,7 +99,7 @@ class ScreenshotCapturer {
       // using png because its compressed, the native SDKs will decompress it
       // and transform to jpeg if needed (soon webp)
       // https://github.com/brendan-duncan/image does not have webp encoding
-      Uint8List? pngBytes = await getImageBytes(image);
+      Uint8List? pngBytes = await _getImageBytes(image);
       if (pngBytes == null || pngBytes.isEmpty) {
         printIfDebug('Error: Failed to convert image byte data to Uint8List.');
         image.dispose();
@@ -125,7 +125,7 @@ class ScreenshotCapturer {
           // Dispose the original image after masking
           image.dispose();
 
-          Uint8List? maskedImagePngBytes = await getImageBytes(maskedImage);
+          Uint8List? maskedImagePngBytes = await _getImageBytes(maskedImage);
           if (maskedImagePngBytes == null || maskedImagePngBytes.isEmpty) {
             maskedImage.dispose();
             return null;

--- a/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -58,7 +58,7 @@ class ScreenshotCapturer {
   Future<Uint8List?> getImageBytes(ui.Image img) async {
     final ByteData? byteData =
         await img.toByteData(format: ui.ImageByteFormat.png);
-    if (byteData == null) {
+    if (byteData == null || byteData.lengthInBytes == 0) {
       printIfDebug('Error: Failed to convert image to byte data.');
       return null;
     }
@@ -108,6 +108,7 @@ class ScreenshotCapturer {
 
       if (const PHListEquality().equals(pngBytes, statusView.imageBytes)) {
         printIfDebug('Snapshot is the same as the last one.');
+        image.dispose();
         return null;
       }
 
@@ -125,7 +126,7 @@ class ScreenshotCapturer {
           image.dispose();
 
           Uint8List? maskedImagePngBytes = await getImageBytes(maskedImage);
-          if (maskedImagePngBytes == null) {
+          if (maskedImagePngBytes == null || maskedImagePngBytes.isEmpty) {
             maskedImage.dispose();
             return null;
           }

--- a/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -57,14 +57,13 @@ class ScreenshotCapturer {
 
   Future<Uint8List?> getImageBytes(ui.Image img) async {
     final ByteData? byteData =
-    await img.toByteData(format: ui.ImageByteFormat.png);
+        await img.toByteData(format: ui.ImageByteFormat.png);
     if (byteData == null) {
       printIfDebug('Error: Failed to convert image to byte data.');
       return null;
     }
     return byteData.buffer.asUint8List();
   }
-
 
   Future<ImageInfo?> captureScreenshot() async {
     final context = PostHogMaskController.instance.containerKey.currentContext;
@@ -132,13 +131,13 @@ class ScreenshotCapturer {
           }
 
           final imageInfo = ImageInfo(
-            viewId,
-            globalPosition.dx.toInt(),
-            globalPosition.dy.toInt(),
-            srcWidth.toInt(),
-            srcHeight.toInt(),
-            shouldSendMetaEvent,
-            maskedImagePngBytes);
+              viewId,
+              globalPosition.dx.toInt(),
+              globalPosition.dy.toInt(),
+              srcWidth.toInt(),
+              srcHeight.toInt(),
+              shouldSendMetaEvent,
+              maskedImagePngBytes);
           _updateStatusView(shouldSendMetaEvent, renderObject, statusView);
           return imageInfo;
         }


### PR DESCRIPTION
- Delayed image disposal until after masking to ensure validity during processing.
- Ensured proper memory management by disposing of images only after usage.
- Added getImageBytes

I removed `ui.Image image` from `ImageInfo `cause we not used it in anywhere and we always dispose it too.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#138 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
