### PR TITLE
fix: bump iOS SDK minimum to 3.43.0

### DIFF
--- a/.changeset/green-hotels-follow.md
+++ b/.changeset/green-hotels-follow.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+fix: bump iOS SDK minimum to 3.43.0 to fix feature flags race condition between preload and identify

--- a/posthog_flutter/ios/posthog_flutter.podspec
+++ b/posthog_flutter/ios/posthog_flutter.podspec
@@ -22,7 +22,7 @@ Postog flutter plugin
   s.osx.dependency 'FlutterMacOS'
 
   # ~> Version 3.40.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.42.1', '< 4.0.0'
+  s.dependency 'PostHog', '>= 3.43.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15


### PR DESCRIPTION
Fixes feature flags race condition between preload and identify (posthog-ios#501).

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
