### PR TITLE
feat: surveys use the new response question id format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: iOS surveys use the new response question id format ([#207](https://github.com/PostHog/posthog-flutter/pull/207))
+
 ## 5.5.0
 
 - chore: Android plugin sets compileSdkVersion to flutter.compileSdkVersion instead of hardcoded ([#207](https://github.com/PostHog/posthog-flutter/pull/207))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- feat: iOS surveys use the new response question id format ([#207](https://github.com/PostHog/posthog-flutter/pull/207))
+- feat: iOS surveys use the new response question id format ([#210](https://github.com/PostHog/posthog-flutter/pull/210))
 
 ## 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- feat: iOS surveys use the new response question id format ([#210](https://github.com/PostHog/posthog-flutter/pull/210))
+- feat: surveys use the new response question id format ([#210](https://github.com/PostHog/posthog-flutter/pull/210))
 
 ## 5.5.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,8 +54,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.21.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.21.0,4.0.0]'
+        // + Version 3.23.0 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.23.0,4.0.0]'
     }
 
     testOptions {

--- a/android/src/main/kotlin/com/posthog/flutter/PostHogDisplaySurveyExt.kt
+++ b/android/src/main/kotlin/com/posthog/flutter/PostHogDisplaySurveyExt.kt
@@ -20,6 +20,7 @@ fun PostHogDisplaySurvey.toMap(): Map<String, Any?> {
                         mutableMapOf<String, Any?>(
                             "question" to question.question,
                             "isOptional" to question.isOptional,
+                            "id" to question.id,
                         )
 
                     questionMap["questionDescription"] = question.questionDescription

--- a/ios/Classes/PostHogDisplaySurvey+Dict.swift
+++ b/ios/Classes/PostHogDisplaySurvey+Dict.swift
@@ -13,6 +13,7 @@
                     var questionDict: [String: Any] = [
                         "question": question.question,
                         "isOptional": question.isOptional,
+                        "id": question.id,
                     ]
 
                     if let desc = question.questionDescription {

--- a/ios/posthog_flutter.podspec
+++ b/ios/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.31.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.31.0', '< 4.0.0'
+  # ~> Version 3.32.0 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.32.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/lib/src/surveys/models/posthog_display_choice_question.dart
+++ b/lib/src/surveys/models/posthog_display_choice_question.dart
@@ -6,6 +6,7 @@ import 'posthog_display_survey_question.dart';
 @immutable
 class PostHogDisplayChoiceQuestion extends PostHogDisplaySurveyQuestion {
   const PostHogDisplayChoiceQuestion({
+    required super.id,
     required super.question,
     required this.choices,
     required this.isMultipleChoice,

--- a/lib/src/surveys/models/posthog_display_link_question.dart
+++ b/lib/src/surveys/models/posthog_display_link_question.dart
@@ -6,6 +6,7 @@ import 'posthog_display_survey_question.dart';
 @immutable
 class PostHogDisplayLinkQuestion extends PostHogDisplaySurveyQuestion {
   const PostHogDisplayLinkQuestion({
+    required super.id,
     required super.question,
     required this.link,
     super.description,

--- a/lib/src/surveys/models/posthog_display_open_question.dart
+++ b/lib/src/surveys/models/posthog_display_open_question.dart
@@ -6,6 +6,7 @@ import 'posthog_display_survey_question.dart';
 @immutable
 class PostHogDisplayOpenQuestion extends PostHogDisplaySurveyQuestion {
   const PostHogDisplayOpenQuestion({
+    required super.id,
     required super.question,
     super.description,
     super.descriptionContentType,

--- a/lib/src/surveys/models/posthog_display_rating_question.dart
+++ b/lib/src/surveys/models/posthog_display_rating_question.dart
@@ -7,6 +7,7 @@ import 'posthog_display_survey_rating_type.dart';
 @immutable
 class PostHogDisplayRatingQuestion extends PostHogDisplaySurveyQuestion {
   const PostHogDisplayRatingQuestion({
+    required super.id,
     required super.question,
     required this.ratingType,
     required this.scaleLowerBound,

--- a/lib/src/surveys/models/posthog_display_survey.dart
+++ b/lib/src/surveys/models/posthog_display_survey.dart
@@ -15,6 +15,7 @@ class PostHogDisplaySurvey {
   // Native platform model -> Dictionary -> Dart model
   factory PostHogDisplaySurvey.fromDict(Map<String, dynamic> dict) {
     final questions = (dict['questions'] as List).map((q) {
+      final id = q['type'] as String? ?? '';
       final type = q['type'] as String;
       final question = q['question'] as String;
       final optional = q['isOptional'] as bool;
@@ -30,6 +31,7 @@ class PostHogDisplaySurvey {
       switch (type) {
         case 'link':
           return PostHogDisplayLinkQuestion(
+            id: id,
             question: question,
             link: q['link'] as String,
             description: questionDescription,
@@ -39,6 +41,7 @@ class PostHogDisplaySurvey {
           );
         case 'rating':
           return PostHogDisplayRatingQuestion(
+            id: id,
             question: question,
             ratingType:
                 PostHogDisplaySurveyRatingType.fromInt(q['ratingType'] as int),
@@ -54,6 +57,7 @@ class PostHogDisplaySurvey {
         case 'multiple_choice':
         case 'single_choice':
           return PostHogDisplayChoiceQuestion(
+            id: id,
             question: question,
             choices: (q['choices'] as List).cast<String>(),
             isMultipleChoice: type == 'multiple_choice',
@@ -67,6 +71,7 @@ class PostHogDisplaySurvey {
         case 'open':
         default:
           return PostHogDisplayOpenQuestion(
+            id: id,
             question: question,
             description: questionDescription,
             descriptionContentType: questionDescriptionContentType,

--- a/lib/src/surveys/models/posthog_display_survey_question.dart
+++ b/lib/src/surveys/models/posthog_display_survey_question.dart
@@ -6,6 +6,7 @@ import 'posthog_display_survey_text_content_type.dart';
 @immutable
 abstract class PostHogDisplaySurveyQuestion {
   const PostHogDisplaySurveyQuestion({
+    required this.id,
     required this.type,
     required this.question,
     this.description,
@@ -14,6 +15,7 @@ abstract class PostHogDisplaySurveyQuestion {
     this.buttonText,
   });
 
+  final String id;
   final PostHogSurveyQuestionType type;
   final String question;
   final String? description;


### PR DESCRIPTION
## :bulb: Motivation and Context

Requires https://github.com/PostHog/posthog-ios/pull/383/
and Android PR incoming
Relates to https://github.com/PostHog/posthog-ios/issues/323


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
