### PR TITLE
chore: add inline Slack failure notifications to release workflows

### DIFF
--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -103,6 +103,34 @@ jobs:
               "packageVersion": "${{ steps.get-version.outputs.version }}"
             }
 
+      - name: Restore Slack thread_ts from cache
+        if: ${{ failure() }}
+        id: restore-thread-ts-for-failure
+        uses: actions/cache/restore@v5
+        with:
+          path: .slack-thread-ts
+          key: slack-thread-ts-${{ steps.get-version.outputs.version }}
+
+      - name: Read Slack thread_ts for failure
+        if: ${{ failure() }}
+        id: slack-thread-for-failure
+        run: |
+          if [ -f .slack-thread-ts ]; then
+            THREAD_TS=$(cat .slack-thread-ts)
+            echo "thread_ts=$THREAD_TS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack - Failed
+        continue-on-error: true
+        if: ${{ failure() && steps.slack-thread-for-failure.outputs.thread_ts != '' }}
+        uses: PostHog/.github/.github/actions/slack-thread-reply@main
+        with:
+          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+          thread_ts: ${{ steps.slack-thread-for-failure.outputs.thread_ts }}
+          message: '❌ Failed to publish `posthog_flutter@${{ steps.get-version.outputs.version }}` to pub.dev! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+          emoji_reaction: 'x'
+
   notify-released:
     name: Notify Slack - Released
     needs: publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,6 +173,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+      - name: Notify Slack - Failed
+        continue-on-error: true
+        if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
+        uses: PostHog/.github/.github/actions/slack-thread-reply@main
+        with:
+          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+          message: '❌ Failed to bump version for `posthog_flutter@${{ steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+          emoji_reaction: 'x'
+
   notify-rejected:
     name: Notify Slack - Rejected
     needs: [version-bump, notify-approval-needed]


### PR DESCRIPTION
## :bulb: Motivation and Context

The release process didn't notify Slack if the release failed mid-workflow. Following the pattern from [posthog-js's release.yml](https://github.com/PostHog/posthog-js/blob/main/.github/workflows/release.yml#L336-L345), this adds inline Slack failure notifications so the team is alerted immediately when something goes wrong.

**Changes:**
- **`publish.yml`**: Added a "Notify Slack - Failed" step at the end of the `version-bump` job. If any step fails (and it's not a rejection), it replies to the Slack thread with a failure message and link to logs.
- **`publish-pub-dev.yml`**: Added inline failure notification steps in the `publish` job. On failure, it restores the Slack thread_ts from cache and sends a failure notification with a link to logs.

Both use `continue-on-error: true` so the Slack notification itself doesn't affect the job status, and `emoji_reaction: 'x'` for visibility.

## :green_heart: How did you test it?

YAML lint validation passed. Logic follows the proven pattern from posthog-js.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.