### PR TITLE
Fixed wasm build and improved type safety

### DIFF
--- a/lib/posthog_flutter_web.dart
+++ b/lib/posthog_flutter_web.dart
@@ -1,9 +1,6 @@
 // In order to *not* need this ignore, consider extracting the "web" version
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
-// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
-import 'dart:js';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -26,5 +23,5 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) =>
-      handleWebMethodCall(call, context);
+      handleWebMethodCall(call);
 }

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -29,7 +29,7 @@ extension PostHogExtension on PostHog {
 
 // Acessar o posthog a partir do window
 @JS('window.posthog')
-external PostHog get posthog;
+external PostHog? get posthog;
 
 // Funções de conversão
 JSAny stringToJSAny(String value) {
@@ -41,7 +41,7 @@ JSAny boolToJSAny(bool value) {
 }
 
 JSAny mapToJSAny(Map<dynamic, dynamic> map) {
-  return map.jsify()!;
+  return map.jsify() ?? JSObject();
 }
 
 // Função para converter mapas de forma segura
@@ -71,7 +71,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final userPropertiesSetOnce =
           safeMapConversion(args['userPropertiesSetOnce']);
 
-      posthog.identify(
+      posthog?.identify(
         stringToJSAny(userId),
         mapToJSAny(userProperties),
         mapToJSAny(userPropertiesSetOnce),
@@ -81,7 +81,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final eventName = args['eventName'] as String;
       final properties = safeMapConversion(args['properties']);
 
-      posthog.capture(
+      posthog?.capture(
         stringToJSAny(eventName),
         mapToJSAny(properties),
       );
@@ -91,7 +91,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final properties = safeMapConversion(args['properties']);
       properties['\$screen_name'] = screenName;
 
-      posthog.capture(
+      posthog?.capture(
         stringToJSAny('\$screen'),
         mapToJSAny(properties),
       );
@@ -99,24 +99,24 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
     case 'alias':
       final alias = args['alias'] as String;
 
-      posthog.alias(
+      posthog?.alias(
         stringToJSAny(alias),
       );
       break;
     case 'distinctId':
-      final distinctId = posthog.get_distinct_id();
-      return distinctId?.dartify();
+      final distinctId = posthog?.get_distinct_id();
+      return distinctId?.dartify() as String?;
     case 'reset':
-      posthog.reset();
+      posthog?.reset();
       break;
     case 'debug':
       final enabled = args['debug'] as bool;
-      posthog.debug(boolToJSAny(enabled));
+      posthog?.debug(boolToJSAny(enabled));
       break;
     case 'isFeatureEnabled':
       final key = args['key'] as String;
       final isFeatureEnabled = posthog
-              .isFeatureEnabled(
+              ?.isFeatureEnabled(
                 stringToJSAny(key),
               )
               ?.dartify() as bool? ??
@@ -127,32 +127,32 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final groupKey = args['groupKey'] as String;
       final groupProperties = safeMapConversion(args['groupProperties']);
 
-      posthog.group(
+      posthog?.group(
         stringToJSAny(groupType),
         stringToJSAny(groupKey),
         mapToJSAny(groupProperties),
       );
       break;
     case 'reloadFeatureFlags':
-      posthog.reloadFeatureFlags();
+      posthog?.reloadFeatureFlags();
       break;
     case 'enable':
-      posthog.opt_in_capturing();
+      posthog?.opt_in_capturing();
       break;
     case 'disable':
-      posthog.opt_out_capturing();
+      posthog?.opt_out_capturing();
       break;
     case 'getFeatureFlag':
       final key = args['key'] as String;
 
-      final featureFlag = posthog.getFeatureFlag(
+      final featureFlag = posthog?.getFeatureFlag(
         stringToJSAny(key),
       );
       return featureFlag?.dartify();
     case 'getFeatureFlagPayload':
       final key = args['key'] as String;
 
-      final featureFlag = posthog.getFeatureFlagPayload(
+      final featureFlag = posthog?.getFeatureFlagPayload(
         stringToJSAny(key),
       );
       return featureFlag?.dartify();
@@ -161,19 +161,19 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final value = args['value'];
       final properties = {key: value};
 
-      posthog.register(
+      posthog?.register(
         mapToJSAny(properties),
       );
       break;
     case 'unregister':
       final key = args['key'] as String;
 
-      posthog.unregister(
+      posthog?.unregister(
         stringToJSAny(key),
       );
       break;
     case 'getSessionId':
-      final sessionId = posthog.get_session_id()?.dartify() as String?;
+      final sessionId = posthog?.get_session_id()?.dartify() as String?;
       if (sessionId?.isEmpty == true) return null;
       return sessionId;
     case 'flush':

--- a/lib/src/posthog_flutter_web_handler.dart
+++ b/lib/src/posthog_flutter_web_handler.dart
@@ -1,107 +1,180 @@
-// ignore: deprecated_member_use
-import 'dart:js';
+import 'dart:js_interop';
 
 import 'package:flutter/services.dart';
 
-Future<dynamic> handleWebMethodCall(MethodCall call, JsObject context) async {
-  final analytics = JsObject.fromBrowserObject(context['posthog']);
+// Definição da interface JS para o PostHog
+@JS()
+@staticInterop
+class PostHog {}
+
+extension PostHogExtension on PostHog {
+  external JSAny? identify(
+      JSAny userId, JSAny properties, JSAny propertiesSetOnce);
+  external JSAny? capture(JSAny eventName, JSAny properties);
+  external JSAny? alias(JSAny alias);
+  external JSAny? get_distinct_id();
+  external void reset();
+  external void debug(JSAny debug);
+  external JSAny? isFeatureEnabled(JSAny key);
+  external void group(JSAny type, JSAny key, JSAny properties);
+  external void reloadFeatureFlags();
+  external void opt_in_capturing();
+  external void opt_out_capturing();
+  external JSAny? getFeatureFlag(JSAny key);
+  external JSAny? getFeatureFlagPayload(JSAny key);
+  external void register(JSAny properties);
+  external void unregister(JSAny key);
+  external JSAny? get_session_id();
+}
+
+// Acessar o posthog a partir do window
+@JS('window.posthog')
+external PostHog get posthog;
+
+// Funções de conversão
+JSAny stringToJSAny(String value) {
+  return value.toJS;
+}
+
+JSAny boolToJSAny(bool value) {
+  return value.toJS;
+}
+
+JSAny mapToJSAny(Map<dynamic, dynamic> map) {
+  return map.jsify()!;
+}
+
+// Função para converter mapas de forma segura
+Map<String, dynamic> safeMapConversion(dynamic mapData) {
+  if (mapData == null) {
+    return {};
+  }
+
+  if (mapData is Map) {
+    return Map<String, dynamic>.from(
+        mapData.map((key, value) => MapEntry(key.toString(), value)));
+  }
+
+  return {};
+}
+
+Future<dynamic> handleWebMethodCall(MethodCall call) async {
+  final args = call.arguments;
+
   switch (call.method) {
     case 'setup':
       // not supported on Web
-      // analytics.callMethod('setup');
       break;
     case 'identify':
-      final userProperties = call.arguments['userProperties'] ?? {};
+      final userId = args['userId'] as String;
+      final userProperties = safeMapConversion(args['userProperties']);
       final userPropertiesSetOnce =
-          call.arguments['userPropertiesSetOnce'] ?? {};
-      analytics.callMethod('identify', [
-        call.arguments['userId'],
-        JsObject.jsify(userProperties),
-        JsObject.jsify(userPropertiesSetOnce),
-      ]);
+          safeMapConversion(args['userPropertiesSetOnce']);
+
+      posthog.identify(
+        stringToJSAny(userId),
+        mapToJSAny(userProperties),
+        mapToJSAny(userPropertiesSetOnce),
+      );
       break;
     case 'capture':
-      final properties = call.arguments['properties'] ?? {};
-      analytics.callMethod('capture', [
-        call.arguments['eventName'],
-        JsObject.jsify(properties),
-      ]);
+      final eventName = args['eventName'] as String;
+      final properties = safeMapConversion(args['properties']);
+
+      posthog.capture(
+        stringToJSAny(eventName),
+        mapToJSAny(properties),
+      );
       break;
     case 'screen':
-      final properties = call.arguments['properties'] ?? {};
-      final screenName = call.arguments['screenName'];
+      final screenName = args['screenName'] as String;
+      final properties = safeMapConversion(args['properties']);
       properties['\$screen_name'] = screenName;
 
-      analytics.callMethod('capture', [
-        '\$screen',
-        JsObject.jsify(properties),
-      ]);
+      posthog.capture(
+        stringToJSAny('\$screen'),
+        mapToJSAny(properties),
+      );
       break;
     case 'alias':
-      analytics.callMethod('alias', [
-        call.arguments['alias'],
-      ]);
+      final alias = args['alias'] as String;
+
+      posthog.alias(
+        stringToJSAny(alias),
+      );
       break;
     case 'distinctId':
-      final distinctId = analytics.callMethod('get_distinct_id');
-
-      return distinctId;
+      final distinctId = posthog.get_distinct_id();
+      return distinctId?.dartify();
     case 'reset':
-      analytics.callMethod('reset');
+      posthog.reset();
       break;
     case 'debug':
-      analytics.callMethod('debug', [
-        call.arguments['debug'],
-      ]);
+      final enabled = args['debug'] as bool;
+      posthog.debug(boolToJSAny(enabled));
       break;
     case 'isFeatureEnabled':
-      final isFeatureEnabled = analytics.callMethod('isFeatureEnabled', [
-            call.arguments['key'],
-          ]) as bool? ??
+      final key = args['key'] as String;
+      final isFeatureEnabled = posthog
+              .isFeatureEnabled(
+                stringToJSAny(key),
+              )
+              ?.dartify() as bool? ??
           false;
       return isFeatureEnabled;
     case 'group':
-      analytics.callMethod('group', [
-        call.arguments['groupType'],
-        call.arguments['groupKey'],
-        JsObject.jsify(call.arguments['groupProperties'] ?? {}),
-      ]);
+      final groupType = args['groupType'] as String;
+      final groupKey = args['groupKey'] as String;
+      final groupProperties = safeMapConversion(args['groupProperties']);
+
+      posthog.group(
+        stringToJSAny(groupType),
+        stringToJSAny(groupKey),
+        mapToJSAny(groupProperties),
+      );
       break;
     case 'reloadFeatureFlags':
-      analytics.callMethod('reloadFeatureFlags');
+      posthog.reloadFeatureFlags();
       break;
     case 'enable':
-      analytics.callMethod('opt_in_capturing');
+      posthog.opt_in_capturing();
       break;
     case 'disable':
-      analytics.callMethod('opt_out_capturing');
+      posthog.opt_out_capturing();
       break;
     case 'getFeatureFlag':
-      final featureFlag = analytics.callMethod('getFeatureFlag', [
-        call.arguments['key'],
-      ]);
-      return featureFlag;
+      final key = args['key'] as String;
+
+      final featureFlag = posthog.getFeatureFlag(
+        stringToJSAny(key),
+      );
+      return featureFlag?.dartify();
     case 'getFeatureFlagPayload':
-      final featureFlag = analytics.callMethod('getFeatureFlagPayload', [
-        call.arguments['key'],
-      ]);
-      return featureFlag;
+      final key = args['key'] as String;
+
+      final featureFlag = posthog.getFeatureFlagPayload(
+        stringToJSAny(key),
+      );
+      return featureFlag?.dartify();
     case 'register':
-      final properties = {call.arguments['key']: call.arguments['value']};
-      analytics.callMethod('register', [
-        JsObject.jsify(properties),
-      ]);
+      final key = args['key'] as String;
+      final value = args['value'];
+      final properties = {key: value};
+
+      posthog.register(
+        mapToJSAny(properties),
+      );
       break;
     case 'unregister':
-      analytics.callMethod('unregister', [
-        call.arguments['key'],
-      ]);
+      final key = args['key'] as String;
+
+      posthog.unregister(
+        stringToJSAny(key),
+      );
       break;
     case 'getSessionId':
-      final sessionId = analytics.callMethod('get_session_id') as String?;
-
+      final sessionId = posthog.get_session_id()?.dartify() as String?;
       if (sessionId?.isEmpty == true) return null;
-
       return sessionId;
     case 'flush':
       // not supported on Web

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   # plugin_platform_interface depends on meta anyway
   meta: ^1.3.0
+  web: ^1.1.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/posthog/posthog-flutter/issues
 documentation: https://github.com/posthog/posthog-flutter#readme
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
-  flutter: '>=3.3.0'
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 
 dependencies:
   flutter:
@@ -18,7 +18,6 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   # plugin_platform_interface depends on meta anyway
   meta: ^1.3.0
-  web: ^1.1.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
## :bulb: Motivation and Context
This change was necessary to modernize the web implementation of the PostHog Flutter plugin, replacing the deprecated `dart:js` API with the new `dart:js_interop` API. This fixes WASM compilation issues for Flutter applications using this plugin and improves type safety, reducing the possibility of runtime errors.

The change is crucial for:
1. Ensuring compatibility with newer versions of Flutter and Dart
2. Allowing the plugin to work correctly in WASM environments
3. Improving stability and security with stricter type checking

## :green_heart: How did you test it?
- Tested the plugin compilation for WASM using Flutter 3.19+
- Verified all core plugin functionalities in web environment:
  - Event capturing
  - User identification
  - Feature flags management
  - Reset and session management
- Compared the behavior of the new implementation with the previous implementation to ensure compatibility

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [] I added tests to verify the changes.
- [] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.