### PR TITLE
fix: Android back button wasn't cleaning up the Survey resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: Android back button wasn't cleaning up the Survey resources ([#204](https://github.com/PostHog/posthog-flutter/pull/204))
+
 ## 5.4.2
 
 - fix: mask TextField widgets automatically if obscureText is enabled ([#204](https://github.com/PostHog/posthog-flutter/pull/204))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: Android back button wasn't cleaning up the Survey resources ([#204](https://github.com/PostHog/posthog-flutter/pull/204))
+- fix: Android back button wasn't cleaning up the Survey resources ([#205](https://github.com/PostHog/posthog-flutter/pull/205))
 
 ## 5.4.2
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,8 +127,10 @@ class InitialScreenState extends State<InitialScreen> {
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
                 ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                Wrap(
+                  alignment: WrapAlignment.spaceEvenly,
+                  spacing: 8.0,
+                  runSpacing: 8.0,
                   children: [
                     ElevatedButton(
                       style: ElevatedButton.styleFrom(

--- a/lib/src/surveys/widgets/survey_bottom_sheet.dart
+++ b/lib/src/surveys/widgets/survey_bottom_sheet.dart
@@ -171,60 +171,70 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
 
-    return Container(
-      decoration: BoxDecoration(
-        color: widget.appearance.backgroundColor ?? Colors.white,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      child: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.only(
-            bottom: mediaQuery.viewInsets.bottom,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Header
-              Padding(
-                padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () => _handleClose(),
-                    ),
-                  ],
+    return PopScope(
+      canPop: false,
+      // TODO: replace with onPopInvokedWithResult once set bump the min Flutter version to 3.24
+      // ignore: deprecated_member_use
+      onPopInvoked: (didPop) {
+        if (!didPop) {
+          _handleClose();
+        }
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          color: widget.appearance.backgroundColor ?? Colors.white,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.only(
+              bottom: mediaQuery.viewInsets.bottom,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Header
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: () => _handleClose(),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              // Content
-              Flexible(
-                child: SingleChildScrollView(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        if (!_isCompleted)
-                          _buildQuestion(context)
-                        else
-                          ConfirmationMessage(
-                            onClose: _handleClose,
-                            appearance: widget.appearance,
-                            thankYouMessageDescriptionContentType: widget
-                                    .survey
-                                    .appearance
-                                    ?.thankYouMessageDescriptionContentType ??
-                                PostHogDisplaySurveyTextContentType.text,
-                          ),
-                      ],
+                // Content
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          if (!_isCompleted)
+                            _buildQuestion(context)
+                          else
+                            ConfirmationMessage(
+                              onClose: _handleClose,
+                              appearance: widget.appearance,
+                              thankYouMessageDescriptionContentType: widget
+                                      .survey
+                                      .appearance
+                                      ?.thankYouMessageDescriptionContentType ??
+                                  PostHogDisplaySurveyTextContentType.text,
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## :bulb: Motivation and Context
Relates to https://posthoghelp.zendesk.com/agent/tickets/37132 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39229)
Android has a back button, which didn't clear the resources and dismissed the survey.
https://github.com/PostHog/posthog-android/blob/fd210a180de9d1353b85f8ec4576104b4b8eeb8e/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt#L553-L561 would always return false so no surveys were shown.


## :green_heart: How did you test it?
Testing dismissing surveys with the close button, the X, and the Android back button

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
