### PR TITLE
fix: mask RenderParagraph and RenderEditable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: RichText, SelectableText, TextField labels and hints not being masked in session replay ([#251](https://github.com/PostHog/posthog-flutter/pull/251))
+
 # 5.11.0
 
 - chore: update languageVersion and apiVersion from 1.8 to 2.0 on Android to be compatible with Kotlin 2.3 ([#245](https://github.com/PostHog/posthog-flutter/pull/245))

--- a/lib/src/replay/element_parsers/element_object_parser.dart
+++ b/lib/src/replay/element_parsers/element_object_parser.dart
@@ -70,6 +70,21 @@ class ElementObjectParser {
       }
     }
 
+    if (element.renderObject is RenderParagraph ||
+        element.renderObject is RenderEditable) {
+      final dataType = element.renderObject.runtimeType.toString();
+
+      final parser = PostHogMaskController.instance.parsers[dataType];
+      if (parser != null) {
+        final elementData = parser.relate(element, activeElementData);
+
+        if (elementData != null) {
+          activeElementData.addChildren(elementData);
+          return elementData;
+        }
+      }
+    }
+
     return null;
   }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #239 

`RenderParagraph` and `RenderEditable` parsers were registered but never invoked, causing text rendered via RichText (including TextField labels, hints, and SelectableText) to not be masked in session replay.

<table>
<tr>
  <td> Before
  <td> After
 <tr>
  <td> <img alt="CleanShot 2026-01-13 at 14 30 53" src="https://github.com/user-attachments/assets/43522eef-174a-416a-9eae-1a6fc85ba8e1" />
  <td> <img alt="CleanShot 2026-01-13 at 15 32 37" src="https://github.com/user-attachments/assets/bae1b9ee-3d3a-43a9-b5f4-fab4cc1093ee" />
</table>

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
