### PR TITLE
feat(surveys): support survey schedule 'always' to show every time

### DIFF
--- a/.changeset/bright-surveys-fly.md
+++ b/.changeset/bright-surveys-fly.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': minor
+---
+
+feat(surveys): support survey schedule 'always' to show every time

--- a/.changeset/bright-surveys-fly.md
+++ b/.changeset/bright-surveys-fly.md
@@ -2,4 +2,4 @@
 'posthog_flutter': minor
 ---
 
-feat(surveys): support survey schedule 'always' to show every time (closes #321)
+feat(surveys): support survey schedule 'always' to show every time and survey wait period filtering (seenSurveyWaitPeriodInDays)

--- a/.changeset/bright-surveys-fly.md
+++ b/.changeset/bright-surveys-fly.md
@@ -2,4 +2,4 @@
 'posthog_flutter': minor
 ---
 
-feat(surveys): support survey schedule 'always' to show every time
+feat(surveys): support survey schedule 'always' to show every time (closes #321)

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -54,7 +54,7 @@ android {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
         // + Version 3.31.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.34.3,4.0.0]'
+        implementation 'com.posthog:posthog-android:[3.35.0,4.0.0]'
     }
 
     testOptions {

--- a/posthog_flutter/ios/posthog_flutter.podspec
+++ b/posthog_flutter/ios/posthog_flutter.podspec
@@ -22,7 +22,7 @@ Postog flutter plugin
   s.osx.dependency 'FlutterMacOS'
 
   # ~> Version 3.40.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.43.0', '< 4.0.0'
+  s.dependency 'PostHog', '>= 3.44.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15


### PR DESCRIPTION
## :bulb: Motivation and Context

Bump the Android SDK minimum to 3.35.0 and iOS SDK minimum to 3.44.0 to support the `schedule: 'always'` survey configuration option, which displays surveys repeatedly regardless of prior viewing history.

This brings the Flutter SDK in line with the native SDKs that now support this functionality.

Related: https://github.com/PostHog/posthog-android/pull/403
Closes https://github.com/PostHog/posthog-flutter/issues/321
Closes https://github.com/PostHog/posthog-flutter/issues/260

## :green_heart: How did you test it?

Dependency bump only — tested by native SDK tests.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR