### PR TITLE
chore: mask TextField widgets automatically if obscureText is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: mask TextField widgets automatically if obscureText is enabled (([#204](https://github.com/PostHog/posthog-flutter/pull/204)))
+
 ## 5.4.1
 
 - chore: update posthog-ios dependency to min. 3.31.0 (([#202](https://github.com/PostHog/posthog-flutter/pull/202)))

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -337,14 +337,14 @@ class SecondRouteState extends State<SecondRoute> with WidgetsBindingObserver {
                 },
               ),
               const SizedBox(height: 20),
-              const PostHogMaskWidget(
-                  child: TextField(
+              const TextField(
                 decoration: InputDecoration(
                   labelText: 'Sensitive Text Input',
                   hintText: 'Enter sensitive data',
                   border: OutlineInputBorder(),
                 ),
-              )),
+                obscureText: true,
+              ),
               const SizedBox(height: 20),
               PostHogMaskWidget(
                   child: Image.asset(

--- a/lib/src/replay/element_parsers/element_data.dart
+++ b/lib/src/replay/element_parsers/element_data.dart
@@ -49,6 +49,11 @@ class ElementData {
     if (!rectList.contains(element.rect)) {
       if (element.widget is PostHogMaskWidget) {
         rectList.add(element.rect);
+      } else if (element.widget is TextField) {
+        final textField = element.widget as TextField;
+        if (textField.obscureText) {
+          rectList.add(element.rect);
+        }
       }
     }
 

--- a/lib/src/replay/element_parsers/element_object_parser.dart
+++ b/lib/src/replay/element_parsers/element_object_parser.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:posthog_flutter/src/replay/element_parsers/element_data.dart';
 import 'package:posthog_flutter/src/replay/element_parsers/element_parser.dart';
@@ -27,6 +27,18 @@ class ElementObjectParser {
       if (elementData != null) {
         activeElementData.addChildren(elementData);
         return elementData;
+      }
+    }
+
+    if (element.widget is TextField) {
+      final textField = element.widget as TextField;
+      if (textField.obscureText) {
+        final elementData = _elementParser.relate(element, activeElementData);
+
+        if (elementData != null) {
+          activeElementData.addChildren(elementData);
+          return elementData;
+        }
       }
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
before:
<img width="314" height="69" alt="Screenshot 2025-09-03 at 09 49 40" src="https://github.com/user-attachments/assets/fccaef4f-db8e-486e-a5ee-5e7279d97a9e" />

after:
<img width="314" height="66" alt="Screenshot 2025-09-03 at 09 49 54" src="https://github.com/user-attachments/assets/59816922-ebf3-4167-b84c-eda4bcefb0a0" />

relates to https://posthoghelp.zendesk.com/agent/tickets/35646 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38661)

## :green_heart: How did you test it?
running, see screenshots

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
