### PR TITLE
fix: do not render HTML content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: don't render HTML content ([#196](https://github.com/PostHog/posthog-flutter/pull/196))
+
 ## 5.3.0
 
 - chore: update languageVersion and apiVersion from 1.6 to 1.8 on Android to be compatible with Kotlin 2.2 ([#193](https://github.com/PostHog/posthog-flutter/pull/193))

--- a/ios/Classes/PostHogDisplaySurvey+Dict.swift
+++ b/ios/Classes/PostHogDisplaySurvey+Dict.swift
@@ -14,8 +14,10 @@
                         "question": question.question,
                         "isOptional": question.isOptional,
                     ]
+
                     if let desc = question.questionDescription {
                         questionDict["questionDescription"] = desc
+                        questionDict["questionDescriptionContentType"] = question.questionDescriptionContentType.rawValue
                     }
                     if let buttonText = question.buttonText {
                         questionDict["buttonText"] = buttonText
@@ -84,6 +86,7 @@
                 }
                 if let thankYouMessageDescription = appearance.thankYouMessageDescription {
                     appearanceDict["thankYouMessageDescription"] = thankYouMessageDescription
+                    appearanceDict["thankYouMessageDescriptionContentType"] = appearance.thankYouMessageDescriptionContentType?.rawValue
                 }
                 if let thankYouMessageCloseButtonText = appearance.thankYouMessageCloseButtonText {
                     appearanceDict["thankYouMessageCloseButtonText"] = thankYouMessageCloseButtonText

--- a/ios/posthog_flutter.podspec
+++ b/ios/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.29.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '~> 3.29' 
+  # ~> Version 3.30.1 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.30.1', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/lib/src/surveys/models/posthog_display_choice_question.dart
+++ b/lib/src/surveys/models/posthog_display_choice_question.dart
@@ -12,6 +12,7 @@ class PostHogDisplayChoiceQuestion extends PostHogDisplaySurveyQuestion {
     this.hasOpenChoice = false,
     this.shuffleOptions = false,
     super.description,
+    super.descriptionContentType,
     super.optional,
     super.buttonText,
   }) : super(

--- a/lib/src/surveys/models/posthog_display_link_question.dart
+++ b/lib/src/surveys/models/posthog_display_link_question.dart
@@ -9,6 +9,7 @@ class PostHogDisplayLinkQuestion extends PostHogDisplaySurveyQuestion {
     required super.question,
     required this.link,
     super.description,
+    super.descriptionContentType,
     super.optional,
     super.buttonText,
   }) : super(

--- a/lib/src/surveys/models/posthog_display_open_question.dart
+++ b/lib/src/surveys/models/posthog_display_open_question.dart
@@ -8,6 +8,7 @@ class PostHogDisplayOpenQuestion extends PostHogDisplaySurveyQuestion {
   const PostHogDisplayOpenQuestion({
     required super.question,
     super.description,
+    super.descriptionContentType,
     super.optional,
     super.buttonText,
   }) : super(

--- a/lib/src/surveys/models/posthog_display_rating_question.dart
+++ b/lib/src/surveys/models/posthog_display_rating_question.dart
@@ -14,6 +14,7 @@ class PostHogDisplayRatingQuestion extends PostHogDisplaySurveyQuestion {
     required this.lowerBoundLabel,
     required this.upperBoundLabel,
     super.description,
+    super.descriptionContentType,
     super.optional,
     super.buttonText,
   }) : super(

--- a/lib/src/surveys/models/posthog_display_survey.dart
+++ b/lib/src/surveys/models/posthog_display_survey.dart
@@ -19,9 +19,12 @@ class PostHogDisplaySurvey {
       final question = q['question'] as String;
       final optional = q['isOptional'] as bool;
       final questionDescription = q['questionDescription'] as String?;
-      final contentTypeValue = q['questionDescriptionContentType'] as int? ?? 1;
+      // Extract content type values with fallback to text (1)
+      final questionContentTypeRaw =
+          q['questionDescriptionContentType'] as int? ?? 1;
       final questionDescriptionContentType =
-          PostHogDisplaySurveyTextContentType.fromInt(contentTypeValue);
+          PostHogDisplaySurveyTextContentType.fromInt(questionContentTypeRaw);
+
       final buttonText = q['buttonText'] as String?;
 
       switch (type) {
@@ -76,6 +79,13 @@ class PostHogDisplaySurvey {
     PostHogDisplaySurveyAppearance? appearance;
     if (dict['appearance'] != null) {
       final a = Map<String, dynamic>.from(dict['appearance'] as Map);
+
+      // Extract thank you message content type with fallback to text (1)
+      final thankYouContentTypeRaw =
+          a['thankYouMessageDescriptionContentType'] as int? ?? 1;
+      final thankYouMessageDescriptionContentType =
+          PostHogDisplaySurveyTextContentType.fromInt(thankYouContentTypeRaw);
+
       appearance = PostHogDisplaySurveyAppearance(
         fontFamily: a['fontFamily'] as String?,
         backgroundColor: a['backgroundColor'] as String?,
@@ -91,10 +101,7 @@ class PostHogDisplaySurvey {
         thankYouMessageHeader: a['thankYouMessageHeader'] as String?,
         thankYouMessageDescription: a['thankYouMessageDescription'] as String?,
         thankYouMessageDescriptionContentType:
-            a['thankYouMessageDescriptionContentType'] != null
-                ? PostHogDisplaySurveyTextContentType.fromInt(
-                    a['thankYouMessageDescriptionContentType'] as int)
-                : PostHogDisplaySurveyTextContentType.text,
+            thankYouMessageDescriptionContentType,
         thankYouMessageCloseButtonText:
             a['thankYouMessageCloseButtonText'] as String?,
       );

--- a/lib/src/surveys/models/posthog_display_survey.dart
+++ b/lib/src/surveys/models/posthog_display_survey.dart
@@ -6,6 +6,7 @@ import 'posthog_display_link_question.dart';
 import 'posthog_display_rating_question.dart';
 import 'posthog_display_choice_question.dart';
 import 'posthog_display_survey_appearance.dart';
+import 'posthog_display_survey_text_content_type.dart';
 
 /// Main survey model containing metadata and questions
 @immutable
@@ -18,6 +19,9 @@ class PostHogDisplaySurvey {
       final question = q['question'] as String;
       final optional = q['isOptional'] as bool;
       final questionDescription = q['questionDescription'] as String?;
+      final contentTypeValue = q['questionDescriptionContentType'] as int? ?? 1;
+      final questionDescriptionContentType =
+          PostHogDisplaySurveyTextContentType.fromInt(contentTypeValue);
       final buttonText = q['buttonText'] as String?;
 
       switch (type) {
@@ -26,6 +30,7 @@ class PostHogDisplaySurvey {
             question: question,
             link: q['link'] as String,
             description: questionDescription,
+            descriptionContentType: questionDescriptionContentType,
             optional: optional,
             buttonText: buttonText,
           );
@@ -39,6 +44,7 @@ class PostHogDisplaySurvey {
             lowerBoundLabel: q['lowerBoundLabel'] as String,
             upperBoundLabel: q['upperBoundLabel'] as String,
             description: questionDescription,
+            descriptionContentType: questionDescriptionContentType,
             optional: optional,
             buttonText: buttonText,
           );
@@ -51,6 +57,7 @@ class PostHogDisplaySurvey {
             hasOpenChoice: q['hasOpenChoice'] as bool,
             shuffleOptions: q['shuffleOptions'] as bool,
             description: questionDescription,
+            descriptionContentType: questionDescriptionContentType,
             optional: optional,
             buttonText: buttonText,
           );
@@ -59,6 +66,7 @@ class PostHogDisplaySurvey {
           return PostHogDisplayOpenQuestion(
             question: question,
             description: questionDescription,
+            descriptionContentType: questionDescriptionContentType,
             optional: optional,
             buttonText: buttonText,
           );
@@ -82,6 +90,11 @@ class PostHogDisplaySurvey {
         displayThankYouMessage: a['displayThankYouMessage'] as bool? ?? true,
         thankYouMessageHeader: a['thankYouMessageHeader'] as String?,
         thankYouMessageDescription: a['thankYouMessageDescription'] as String?,
+        thankYouMessageDescriptionContentType:
+            a['thankYouMessageDescriptionContentType'] != null
+                ? PostHogDisplaySurveyTextContentType.fromInt(
+                    a['thankYouMessageDescriptionContentType'] as int)
+                : PostHogDisplaySurveyTextContentType.text,
         thankYouMessageCloseButtonText:
             a['thankYouMessageCloseButtonText'] as String?,
       );

--- a/lib/src/surveys/models/posthog_display_survey_appearance.dart
+++ b/lib/src/surveys/models/posthog_display_survey_appearance.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'posthog_display_survey_text_content_type.dart';
 
 /// Appearance configuration for surveys
 @immutable
@@ -17,6 +18,7 @@ class PostHogDisplaySurveyAppearance {
     this.displayThankYouMessage = true,
     this.thankYouMessageHeader,
     this.thankYouMessageDescription,
+    this.thankYouMessageDescriptionContentType,
     this.thankYouMessageCloseButtonText,
   });
 
@@ -33,5 +35,7 @@ class PostHogDisplaySurveyAppearance {
   final bool displayThankYouMessage;
   final String? thankYouMessageHeader;
   final String? thankYouMessageDescription;
+  final PostHogDisplaySurveyTextContentType?
+      thankYouMessageDescriptionContentType;
   final String? thankYouMessageCloseButtonText;
 }

--- a/lib/src/surveys/models/posthog_display_survey_question.dart
+++ b/lib/src/surveys/models/posthog_display_survey_question.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'posthog_survey_question_type.dart';
+import 'posthog_display_survey_text_content_type.dart';
 
 /// Base class for all survey questions
 @immutable
@@ -8,6 +9,7 @@ abstract class PostHogDisplaySurveyQuestion {
     required this.type,
     required this.question,
     this.description,
+    this.descriptionContentType = PostHogDisplaySurveyTextContentType.text,
     this.optional = false,
     this.buttonText,
   });
@@ -15,6 +17,7 @@ abstract class PostHogDisplaySurveyQuestion {
   final PostHogSurveyQuestionType type;
   final String question;
   final String? description;
+  final PostHogDisplaySurveyTextContentType descriptionContentType;
   final bool optional;
   final String? buttonText;
 }

--- a/lib/src/surveys/models/posthog_display_survey_text_content_type.dart
+++ b/lib/src/surveys/models/posthog_display_survey_text_content_type.dart
@@ -1,0 +1,20 @@
+/// Content type for text-based survey elements
+enum PostHogDisplaySurveyTextContentType {
+  /// Content should be rendered as HTML
+  html(0),
+
+  /// Content should be rendered as plain text
+  text(1);
+
+  const PostHogDisplaySurveyTextContentType(this.value);
+
+  final int value;
+
+  /// Create from raw int value
+  static PostHogDisplaySurveyTextContentType fromInt(int value) {
+    return PostHogDisplaySurveyTextContentType.values.firstWhere(
+      (e) => e.value == value,
+      orElse: () => PostHogDisplaySurveyTextContentType.text, // Default to text
+    );
+  }
+}

--- a/lib/src/surveys/widgets/choice_question.dart
+++ b/lib/src/surveys/widgets/choice_question.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/survey_appearance.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 import 'question_header.dart';
 import 'survey_button.dart';
 import 'survey_choice_button.dart';
@@ -10,6 +11,7 @@ class ChoiceQuestionWidget extends StatefulWidget {
     super.key,
     required this.question,
     required this.description,
+    this.descriptionContentType,
     required this.choices,
     required this.appearance,
     this.buttonText,
@@ -21,6 +23,7 @@ class ChoiceQuestionWidget extends StatefulWidget {
 
   final String question;
   final String? description;
+  final PostHogDisplaySurveyTextContentType? descriptionContentType;
   final List<String> choices;
   final SurveyAppearance appearance;
   final String? buttonText;
@@ -104,6 +107,7 @@ class _ChoiceQuestionWidgetState extends State<ChoiceQuestionWidget> {
             QuestionHeader(
               question: widget.question,
               description: widget.description,
+              descriptionContentType: widget.descriptionContentType,
               appearance: widget.appearance,
             ),
             const SizedBox(height: 16),

--- a/lib/src/surveys/widgets/confirmation_message.dart
+++ b/lib/src/surveys/widgets/confirmation_message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/survey_appearance.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 import 'survey_button.dart';
 
 class ConfirmationMessage extends StatelessWidget {
@@ -7,10 +8,13 @@ class ConfirmationMessage extends StatelessWidget {
     super.key,
     required this.onClose,
     this.appearance = SurveyAppearance.defaultAppearance,
+    this.thankYouMessageDescriptionContentType,
   });
 
   final VoidCallback onClose;
   final SurveyAppearance appearance;
+  final PostHogDisplaySurveyTextContentType?
+      thankYouMessageDescriptionContentType;
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +31,9 @@ class ConfirmationMessage extends StatelessWidget {
           ),
           textAlign: TextAlign.center,
         ),
-        if (appearance.thankYouMessageDescription?.isNotEmpty == true) ...[
+        if (appearance.thankYouMessageDescription?.isNotEmpty == true &&
+            thankYouMessageDescriptionContentType ==
+                PostHogDisplaySurveyTextContentType.text) ...[
           const SizedBox(height: 16),
           Text(
             appearance.thankYouMessageDescription!,

--- a/lib/src/surveys/widgets/link_question.dart
+++ b/lib/src/surveys/widgets/link_question.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/survey_appearance.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 import 'question_header.dart';
 import 'survey_button.dart';
 
@@ -10,6 +11,7 @@ class LinkQuestion extends StatelessWidget {
     super.key,
     required this.question,
     required this.description,
+    this.descriptionContentType,
     required this.appearance,
     required this.onPressed,
     this.buttonText,
@@ -18,6 +20,7 @@ class LinkQuestion extends StatelessWidget {
 
   final String question;
   final String? description;
+  final PostHogDisplaySurveyTextContentType? descriptionContentType;
   final SurveyAppearance appearance;
   final Future<void> Function() onPressed;
   final String? buttonText;
@@ -32,6 +35,7 @@ class LinkQuestion extends StatelessWidget {
         QuestionHeader(
           question: question,
           description: description,
+          descriptionContentType: descriptionContentType,
           appearance: appearance,
         ),
         const SizedBox(height: 16),

--- a/lib/src/surveys/widgets/open_text_question.dart
+++ b/lib/src/surveys/widgets/open_text_question.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/survey_appearance.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 import 'question_header.dart';
 import 'survey_button.dart';
 
@@ -8,6 +9,7 @@ class OpenTextQuestion extends StatefulWidget {
     super.key,
     required this.question,
     required this.description,
+    this.descriptionContentType,
     required this.onSubmit,
     this.buttonText = 'Submit',
     this.optional = false,
@@ -16,6 +18,7 @@ class OpenTextQuestion extends StatefulWidget {
 
   final String? question;
   final String? description;
+  final PostHogDisplaySurveyTextContentType? descriptionContentType;
   final String buttonText;
   final bool optional;
   final SurveyAppearance appearance;
@@ -53,6 +56,7 @@ class _OpenTextQuestionState extends State<OpenTextQuestion> {
             QuestionHeader(
               question: widget.question,
               description: widget.description,
+              descriptionContentType: widget.descriptionContentType,
               appearance: widget.appearance,
             ),
             const SizedBox(height: 16),

--- a/lib/src/surveys/widgets/question_header.dart
+++ b/lib/src/surveys/widgets/question_header.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 import '../models/survey_appearance.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 
 class QuestionHeader extends StatelessWidget {
   const QuestionHeader({
     super.key,
     required this.question,
     this.description,
+    this.descriptionContentType,
     required this.appearance,
   });
 
   final String? question;
   final String? description;
+  final PostHogDisplaySurveyTextContentType? descriptionContentType;
   final SurveyAppearance appearance;
 
   @override
@@ -28,7 +31,9 @@ class QuestionHeader extends StatelessWidget {
             ),
           ),
         ],
-        if (description?.isNotEmpty == true) ...[
+        if (description?.isNotEmpty == true &&
+            descriptionContentType ==
+                PostHogDisplaySurveyTextContentType.text) ...[
           const SizedBox(height: 8),
           Text(
             description!,

--- a/lib/src/surveys/widgets/rating_question.dart
+++ b/lib/src/surveys/widgets/rating_question.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/posthog_display_survey_rating_type.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 import '../models/survey_appearance.dart';
 import 'question_header.dart';
 import 'survey_button.dart';
@@ -11,6 +12,7 @@ class RatingQuestion extends StatefulWidget {
     super.key,
     required this.question,
     required this.description,
+    this.descriptionContentType,
     required this.onSubmit,
     this.buttonText,
     this.optional = false,
@@ -24,6 +26,7 @@ class RatingQuestion extends StatefulWidget {
 
   final String? question;
   final String? description;
+  final PostHogDisplaySurveyTextContentType? descriptionContentType;
   final String? buttonText;
   final bool optional;
   final int scaleLowerBound;
@@ -147,6 +150,7 @@ class _RatingQuestionState extends State<RatingQuestion> {
         QuestionHeader(
           question: widget.question,
           description: widget.description,
+          descriptionContentType: widget.descriptionContentType,
           appearance: widget.appearance,
         ),
         const SizedBox(height: 24),

--- a/lib/src/surveys/widgets/survey_bottom_sheet.dart
+++ b/lib/src/surveys/widgets/survey_bottom_sheet.dart
@@ -7,6 +7,7 @@ import '../models/survey_callbacks.dart';
 import '../models/posthog_display_link_question.dart';
 import '../models/posthog_display_rating_question.dart';
 import '../models/posthog_display_choice_question.dart';
+import '../models/posthog_display_survey_text_content_type.dart';
 import '../../posthog_flutter_platform_interface.dart';
 
 import 'link_question.dart';
@@ -61,6 +62,7 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
           key: ValueKey('open_text_question_$_currentIndex'),
           question: currentQuestion.question,
           description: currentQuestion.description,
+          descriptionContentType: currentQuestion.descriptionContentType,
           appearance: SurveyAppearance.fromPostHog(widget.survey.appearance),
           onSubmit: (response) async {
             final nextQuestion = await widget.onResponse(
@@ -80,6 +82,7 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
           key: ValueKey('link_question_$_currentIndex'),
           question: linkQuestion.question,
           description: linkQuestion.description,
+          descriptionContentType: linkQuestion.descriptionContentType,
           appearance: SurveyAppearance.fromPostHog(widget.survey.appearance),
           buttonText: linkQuestion.buttonText,
           link: linkQuestion.link,
@@ -111,6 +114,7 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
           key: ValueKey('rating_question_$_currentIndex'),
           question: ratingQuestion.question,
           description: ratingQuestion.description,
+          descriptionContentType: ratingQuestion.descriptionContentType,
           appearance: SurveyAppearance.fromPostHog(widget.survey.appearance),
           buttonText: ratingQuestion.buttonText,
           optional: ratingQuestion.optional,
@@ -138,6 +142,7 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
           key: ValueKey('choice_question_$_currentIndex'),
           question: choiceQuestion.question,
           description: choiceQuestion.description,
+          descriptionContentType: choiceQuestion.descriptionContentType,
           choices: choiceQuestion.choices,
           appearance: SurveyAppearance.fromPostHog(widget.survey.appearance),
           buttonText: choiceQuestion.buttonText,
@@ -208,6 +213,11 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
                           ConfirmationMessage(
                             onClose: _handleClose,
                             appearance: widget.appearance,
+                            thankYouMessageDescriptionContentType: widget
+                                    .survey
+                                    .appearance
+                                    ?.thankYouMessageDescriptionContentType ??
+                                PostHogDisplaySurveyTextContentType.text,
                           ),
                       ],
                     ),


### PR DESCRIPTION
## :bulb: Motivation and Context
see: https://github.com/PostHog/posthog-flutter/issues/194

Do not render HTML content in surveys until proper support is added. 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
