### PR TITLE
fix: update color property accessors to match Flutter's stable API

### DIFF
--- a/lib/src/surveys/models/survey_appearance.dart
+++ b/lib/src/surveys/models/survey_appearance.dart
@@ -113,9 +113,9 @@ class SurveyAppearance {
   /// Uses the HSP (Highly Sensitive Perceived) color model for perceived brightness.
   /// This matches the algorithm used in posthog-js.
   static Color _getContrastingTextColor(Color color) {
-    final r = color.r;
-    final g = color.g;
-    final b = color.b;
+    final r = (color.r * 255.0).round().clamp(0, 255);
+    final g = (color.g * 255.0).round().clamp(0, 255);
+    final b = (color.b * 255.0).round().clamp(0, 255);
     // HSP equation for perceived brightness
     final hsp = sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b));
     // Using 127.5 as threshold (same as JS)


### PR DESCRIPTION
## :bulb: Motivation and Context

To avoid a info lint about deprecation.
Related [PR on Flutter](https://github.com/flutter/flutter/pull/171160).
This would improve the pub points on pub.dev

#skip-changelog

## :green_heart: How did you test it?

When applied the change, the lint was solved

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
