### PR TITLE
chore: bump GitHub Actions versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
       uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
         cache: 'pnpm'

--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Restore Slack thread_ts from cache
         id: restore-thread-ts
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .slack-thread-ts
           key: slack-thread-ts-${{ steps.get-version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Cache Slack thread_ts for publish workflow
         if: steps.commit-version-bump.outputs.committed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .slack-thread-ts
           key: slack-thread-ts-${{ steps.apply-changesets.outputs.new-version }}


### PR DESCRIPTION
## Changes

- `actions/setup-node` v4 → v6
- `actions/cache/restore` v4 → v5
- `actions/cache/save` v4 → v5

Keeps CI dependencies up to date.