### PR TITLE
fix: isSessionReplayActive returns false by default for flutter web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: isSessionReplayActive returns false by default for flutter web ([#153](https://github.com/PostHog/posthog-flutter/pull/153))
+
 ## 4.10.0
 
 - chore: add support for session replay manual masking with the PostHogMaskWidget widget ([#153](https://github.com/PostHog/posthog-flutter/pull/153))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: isSessionReplayActive returns false by default for flutter web ([#153](https://github.com/PostHog/posthog-flutter/pull/153))
+- fix: isSessionReplayActive returns false by default for flutter web ([#158](https://github.com/PostHog/posthog-flutter/pull/158))
 
 ## 4.10.0
 

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -121,7 +121,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
     case 'isSessionReplayActive':
       // not supported on Web
       // Flutter Web uses the JS SDK for Session replay
-      break;
+      return false;
     default:
       throw PlatformException(
         code: 'Unimplemented',


### PR DESCRIPTION
## :bulb: Motivation and Context

> Error sending full snapshot to native: TypeError: null: type 'Null' is not a subtype of type 'FutureOr<bool>'

Potential fix for https://posthoghelp.zendesk.com/agent/tickets/24603 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26602)


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
