### PR TITLE
chore: update languageVersion and apiVersion from 1.6 to 1.8 on Android to be compatible with Kotlin 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: update languageVersion and apiVersion from 1.6 to 1.8 on Android to be compatible with Kotlin 2.2 ([#190](https://github.com/PostHog/posthog-flutter/pull/190))
+- chore: update languageVersion and apiVersion from 1.6 to 1.8 on Android to be compatible with Kotlin 2.2 ([#193](https://github.com/PostHog/posthog-flutter/pull/193))
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: update languageVersion and apiVersion from 1.6 to 1.8 on Android to be compatible with Kotlin 2.2 ([#190](https://github.com/PostHog/posthog-flutter/pull/190))
+
 ## 5.2.0
 
 - feat: add `isOptOut` method to check if the current user is opted out of data capture. ([#190](https://github.com/PostHog/posthog-flutter/pull/190))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,8 +38,8 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
-        languageVersion = "1.6"
-        apiVersion = "1.6"
+        languageVersion = "1.8"
+        apiVersion = "1.8"
     }
 
     sourceSets {


### PR DESCRIPTION
## :bulb: Motivation and Context
Because of https://github.com/PostHog/posthog-flutter/issues/191
Closes https://github.com/PostHog/posthog-flutter/issues/191

> e: Language version 1.6 is no longer supported; please, use version 1.8 or greater.
> 
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> Execution failed for task ':posthog_flutter:compileReleaseKotlin'.
> > A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
>    > Compilation error. See log for more details


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
