### PR TITLE
fix(surveys): fix app theme leaking in for input backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - feat: add `setPersonProperties` method to set person properties without requiring `identify` ([#284](https://github.com/PostHog/posthog-flutter/pull/284))
 
+- fix: add `filled: false` to survey open-text questions to prevent app theme from overriding survey customization values ([#285](https://github.com/PostHog/posthog-flutter/pull/285))
+
 # 5.14.0
 
 - feat: add manual session recording control APIs ([#256](https://github.com/PostHog/posthog-flutter/pull/256))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,6 +89,9 @@ class _MyAppState extends State<MyApp> {
       child: MaterialApp(
         navigatorObservers: [PosthogObserver()],
         title: 'Flutter App',
+        theme: ThemeData.light(),
+        darkTheme: ThemeData.dark(),
+        themeMode: ThemeMode.system,
         home: const InitialScreen(),
       ),
     );

--- a/lib/src/surveys/widgets/open_text_question.dart
+++ b/lib/src/surveys/widgets/open_text_question.dart
@@ -81,6 +81,7 @@ class _OpenTextQuestionState extends State<OpenTextQuestion> {
                         color: widget.appearance.inputPlaceholderColor),
                     contentPadding: const EdgeInsets.all(12),
                     border: InputBorder.none,
+                    filled: false,
                   ),
                   style: TextStyle(color: widget.appearance.inputTextColor),
                   onChanged: (value) {

--- a/lib/src/surveys/widgets/survey_choice_button.dart
+++ b/lib/src/surveys/widgets/survey_choice_button.dart
@@ -64,6 +64,7 @@ class SurveyChoiceButton extends StatelessWidget {
                             initialValue: openChoiceInput,
                             decoration: const InputDecoration(
                               border: InputBorder.none,
+                              filled: false,
                               isDense: true,
                               contentPadding: EdgeInsets.zero,
                             ),


### PR DESCRIPTION
## :bulb: Motivation and Context
see https://posthog.com/questions/other-texbox-showing-with-black-background

when a flutter app's theme has `inputDecorationTheme.filled: true`, that setting overrides the survey customization values

this sets `filled: false` on open text questions (and open-text responses for choice questions) so the app's theme does not override it, and the survey customization values are source of truth

## :green_heart: How did you test it?

manual testing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
