### PR TITLE
feat: synchronous feature flag reads via Dart-side fetch

### DIFF
--- a/posthog_flutter/lib/posthog_flutter.dart
+++ b/posthog_flutter/lib/posthog_flutter.dart
@@ -1,9 +1,13 @@
 library posthog_flutter;
 
 export 'src/feature_flag_result.dart';
+export 'src/feature_flags/feature_flags_types.dart'
+    show FeatureFlagDetail, FeatureFlagMetadata, EvaluationReason;
 export 'src/posthog.dart';
 export 'src/posthog_config.dart';
 export 'src/posthog_event.dart';
+export 'src/posthog_flutter_platform_interface.dart'
+    show OnFeatureFlagsCallback, OnFeatureFlagsLoadedCallback;
 export 'src/posthog_observer.dart';
 export 'src/posthog_widget.dart';
 export 'src/replay/mask/posthog_mask_widget.dart';

--- a/posthog_flutter/lib/src/feature_flags/feature_flags_types.dart
+++ b/posthog_flutter/lib/src/feature_flags/feature_flags_types.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+
+/// Detailed information about a single feature flag evaluation from the v2 API.
+class FeatureFlagDetail {
+  final String key;
+  final bool enabled;
+  final String? variant;
+  final EvaluationReason? reason;
+  final FeatureFlagMetadata? metadata;
+  final bool? failed;
+
+  const FeatureFlagDetail({
+    required this.key,
+    required this.enabled,
+    this.variant,
+    this.reason,
+    this.metadata,
+    this.failed,
+  });
+
+  factory FeatureFlagDetail.fromJson(String key, Map<String, dynamic> json) {
+    return FeatureFlagDetail(
+      key: key,
+      enabled: json['enabled'] as bool? ?? false,
+      variant: json['variant'] as String?,
+      reason: json['reason'] != null
+          ? EvaluationReason.fromJson(
+              Map<String, dynamic>.from(json['reason'] as Map))
+          : null,
+      metadata: json['metadata'] != null
+          ? FeatureFlagMetadata.fromJson(
+              Map<String, dynamic>.from(json['metadata'] as Map))
+          : null,
+      failed: json['failed'] as bool?,
+    );
+  }
+
+  /// Returns the effective value of this flag.
+  /// For multivariate flags, returns the variant string.
+  /// For boolean flags, returns the enabled bool.
+  Object? get value => variant ?? enabled;
+
+  @override
+  String toString() =>
+      'FeatureFlagDetail(key: $key, enabled: $enabled, variant: $variant, failed: $failed)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FeatureFlagDetail &&
+        other.key == key &&
+        other.enabled == enabled &&
+        other.variant == variant &&
+        other.failed == failed;
+  }
+
+  @override
+  int get hashCode => Object.hash(key, enabled, variant, failed);
+}
+
+/// Metadata about a feature flag.
+class FeatureFlagMetadata {
+  final int? id;
+  final int? version;
+  final String? description;
+  final Object? payload;
+
+  const FeatureFlagMetadata({
+    this.id,
+    this.version,
+    this.description,
+    this.payload,
+  });
+
+  factory FeatureFlagMetadata.fromJson(Map<String, dynamic> json) {
+    return FeatureFlagMetadata(
+      id: json['id'] as int?,
+      version: json['version'] as int?,
+      description: json['description'] as String?,
+      payload: _parsePayload(json['payload']),
+    );
+  }
+
+  static Object? _parsePayload(Object? raw) {
+    if (raw == null) return null;
+    if (raw is String) {
+      try {
+        return jsonDecode(raw);
+      } catch (_) {
+        return raw;
+      }
+    }
+    return raw;
+  }
+}
+
+/// The reason a feature flag was evaluated to its current value.
+class EvaluationReason {
+  final String? code;
+  final int? conditionIndex;
+  final String? description;
+
+  const EvaluationReason({
+    this.code,
+    this.conditionIndex,
+    this.description,
+  });
+
+  factory EvaluationReason.fromJson(Map<String, dynamic> json) {
+    return EvaluationReason(
+      code: json['code'] as String?,
+      conditionIndex: json['condition_index'] as int?,
+      description: json['description'] as String?,
+    );
+  }
+}
+
+/// Parsed response from the `/flags/?v=2` API endpoint.
+class PostHogFlagsResponse {
+  final Map<String, FeatureFlagDetail> flags;
+  final bool errorsWhileComputingFlags;
+  final List<String> quotaLimited;
+  final String? requestId;
+  final int? evaluatedAt;
+
+  const PostHogFlagsResponse({
+    required this.flags,
+    this.errorsWhileComputingFlags = false,
+    this.quotaLimited = const [],
+    this.requestId,
+    this.evaluatedAt,
+  });
+
+  /// Returns a map of flag key → value (variant string or enabled bool),
+  /// matching the legacy `featureFlags` format.
+  Map<String, Object> get featureFlags {
+    final result = <String, Object>{};
+    for (final entry in flags.entries) {
+      if (entry.value.enabled) {
+        result[entry.key] = entry.value.variant ?? true;
+      }
+    }
+    return result;
+  }
+
+  /// Returns a map of flag key → payload, for flags that have payloads.
+  Map<String, Object> get featureFlagPayloads {
+    final result = <String, Object>{};
+    for (final entry in flags.entries) {
+      final payload = entry.value.metadata?.payload;
+      if (payload != null) {
+        result[entry.key] = payload;
+      }
+    }
+    return result;
+  }
+}
+
+/// Error types for feature flag requests.
+enum FeatureFlagRequestErrorType {
+  networkError,
+  httpError,
+  parseError,
+}
+
+/// Error from a feature flag request.
+class FeatureFlagRequestError {
+  final FeatureFlagRequestErrorType type;
+  final String message;
+  final int? statusCode;
+
+  const FeatureFlagRequestError({
+    required this.type,
+    required this.message,
+    this.statusCode,
+  });
+
+  @override
+  String toString() =>
+      'FeatureFlagRequestError($type: $message${statusCode != null ? ', status: $statusCode' : ''})';
+}
+
+/// Result of a feature flag fetch operation.
+sealed class GetFlagsResult {
+  const GetFlagsResult();
+}
+
+class GetFlagsSuccess extends GetFlagsResult {
+  final PostHogFlagsResponse response;
+  const GetFlagsSuccess(this.response);
+}
+
+class GetFlagsFailure extends GetFlagsResult {
+  final FeatureFlagRequestError error;
+  const GetFlagsFailure(this.error);
+}

--- a/posthog_flutter/lib/src/feature_flags/feature_flags_utils.dart
+++ b/posthog_flutter/lib/src/feature_flags/feature_flags_utils.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'feature_flags_types.dart';
+
+/// Parses a JSON response body from the `/flags/?v=2` endpoint
+/// into a [PostHogFlagsResponse].
+GetFlagsResult parseFlagsResponse(String responseBody, int statusCode) {
+  if (statusCode < 200 || statusCode >= 300) {
+    return GetFlagsFailure(FeatureFlagRequestError(
+      type: FeatureFlagRequestErrorType.httpError,
+      message: 'HTTP $statusCode',
+      statusCode: statusCode,
+    ));
+  }
+
+  try {
+    final json = jsonDecode(responseBody) as Map<String, dynamic>;
+    return GetFlagsSuccess(_parseResponseJson(json));
+  } catch (e) {
+    return GetFlagsFailure(FeatureFlagRequestError(
+      type: FeatureFlagRequestErrorType.parseError,
+      message: 'Failed to parse flags response: $e',
+    ));
+  }
+}
+
+PostHogFlagsResponse _parseResponseJson(Map<String, dynamic> json) {
+  final flagsJson = json['flags'] as Map<String, dynamic>? ?? {};
+  final flags = <String, FeatureFlagDetail>{};
+
+  for (final entry in flagsJson.entries) {
+    if (entry.value is Map) {
+      flags[entry.key] = FeatureFlagDetail.fromJson(
+        entry.key,
+        Map<String, dynamic>.from(entry.value as Map),
+      );
+    }
+  }
+
+  final quotaLimitedRaw = json['quotaLimited'] as List<dynamic>? ?? [];
+  final quotaLimited =
+      quotaLimitedRaw.whereType<String>().toList(growable: false);
+
+  return PostHogFlagsResponse(
+    flags: flags,
+    errorsWhileComputingFlags:
+        json['errorsWhileComputingFlags'] as bool? ?? false,
+    quotaLimited: quotaLimited,
+    requestId: json['requestId'] as String?,
+    evaluatedAt: json['evaluatedAt'] as int?,
+  );
+}

--- a/posthog_flutter/lib/src/feature_flags/posthog_feature_flags.dart
+++ b/posthog_flutter/lib/src/feature_flags/posthog_feature_flags.dart
@@ -1,0 +1,254 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../feature_flag_result.dart';
+import '../util/logging.dart';
+import 'feature_flags_types.dart';
+import 'feature_flags_utils.dart';
+
+/// Parameters for a feature flag load request.
+class _LoadParams {
+  final String distinctId;
+  final String? anonymousId;
+  final Map<String, Object>? groups;
+  final Map<String, Object>? personProperties;
+  final Map<String, Map<String, Object>>? groupProperties;
+
+  const _LoadParams({
+    required this.distinctId,
+    this.anonymousId,
+    this.groups,
+    this.personProperties,
+    this.groupProperties,
+  });
+}
+
+/// Manages feature flags fetched from PostHog's `/flags/?v=2` API.
+///
+/// Provides synchronous reads from an in-memory cache and handles
+/// request coalescing, error merging, and quota limiting following
+/// the patterns from the Android SDK's `PostHogRemoteConfig`.
+class PostHogFeatureFlags {
+  final String _apiKey;
+  final String _host;
+  final http.Client _httpClient;
+
+  /// Cached flags (sync reads).
+  Map<String, FeatureFlagDetail> _flags = {};
+  bool _isLoaded = false;
+
+  /// The request ID from the last successful flags response.
+  String? requestId;
+
+  /// The evaluation timestamp from the last successful flags response.
+  int? evaluatedAt;
+
+  /// Request coalescing state.
+  Future<void>? _loadingFuture;
+  Completer<void>? _pendingReload;
+  _LoadParams? _pendingParams;
+
+  /// Callback invoked when feature flags are updated.
+  void Function(Map<String, PostHogFeatureFlagResult> flags)? onFeatureFlags;
+
+  PostHogFeatureFlags({
+    required String apiKey,
+    required String host,
+    http.Client? httpClient,
+  })  : _apiKey = apiKey,
+        _host = host.endsWith('/') ? host.substring(0, host.length - 1) : host,
+        _httpClient = httpClient ?? http.Client();
+
+  // ---------------------------------------------------------------------------
+  // Public sync reads
+  // ---------------------------------------------------------------------------
+
+  /// Whether flags have been successfully loaded at least once.
+  bool get isLoaded => _isLoaded;
+
+  /// Returns a [PostHogFeatureFlagResult] for the given flag key,
+  /// or `null` if the flag is not in the cache.
+  PostHogFeatureFlagResult? getFeatureFlagResult(String key) {
+    final detail = _flags[key];
+    if (detail == null) return null;
+
+    return PostHogFeatureFlagResult(
+      key: detail.key,
+      enabled: detail.enabled,
+      variant: detail.variant,
+      payload: detail.metadata?.payload,
+    );
+  }
+
+  /// Returns `true` if the flag is enabled (exists and enabled).
+  /// Returns `false` for unknown flags or disabled flags.
+  bool isFeatureEnabled(String key) {
+    return _flags[key]?.enabled ?? false;
+  }
+
+  /// Returns the flag value: variant string for multivariate flags,
+  /// `true`/`false` for boolean flags, or `null` if not found.
+  Object? getFeatureFlag(String key) {
+    final detail = _flags[key];
+    if (detail == null) return null;
+    if (!detail.enabled) return false;
+    return detail.variant ?? true;
+  }
+
+  /// Returns the payload associated with a feature flag, if any.
+  Object? getFeatureFlagPayload(String key) {
+    return _flags[key]?.metadata?.payload;
+  }
+
+  /// Returns all cached flags as a map of key → [PostHogFeatureFlagResult].
+  Map<String, PostHogFeatureFlagResult> getAllFlags() {
+    final result = <String, PostHogFeatureFlagResult>{};
+    for (final entry in _flags.entries) {
+      result[entry.key] = PostHogFeatureFlagResult(
+        key: entry.key,
+        enabled: entry.value.enabled,
+        variant: entry.value.variant,
+        payload: entry.value.metadata?.payload,
+      );
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Async operations
+  // ---------------------------------------------------------------------------
+
+  /// Loads feature flags from the PostHog API.
+  ///
+  /// Uses request coalescing: if a request is already in-flight, the new
+  /// request is queued and executed after the current one completes.
+  /// This follows the Android SDK's `pendingFeatureFlagsReload` pattern.
+  Future<void> loadFeatureFlags(
+    String distinctId, {
+    String? anonymousId,
+    Map<String, Object>? groups,
+    Map<String, Object>? personProperties,
+    Map<String, Map<String, Object>>? groupProperties,
+  }) async {
+    final params = _LoadParams(
+      distinctId: distinctId,
+      anonymousId: anonymousId,
+      groups: groups,
+      personProperties: personProperties,
+      groupProperties: groupProperties,
+    );
+
+    if (_loadingFuture != null) {
+      // Request in-flight — queue this one
+      _pendingReload?.complete();
+      _pendingReload = Completer<void>();
+      _pendingParams = params;
+      return _pendingReload!.future;
+    }
+
+    _loadingFuture = _doLoadFeatureFlags(params);
+    try {
+      await _loadingFuture;
+    } finally {
+      _loadingFuture = null;
+      if (_pendingReload != null) {
+        final pending = _pendingReload!;
+        final pendingParams = _pendingParams!;
+        _pendingReload = null;
+        _pendingParams = null;
+        loadFeatureFlags(
+          pendingParams.distinctId,
+          anonymousId: pendingParams.anonymousId,
+          groups: pendingParams.groups,
+          personProperties: pendingParams.personProperties,
+          groupProperties: pendingParams.groupProperties,
+        ).then((_) {
+          if (!pending.isCompleted) {
+            pending.complete();
+          }
+        }).catchError((e) {
+          if (!pending.isCompleted) {
+            pending.completeError(e);
+          }
+        });
+      }
+    }
+  }
+
+  Future<void> _doLoadFeatureFlags(_LoadParams params) async {
+    final url = '$_host/flags/?v=2&config=true';
+
+    final body = <String, Object?>{
+      'token': _apiKey,
+      'distinct_id': params.distinctId,
+    };
+
+    if (params.anonymousId != null) {
+      body[r'$anon_distinct_id'] = params.anonymousId;
+    }
+    if (params.groups != null && params.groups!.isNotEmpty) {
+      body['groups'] = params.groups;
+    }
+    if (params.personProperties != null &&
+        params.personProperties!.isNotEmpty) {
+      body['person_properties'] = params.personProperties;
+    }
+    if (params.groupProperties != null && params.groupProperties!.isNotEmpty) {
+      body['group_properties'] = params.groupProperties;
+    }
+
+    try {
+      final response = await _httpClient.post(
+        Uri.parse(url),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(body),
+      );
+
+      final result = parseFlagsResponse(response.body, response.statusCode);
+
+      switch (result) {
+        case GetFlagsSuccess(:final response):
+          _applyResponse(response);
+        case GetFlagsFailure(:final error):
+          printIfDebug('[PostHog] Failed to load feature flags: $error');
+      }
+    } catch (e) {
+      printIfDebug('[PostHog] Network error loading feature flags: $e');
+    }
+  }
+
+  void _applyResponse(PostHogFlagsResponse response) {
+    // Check quota limiting
+    if (response.quotaLimited.contains('feature_flags')) {
+      printIfDebug('[PostHog] Feature flags quota limited, skipping update');
+      return;
+    }
+
+    if (response.errorsWhileComputingFlags) {
+      // MERGE: only update non-failed flags, preserve existing cache for failed ones
+      final successful = response.flags.entries
+          .where((e) => e.value.failed != true);
+      _flags = {..._flags, ...Map.fromEntries(successful)};
+    } else {
+      // REPLACE: full response, safe to overwrite
+      _flags = Map.of(response.flags);
+    }
+
+    requestId = response.requestId;
+    evaluatedAt = response.evaluatedAt;
+    _isLoaded = true;
+
+    // Notify callback
+    onFeatureFlags?.call(getAllFlags());
+  }
+
+  /// Clears all cached flag state.
+  void clear() {
+    _flags = {};
+    requestId = null;
+    evaluatedAt = null;
+    _isLoaded = false;
+  }
+}

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -6,6 +6,7 @@ import 'package:posthog_flutter/src/error_tracking/posthog_error_tracking_autoca
 import 'package:posthog_flutter/src/error_tracking/posthog_exception.dart';
 import 'feature_flag_result.dart';
 import 'posthog_config.dart';
+import 'posthog_flutter_io.dart';
 import 'posthog_flutter_platform_interface.dart';
 import 'posthog_internal_events.dart';
 import 'posthog_observer.dart';
@@ -37,6 +38,10 @@ class Posthog {
   /// config.host = 'YOUR_POSTHOG_HOST';
   /// config.onFeatureFlags = () {
   ///   // Feature flags are now loaded, you can read flag values here
+  /// };
+  /// // Or use the new callback with flag data:
+  /// config.onFeatureFlagsLoaded = (flags) {
+  ///   // flags contains all loaded feature flags
   /// };
   /// await Posthog().setup(config);
   /// ```
@@ -239,14 +244,20 @@ class Posthog {
   /// [key] the Key
   Future<void> unregister(String key) => _posthog.unregister(key);
 
-  /// Returns if a feature flag is enabled, the feature flag must be a Boolean
+  /// Returns if a feature flag is enabled via the native SDK.
+  ///
+  /// This is an async call that reads from the native iOS/Android SDK cache.
+  /// For synchronous reads from the Dart-side cache, use [isFeatureEnabledSync].
   ///
   /// Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
   ///
   /// - [key] the Key of the feature
   Future<bool> isFeatureEnabled(String key) => _posthog.isFeatureEnabled(key);
 
-  /// Reloads the feature flags
+  /// Reloads feature flags from both the native SDK and the Dart-side cache.
+  ///
+  /// After completion, both the native async methods and the Dart sync methods
+  /// will reflect the updated flag values.
   Future<void> reloadFeatureFlags() => _posthog.reloadFeatureFlags();
 
   /// Creates a group.
@@ -276,7 +287,10 @@ class Posthog {
         groupProperties: groupProperties,
       );
 
-  /// Returns the feature flag value for the given key.
+  /// Returns the feature flag value via the native SDK.
+  ///
+  /// This is an async call that reads from the native iOS/Android SDK cache.
+  /// For synchronous reads from the Dart-side cache, use [getFeatureFlagSync].
   ///
   /// Returns `null` if the flag doesn't exist.
   /// For boolean flags, returns `true` or `false`.
@@ -284,9 +298,13 @@ class Posthog {
   Future<Object?> getFeatureFlag(String key) =>
       _posthog.getFeatureFlag(key: key);
 
-  /// Returns the full feature flag result including value and payload.
+  /// Returns the full feature flag result via the native SDK, including
+  /// value and payload.
   ///
-  /// This is the canonical method for getting feature flag data.
+  /// This is an async call that reads from the native iOS/Android SDK cache.
+  /// For synchronous reads from the Dart-side cache, use
+  /// [getFeatureFlagResultSync].
+  ///
   /// Returns `null` if the flag doesn't exist.
   ///
   /// Set [sendEvent] to `false` to suppress the `$feature_flag_called` event.
@@ -304,11 +322,88 @@ class Posthog {
           {bool sendEvent = true}) =>
       _posthog.getFeatureFlagResult(key: key, sendEvent: sendEvent);
 
-  /// Returns the payload for a feature flag.
+  /// Returns the payload for a feature flag via the native SDK.
   @Deprecated(
       'Use getFeatureFlagResult instead, which returns both value and payload.')
   Future<Object?> getFeatureFlagPayload(String key) =>
       _posthog.getFeatureFlagPayload(key: key);
+
+  // ---------------------------------------------------------------------------
+  // Sync feature flag API — reads directly from Dart-side cache
+  // ---------------------------------------------------------------------------
+
+  /// Returns `true` if the feature flag is enabled, `false` otherwise.
+  ///
+  /// This is a **synchronous** read from the Dart-side cache — safe to call
+  /// directly inside `build()` methods without `FutureBuilder`. Flags are
+  /// loaded automatically during [setup] (when `preloadFeatureFlags: true`)
+  /// and updated via [reloadFeatureFlags].
+  ///
+  /// See also [isFeatureEnabled] for the async native SDK equivalent.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// if (Posthog().isFeatureEnabledSync('new-onboarding')) {
+  ///   // Show new onboarding flow
+  /// }
+  /// ```
+  bool isFeatureEnabledSync(String key) {
+    final io = _posthog;
+    if (io is PosthogFlutterIO) {
+      return io.featureFlags?.isFeatureEnabled(key) ?? false;
+    }
+    return false;
+  }
+
+  /// Returns the feature flag value synchronously from the Dart-side cache.
+  ///
+  /// Safe to call directly inside `build()` methods.
+  /// For boolean flags, returns `true` or `false`.
+  /// For multivariate flags, returns the variant string.
+  /// Returns `null` if the flag doesn't exist in the cache.
+  ///
+  /// See also [getFeatureFlag] for the async native SDK equivalent.
+  Object? getFeatureFlagSync(String key) {
+    final io = _posthog;
+    if (io is PosthogFlutterIO) {
+      return io.featureFlags?.getFeatureFlag(key);
+    }
+    return null;
+  }
+
+  /// Returns the full feature flag result synchronously from the Dart-side
+  /// cache, including payload.
+  ///
+  /// Safe to call directly inside `build()` methods.
+  /// Returns `null` if the flag doesn't exist in the cache.
+  ///
+  /// See also [getFeatureFlagResult] for the async native SDK equivalent.
+  PostHogFeatureFlagResult? getFeatureFlagResultSync(String key) {
+    final io = _posthog;
+    if (io is PosthogFlutterIO) {
+      return io.featureFlags?.getFeatureFlagResult(key);
+    }
+    return null;
+  }
+
+  /// Returns all currently cached feature flag results from the Dart-side cache.
+  Map<String, PostHogFeatureFlagResult> getAllFeatureFlagResults() {
+    final io = _posthog;
+    if (io is PosthogFlutterIO) {
+      return io.featureFlags?.getAllFlags() ?? {};
+    }
+    return {};
+  }
+
+  /// Returns whether the Dart-side feature flag cache has been loaded
+  /// at least once.
+  bool get isFeatureFlagsLoaded {
+    final io = _posthog;
+    if (io is PosthogFlutterIO) {
+      return io.featureFlags?.isLoaded ?? false;
+    }
+    return false;
+  }
 
   Future<void> flush() => _posthog.flush();
 

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -62,6 +62,13 @@ class PostHogConfig {
   /// callback to access the loaded flag values.
   OnFeatureFlagsCallback? onFeatureFlags;
 
+  /// Callback to be invoked when feature flags are loaded, receiving the
+  /// full flag data as a map.
+  ///
+  /// You can also use [Posthog.isFeatureEnabledSync] or
+  /// [Posthog.getFeatureFlagSync] to read flag values synchronously.
+  OnFeatureFlagsLoadedCallback? onFeatureFlagsLoaded;
+
   /// Callbacks to intercept and modify events before they are sent to PostHog.
   ///
   /// Callbacks are invoked in order for events captured via Dart APIs:

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -25,6 +25,18 @@ class PostHogConfig {
   var preloadFeatureFlags = true;
   var captureApplicationLifecycleEvents = false;
 
+  /// Enable Dart-side feature flag cache for synchronous reads.
+  ///
+  /// When `false` (default), feature flags are managed entirely by the native
+  /// iOS/Android SDK. The sync methods ([Posthog.isFeatureEnabledSync],
+  /// [Posthog.getFeatureFlagSync], etc.) will return `false`/`null`/`{}`.
+  ///
+  /// When `true`, the SDK fetches flags via a Dart HTTP call and caches them
+  /// locally. This enables synchronous reads from the Dart-side cache, and
+  /// the async feature flag methods also read from this cache. The native
+  /// SDK's own flag fetching is suppressed to avoid duplicate HTTP calls.
+  var enableSyncFeatureFlags = false;
+
   var debug = false;
   var optOut = false;
   var personProfiles = PostHogPersonProfiles.identifiedOnly;

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -10,6 +10,7 @@ import 'package:posthog_flutter/src/util/logging.dart';
 import 'surveys/models/posthog_display_survey.dart' as models;
 import 'surveys/models/survey_callbacks.dart';
 import 'error_tracking/dart_exception_processor.dart';
+import 'feature_flags/posthog_feature_flags.dart';
 import 'utils/capture_utils.dart';
 import 'utils/property_normalizer.dart';
 
@@ -29,6 +30,13 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   final _methodChannel = const MethodChannel('posthog_flutter');
 
   OnFeatureFlagsCallback? _onFeatureFlagsCallback;
+  OnFeatureFlagsLoadedCallback? _onFeatureFlagsLoadedCallback;
+
+  /// Dart-side feature flags manager.
+  PostHogFeatureFlags? _featureFlags;
+
+  /// Exposes the feature flags manager for sync reads from [Posthog].
+  PostHogFeatureFlags? get featureFlags => _featureFlags;
 
   /// Stored configuration for accessing inAppIncludes and other settings
   PostHogConfig? _config;
@@ -89,7 +97,10 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
         await cleanupSurveys();
         return null;
       case 'onFeatureFlagsCallback':
+        // Fire legacy callback immediately (backward compat)
         _onFeatureFlagsCallback?.call();
+        // Also reload Dart-side flags; onFeatureFlagsLoaded fires when done
+        _reloadDartFlags();
         break;
       default:
         printIfDebug(
@@ -182,12 +193,27 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     }
 
     _onFeatureFlagsCallback = config.onFeatureFlags;
+    _onFeatureFlagsLoadedCallback = config.onFeatureFlagsLoaded;
     _beforeSendCallbacks = config.beforeSend;
+
+    // Create Dart-side feature flags manager
+    _featureFlags = PostHogFeatureFlags(
+      apiKey: config.apiKey,
+      host: config.host,
+    );
+    _featureFlags!.onFeatureFlags = (flags) {
+      _onFeatureFlagsLoadedCallback?.call(flags);
+    };
 
     try {
       await _methodChannel.invokeMethod('setup', config.toMap());
     } on PlatformException catch (exception) {
       printIfDebug('Exeption on setup: $exception');
+    }
+
+    // Also load flags on the Dart side for sync reads
+    if (config.preloadFeatureFlags) {
+      _reloadDartFlags();
     }
   }
 
@@ -396,6 +422,8 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
 
   @override
   Future<void> reset() async {
+    _featureFlags?.clear();
+
     if (!isSupportedPlatform()) {
       return;
     }
@@ -485,11 +513,13 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
       return;
     }
 
+    // Reload both native and Dart-side flags
     try {
       await _methodChannel.invokeMethod('reloadFeatureFlags');
     } on PlatformException catch (exception) {
       printIfDebug('Exeption on reloadFeatureFlags: $exception');
     }
+    _reloadDartFlags();
   }
 
   @override
@@ -668,8 +698,27 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     }
   }
 
+  /// Reloads feature flags from the Dart side by fetching the current
+  /// distinct ID from native and making a direct API call.
+  Future<void> _reloadDartFlags() async {
+    final featureFlags = _featureFlags;
+    if (featureFlags == null) return;
+
+    try {
+      final distinctId = await getDistinctId();
+      if (distinctId.isNotEmpty) {
+        await featureFlags.loadFeatureFlags(distinctId);
+      }
+    } catch (e) {
+      printIfDebug('[PostHog] Error reloading Dart feature flags: $e');
+    }
+  }
+
   @override
   Future<void> close() async {
+    _featureFlags?.clear();
+    _featureFlags = null;
+
     if (!isSupportedPlatform()) {
       return;
     }

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -1,24 +1,22 @@
 import 'dart:async';
 
-import 'util/platform_io_stub.dart'
-    if (dart.library.io) 'util/platform_io_real.dart';
-
 import 'package:flutter/services.dart';
-
 import 'package:posthog_flutter/src/surveys/survey_service.dart';
 import 'package:posthog_flutter/src/util/logging.dart';
-import 'surveys/models/posthog_display_survey.dart' as models;
-import 'surveys/models/survey_callbacks.dart';
-import 'error_tracking/dart_exception_processor.dart';
-import 'feature_flags/posthog_feature_flags.dart';
-import 'utils/capture_utils.dart';
-import 'utils/property_normalizer.dart';
 
+import 'error_tracking/dart_exception_processor.dart';
 import 'feature_flag_result.dart';
+import 'feature_flags/posthog_feature_flags.dart';
 import 'posthog_config.dart';
 import 'posthog_constants.dart';
 import 'posthog_event.dart';
 import 'posthog_flutter_platform_interface.dart';
+import 'surveys/models/posthog_display_survey.dart' as models;
+import 'surveys/models/survey_callbacks.dart';
+import 'util/platform_io_stub.dart'
+    if (dart.library.io) 'util/platform_io_real.dart';
+import 'utils/capture_utils.dart';
+import 'utils/property_normalizer.dart';
 
 /// An implementation of [PosthogFlutterPlatformInterface] that uses method channels.
 class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
@@ -97,10 +95,13 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
         await cleanupSurveys();
         return null;
       case 'onFeatureFlagsCallback':
-        // Fire legacy callback immediately (backward compat)
-        _onFeatureFlagsCallback?.call();
-        // Also reload Dart-side flags; onFeatureFlagsLoaded fires when done
-        _reloadDartFlags();
+        if (_featureFlags != null) {
+          // Sync mode: reload Dart-side flags; both callbacks fire on completion
+          _reloadDartFlags();
+        } else {
+          // Default mode: fire native callback directly (unchanged behavior)
+          _onFeatureFlagsCallback?.call();
+        }
         break;
       default:
         printIfDebug(
@@ -196,23 +197,33 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     _onFeatureFlagsLoadedCallback = config.onFeatureFlagsLoaded;
     _beforeSendCallbacks = config.beforeSend;
 
-    // Create Dart-side feature flags manager
-    _featureFlags = PostHogFeatureFlags(
-      apiKey: config.apiKey,
-      host: config.host,
-    );
-    _featureFlags!.onFeatureFlags = (flags) {
-      _onFeatureFlagsLoadedCallback?.call(flags);
-    };
+    if (config.enableSyncFeatureFlags) {
+      // Create Dart-side feature flags manager (opt-in)
+      _featureFlags = PostHogFeatureFlags(
+        apiKey: config.apiKey,
+        host: config.host,
+      );
+      _featureFlags!.onFeatureFlags = (flags) {
+        // Fire both callbacks from the Dart reload
+        _onFeatureFlagsCallback?.call();
+        _onFeatureFlagsLoadedCallback?.call(flags);
+      };
+    }
+
+    // When Dart handles flags, suppress native preload to avoid duplicate HTTP calls
+    final nativeConfig = config.toMap();
+    if (_featureFlags != null) {
+      nativeConfig['preloadFeatureFlags'] = false;
+    }
 
     try {
-      await _methodChannel.invokeMethod('setup', config.toMap());
+      await _methodChannel.invokeMethod('setup', nativeConfig);
     } on PlatformException catch (exception) {
       printIfDebug('Exeption on setup: $exception');
     }
 
-    // Also load flags on the Dart side for sync reads
-    if (config.preloadFeatureFlags) {
+    // Load flags on the Dart side for sync reads
+    if (_featureFlags != null && config.preloadFeatureFlags) {
       _reloadDartFlags();
     }
   }
@@ -493,6 +504,11 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
 
   @override
   Future<bool> isFeatureEnabled(String key) async {
+    final ff = _featureFlags;
+    if (ff != null) {
+      return ff.isFeatureEnabled(key);
+    }
+
     if (!isSupportedPlatform()) {
       return false;
     }
@@ -509,17 +525,21 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
 
   @override
   Future<void> reloadFeatureFlags() async {
+    if (_featureFlags != null) {
+      // Sync mode: only reload Dart-side flags (skip native call)
+      await _reloadDartFlags();
+      return;
+    }
+
     if (!isSupportedPlatform()) {
       return;
     }
 
-    // Reload both native and Dart-side flags
     try {
       await _methodChannel.invokeMethod('reloadFeatureFlags');
     } on PlatformException catch (exception) {
       printIfDebug('Exeption on reloadFeatureFlags: $exception');
     }
-    _reloadDartFlags();
   }
 
   @override
@@ -552,6 +572,11 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   Future<Object?> getFeatureFlag({
     required String key,
   }) async {
+    final ff = _featureFlags;
+    if (ff != null) {
+      return ff.getFeatureFlag(key);
+    }
+
     if (!isSupportedPlatform()) {
       return null;
     }
@@ -570,6 +595,11 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   Future<Object?> getFeatureFlagPayload({
     required String key,
   }) async {
+    final ff = _featureFlags;
+    if (ff != null) {
+      return ff.getFeatureFlagPayload(key);
+    }
+
     if (!isSupportedPlatform()) {
       return null;
     }
@@ -589,6 +619,11 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     required String key,
     bool sendEvent = true,
   }) async {
+    final ff = _featureFlags;
+    if (ff != null) {
+      return ff.getFeatureFlagResult(key);
+    }
+
     if (!isSupportedPlatform()) {
       return null;
     }

--- a/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
@@ -10,6 +10,15 @@ import 'posthog_flutter_io.dart';
 /// callback to access the loaded flag values.
 typedef OnFeatureFlagsCallback = void Function();
 
+/// Defines the callback signature for when feature flags are loaded,
+/// receiving the full flag data.
+///
+/// The [flags] parameter contains all currently loaded feature flags.
+/// You can also use [Posthog.isFeatureEnabledSync] or
+/// [Posthog.getFeatureFlagSync] to read flag values synchronously.
+typedef OnFeatureFlagsLoadedCallback = void Function(
+    Map<String, PostHogFeatureFlagResult> flags);
+
 abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
   /// Constructs a PosthogFlutterPlatform.
   PosthogFlutterPlatformInterface() : super(token: _token);

--- a/posthog_flutter/pubspec.yaml
+++ b/posthog_flutter/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   # plugin_platform_interface depends on meta anyway
   meta: ^1.3.0
   stack_trace: ^1.12.0
+  http: ^1.2.0
   web: ^1.1.0
 
 dev_dependencies:

--- a/posthog_flutter/test/feature_flags/posthog_feature_flags_test.dart
+++ b/posthog_flutter/test/feature_flags/posthog_feature_flags_test.dart
@@ -1,0 +1,690 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:posthog_flutter/src/feature_flag_result.dart';
+import 'package:posthog_flutter/src/feature_flags/feature_flags_types.dart';
+import 'package:posthog_flutter/src/feature_flags/feature_flags_utils.dart';
+import 'package:posthog_flutter/src/feature_flags/posthog_feature_flags.dart';
+
+/// Helper to build a standard v2 flags response JSON.
+String _buildFlagsResponse({
+  Map<String, dynamic>? flags,
+  bool errorsWhileComputingFlags = false,
+  List<String>? quotaLimited,
+  String? requestId,
+  int? evaluatedAt,
+}) {
+  return jsonEncode({
+    'flags': flags ?? {},
+    'errorsWhileComputingFlags': errorsWhileComputingFlags,
+    if (quotaLimited != null) 'quotaLimited': quotaLimited,
+    if (requestId != null) 'requestId': requestId,
+    if (evaluatedAt != null) 'evaluatedAt': evaluatedAt,
+  });
+}
+
+/// Helper to build a flag detail JSON object.
+Map<String, dynamic> _flagDetail({
+  required bool enabled,
+  String? variant,
+  bool? failed,
+  Map<String, dynamic>? metadata,
+  Map<String, dynamic>? reason,
+}) {
+  return {
+    'enabled': enabled,
+    if (variant != null) 'variant': variant,
+    if (failed != null) 'failed': failed,
+    if (metadata != null) 'metadata': metadata,
+    if (reason != null) 'reason': reason,
+  };
+}
+
+void main() {
+  group('parseFlagsResponse', () {
+    test('parses valid v2 flags response', () {
+      final body = _buildFlagsResponse(
+        flags: {
+          'bool-flag': _flagDetail(enabled: true),
+          'disabled-flag': _flagDetail(enabled: false),
+          'variant-flag': _flagDetail(enabled: true, variant: 'control'),
+        },
+        requestId: 'req-123',
+        evaluatedAt: 1700000000,
+      );
+
+      final result = parseFlagsResponse(body, 200);
+      expect(result, isA<GetFlagsSuccess>());
+
+      final response = (result as GetFlagsSuccess).response;
+      expect(response.flags.length, 3);
+      expect(response.flags['bool-flag']!.enabled, true);
+      expect(response.flags['bool-flag']!.variant, isNull);
+      expect(response.flags['disabled-flag']!.enabled, false);
+      expect(response.flags['variant-flag']!.variant, 'control');
+      expect(response.requestId, 'req-123');
+      expect(response.evaluatedAt, 1700000000);
+    });
+
+    test('parses errorsWhileComputingFlags', () {
+      final body = _buildFlagsResponse(
+        flags: {
+          'ok-flag': _flagDetail(enabled: true),
+          'failed-flag': _flagDetail(enabled: false, failed: true),
+        },
+        errorsWhileComputingFlags: true,
+      );
+
+      final result = parseFlagsResponse(body, 200);
+      final response = (result as GetFlagsSuccess).response;
+      expect(response.errorsWhileComputingFlags, true);
+      expect(response.flags['failed-flag']!.failed, true);
+    });
+
+    test('parses quotaLimited', () {
+      final body = _buildFlagsResponse(
+        quotaLimited: ['feature_flags'],
+      );
+
+      final result = parseFlagsResponse(body, 200);
+      final response = (result as GetFlagsSuccess).response;
+      expect(response.quotaLimited, ['feature_flags']);
+    });
+
+    test('returns failure for HTTP error', () {
+      final result = parseFlagsResponse('Internal Server Error', 500);
+      expect(result, isA<GetFlagsFailure>());
+      final error = (result as GetFlagsFailure).error;
+      expect(error.type, FeatureFlagRequestErrorType.httpError);
+      expect(error.statusCode, 500);
+    });
+
+    test('returns failure for invalid JSON', () {
+      final result = parseFlagsResponse('not json', 200);
+      expect(result, isA<GetFlagsFailure>());
+      final error = (result as GetFlagsFailure).error;
+      expect(error.type, FeatureFlagRequestErrorType.parseError);
+    });
+
+    test('parses metadata with payload', () {
+      final body = _buildFlagsResponse(
+        flags: {
+          'flag-with-payload': _flagDetail(
+            enabled: true,
+            metadata: {
+              'id': 42,
+              'version': 3,
+              'description': 'A test flag',
+              'payload': '{"key":"value"}',
+            },
+          ),
+        },
+      );
+
+      final result = parseFlagsResponse(body, 200);
+      final response = (result as GetFlagsSuccess).response;
+      final flag = response.flags['flag-with-payload']!;
+      expect(flag.metadata!.id, 42);
+      expect(flag.metadata!.version, 3);
+      expect(flag.metadata!.description, 'A test flag');
+      // Payload should be parsed from JSON string
+      expect(flag.metadata!.payload, {'key': 'value'});
+    });
+
+    test('parses evaluation reason', () {
+      final body = _buildFlagsResponse(
+        flags: {
+          'flag-with-reason': _flagDetail(
+            enabled: true,
+            reason: {
+              'code': 'condition_match',
+              'condition_index': 2,
+              'description': 'Matched condition 2',
+            },
+          ),
+        },
+      );
+
+      final result = parseFlagsResponse(body, 200);
+      final response = (result as GetFlagsSuccess).response;
+      final flag = response.flags['flag-with-reason']!;
+      expect(flag.reason!.code, 'condition_match');
+      expect(flag.reason!.conditionIndex, 2);
+      expect(flag.reason!.description, 'Matched condition 2');
+    });
+
+    test('handles empty flags object', () {
+      final body = _buildFlagsResponse(flags: {});
+
+      final result = parseFlagsResponse(body, 200);
+      final response = (result as GetFlagsSuccess).response;
+      expect(response.flags, isEmpty);
+    });
+  });
+
+  group('PostHogFlagsResponse derived getters', () {
+    test('featureFlags returns values map', () {
+      final response = PostHogFlagsResponse(
+        flags: {
+          'bool-flag': const FeatureFlagDetail(key: 'bool-flag', enabled: true),
+          'variant-flag': const FeatureFlagDetail(
+              key: 'variant-flag', enabled: true, variant: 'test'),
+          'disabled-flag':
+              const FeatureFlagDetail(key: 'disabled-flag', enabled: false),
+        },
+      );
+
+      final featureFlags = response.featureFlags;
+      expect(featureFlags['bool-flag'], true);
+      expect(featureFlags['variant-flag'], 'test');
+      expect(featureFlags.containsKey('disabled-flag'), false);
+    });
+
+    test('featureFlagPayloads returns payloads', () {
+      final response = PostHogFlagsResponse(
+        flags: {
+          'flag-with-payload': const FeatureFlagDetail(
+            key: 'flag-with-payload',
+            enabled: true,
+            metadata: FeatureFlagMetadata(payload: 'test-payload'),
+          ),
+          'flag-no-payload': const FeatureFlagDetail(
+            key: 'flag-no-payload',
+            enabled: true,
+          ),
+        },
+      );
+
+      final payloads = response.featureFlagPayloads;
+      expect(payloads['flag-with-payload'], 'test-payload');
+      expect(payloads.containsKey('flag-no-payload'), false);
+    });
+  });
+
+  group('PostHogFeatureFlags sync reads', () {
+    late PostHogFeatureFlags featureFlags;
+
+    setUp(() {
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          _buildFlagsResponse(
+            flags: {
+              'bool-flag': _flagDetail(enabled: true),
+              'disabled-flag': _flagDetail(enabled: false),
+              'variant-flag':
+                  _flagDetail(enabled: true, variant: 'test-variant'),
+              'payload-flag': _flagDetail(
+                enabled: true,
+                metadata: {
+                  'id': 1,
+                  'version': 1,
+                  'payload': '{"setting":true}',
+                },
+              ),
+            },
+            requestId: 'req-1',
+            evaluatedAt: 1700000000,
+          ),
+          200,
+        );
+      });
+
+      featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-api-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+    });
+
+    test('isLoaded is false before loading', () {
+      expect(featureFlags.isLoaded, false);
+    });
+
+    test('isLoaded is true after loading', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isLoaded, true);
+    });
+
+    test('isFeatureEnabled returns correct values', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('bool-flag'), true);
+      expect(featureFlags.isFeatureEnabled('disabled-flag'), false);
+      expect(featureFlags.isFeatureEnabled('variant-flag'), true);
+    });
+
+    test('isFeatureEnabled returns false for unknown flags', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('unknown-flag'), false);
+    });
+
+    test('getFeatureFlag returns correct values', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.getFeatureFlag('bool-flag'), true);
+      expect(featureFlags.getFeatureFlag('disabled-flag'), false);
+      expect(featureFlags.getFeatureFlag('variant-flag'), 'test-variant');
+    });
+
+    test('getFeatureFlag returns null for unknown flags', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.getFeatureFlag('unknown-flag'), isNull);
+    });
+
+    test('getFeatureFlagResult returns PostHogFeatureFlagResult', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+
+      final result = featureFlags.getFeatureFlagResult('variant-flag');
+      expect(result, isNotNull);
+      expect(result!.key, 'variant-flag');
+      expect(result.enabled, true);
+      expect(result.variant, 'test-variant');
+    });
+
+    test('getFeatureFlagResult returns null for unknown flags', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.getFeatureFlagResult('unknown-flag'), isNull);
+    });
+
+    test('getFeatureFlagPayload returns parsed payload', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      final payload = featureFlags.getFeatureFlagPayload('payload-flag');
+      expect(payload, {'setting': true});
+    });
+
+    test('getAllFlags returns all flags as PostHogFeatureFlagResult', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      final allFlags = featureFlags.getAllFlags();
+      expect(allFlags.length, 4);
+      expect(allFlags['bool-flag'], isA<PostHogFeatureFlagResult>());
+      expect(allFlags['bool-flag']!.enabled, true);
+    });
+
+    test('clear resets all state', () async {
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isLoaded, true);
+
+      featureFlags.clear();
+      expect(featureFlags.isLoaded, false);
+      expect(featureFlags.isFeatureEnabled('bool-flag'), false);
+      expect(featureFlags.getAllFlags(), isEmpty);
+      expect(featureFlags.requestId, isNull);
+      expect(featureFlags.evaluatedAt, isNull);
+    });
+  });
+
+  group('PostHogFeatureFlags HTTP request', () {
+    test('sends correct request body', () async {
+      Map<String, dynamic>? capturedBody;
+
+      final mockClient = MockClient((request) async {
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          _buildFlagsResponse(flags: {}),
+          200,
+        );
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'phc_test123',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      await featureFlags.loadFeatureFlags(
+        'user-distinct-id',
+        anonymousId: 'anon-123',
+        groups: {'company': 'posthog'},
+      );
+
+      expect(capturedBody!['token'], 'phc_test123');
+      expect(capturedBody!['distinct_id'], 'user-distinct-id');
+      expect(capturedBody![r'$anon_distinct_id'], 'anon-123');
+      expect(capturedBody!['groups'], {'company': 'posthog'});
+    });
+
+    test('sends request to correct URL', () async {
+      Uri? capturedUri;
+
+      final mockClient = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response(
+          _buildFlagsResponse(flags: {}),
+          200,
+        );
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      await featureFlags.loadFeatureFlags('user-1');
+
+      expect(capturedUri.toString(),
+          'https://us.i.posthog.com/flags/?v=2&config=true');
+    });
+
+    test('omits optional fields when not provided', () async {
+      Map<String, dynamic>? capturedBody;
+
+      final mockClient = MockClient((request) async {
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          _buildFlagsResponse(flags: {}),
+          200,
+        );
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      await featureFlags.loadFeatureFlags('user-1');
+
+      expect(capturedBody!.containsKey(r'$anon_distinct_id'), false);
+      expect(capturedBody!.containsKey('groups'), false);
+    });
+  });
+
+  group('PostHogFeatureFlags request coalescing', () {
+    test('concurrent calls result in at most 2 requests', () async {
+      var requestCount = 0;
+
+      final mockClient = MockClient((request) async {
+        requestCount++;
+        // Simulate network delay
+        await Future.delayed(const Duration(milliseconds: 50));
+        return http.Response(
+          _buildFlagsResponse(flags: {
+            'flag': _flagDetail(enabled: true),
+          }),
+          200,
+        );
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      // Fire multiple concurrent loads
+      final futures = [
+        featureFlags.loadFeatureFlags('user-1'),
+        featureFlags.loadFeatureFlags('user-2'),
+        featureFlags.loadFeatureFlags('user-3'),
+      ];
+
+      await Future.wait(futures);
+
+      // Should be at most 2: one in-flight + one queued
+      expect(requestCount, lessThanOrEqualTo(2));
+    });
+  });
+
+  group('PostHogFeatureFlags error merging', () {
+    test('merges only non-failed flags when errorsWhileComputingFlags is true',
+        () async {
+      var callCount = 0;
+      final mockClient = MockClient((request) async {
+        callCount++;
+        if (callCount == 1) {
+          // First call: full success
+          return http.Response(
+            _buildFlagsResponse(flags: {
+              'flag-a': _flagDetail(enabled: true),
+              'flag-b': _flagDetail(enabled: true, variant: 'original'),
+            }),
+            200,
+          );
+        } else {
+          // Second call: partial failure
+          return http.Response(
+            _buildFlagsResponse(
+              flags: {
+                'flag-a': _flagDetail(enabled: false),
+                'flag-b': _flagDetail(enabled: false, failed: true),
+              },
+              errorsWhileComputingFlags: true,
+            ),
+            200,
+          );
+        }
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      // First load — full cache
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('flag-a'), true);
+      expect(featureFlags.getFeatureFlag('flag-b'), 'original');
+
+      // Second load — partial errors
+      await featureFlags.loadFeatureFlags('user-1');
+      // flag-a should be updated (not failed)
+      expect(featureFlags.isFeatureEnabled('flag-a'), false);
+      // flag-b should preserve original (it failed)
+      expect(featureFlags.getFeatureFlag('flag-b'), 'original');
+    });
+
+    test('replaces all flags when errorsWhileComputingFlags is false',
+        () async {
+      var callCount = 0;
+      final mockClient = MockClient((request) async {
+        callCount++;
+        if (callCount == 1) {
+          return http.Response(
+            _buildFlagsResponse(flags: {
+              'flag-a': _flagDetail(enabled: true),
+              'flag-b': _flagDetail(enabled: true),
+            }),
+            200,
+          );
+        } else {
+          return http.Response(
+            _buildFlagsResponse(flags: {
+              'flag-a': _flagDetail(enabled: false),
+              // flag-b deliberately omitted
+            }),
+            200,
+          );
+        }
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.getAllFlags().length, 2);
+
+      await featureFlags.loadFeatureFlags('user-1');
+      // Full replace: flag-b should be gone
+      expect(featureFlags.getAllFlags().length, 1);
+      expect(featureFlags.isFeatureEnabled('flag-a'), false);
+      expect(featureFlags.getFeatureFlag('flag-b'), isNull);
+    });
+  });
+
+  group('PostHogFeatureFlags quota limiting', () {
+    test('skips update when feature_flags is quota limited', () async {
+      var callCount = 0;
+      final mockClient = MockClient((request) async {
+        callCount++;
+        if (callCount == 1) {
+          return http.Response(
+            _buildFlagsResponse(flags: {
+              'flag': _flagDetail(enabled: true),
+            }),
+            200,
+          );
+        } else {
+          return http.Response(
+            _buildFlagsResponse(
+              flags: {
+                'flag': _flagDetail(enabled: false),
+              },
+              quotaLimited: ['feature_flags'],
+            ),
+            200,
+          );
+        }
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('flag'), true);
+
+      // Second load — quota limited, should not update
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('flag'), true);
+    });
+  });
+
+  group('PostHogFeatureFlags callback', () {
+    test('onFeatureFlags fires with flags map after successful load', () async {
+      Map<String, PostHogFeatureFlagResult>? receivedFlags;
+
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          _buildFlagsResponse(flags: {
+            'test-flag': _flagDetail(enabled: true, variant: 'beta'),
+          }),
+          200,
+        );
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      featureFlags.onFeatureFlags = (flags) {
+        receivedFlags = flags;
+      };
+
+      await featureFlags.loadFeatureFlags('user-1');
+
+      expect(receivedFlags, isNotNull);
+      expect(receivedFlags!['test-flag']!.enabled, true);
+      expect(receivedFlags!['test-flag']!.variant, 'beta');
+    });
+
+    test('onFeatureFlags does not fire on HTTP error', () async {
+      var callbackCalled = false;
+
+      final mockClient = MockClient((request) async {
+        return http.Response('error', 500);
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      featureFlags.onFeatureFlags = (_) {
+        callbackCalled = true;
+      };
+
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(callbackCalled, false);
+    });
+
+    test('onFeatureFlags does not fire when quota limited', () async {
+      var callbackCount = 0;
+
+      var isQuotaLimited = false;
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          _buildFlagsResponse(
+            flags: {'flag': _flagDetail(enabled: true)},
+            quotaLimited: isQuotaLimited ? ['feature_flags'] : [],
+          ),
+          200,
+        );
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      featureFlags.onFeatureFlags = (_) {
+        callbackCount++;
+      };
+
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(callbackCount, 1);
+
+      isQuotaLimited = true;
+      await featureFlags.loadFeatureFlags('user-1');
+      // Should still be 1 — callback not fired for quota limited
+      expect(callbackCount, 1);
+    });
+  });
+
+  group('PostHogFeatureFlags error handling', () {
+    test('handles network error gracefully', () async {
+      final mockClient = MockClient((request) async {
+        throw Exception('Network error');
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      // Should not throw
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isLoaded, false);
+    });
+
+    test('preserves cache on error', () async {
+      var callCount = 0;
+      final mockClient = MockClient((request) async {
+        callCount++;
+        if (callCount == 1) {
+          return http.Response(
+            _buildFlagsResponse(flags: {
+              'flag': _flagDetail(enabled: true),
+            }),
+            200,
+          );
+        }
+        throw Exception('Network error');
+      });
+
+      final featureFlags = PostHogFeatureFlags(
+        apiKey: 'test-key',
+        host: 'https://us.i.posthog.com',
+        httpClient: mockClient,
+      );
+
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('flag'), true);
+
+      // Second call fails — cache should be preserved
+      await featureFlags.loadFeatureFlags('user-1');
+      expect(featureFlags.isFeatureEnabled('flag'), true);
+    });
+  });
+}

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -27,6 +27,9 @@ void main() {
       if (methodCall.method == 'isFeatureEnabled') {
         return true;
       }
+      if (methodCall.method == 'distinctId') {
+        return 'test-distinct-id';
+      }
       // Simulate setup call success
       if (methodCall.method == 'setup') {
         return null;

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -210,6 +210,162 @@ void main() {
     });
   });
 
+  group('PosthogFlutterIO enableSyncFeatureFlags', () {
+    test('native config has preloadFeatureFlags=false when sync flags enabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      await posthogFlutterIO.setup(testConfig);
+
+      final setupCall = log.firstWhere((c) => c.method == 'setup');
+      final args = Map<String, dynamic>.from(setupCall.arguments as Map);
+      expect(args['preloadFeatureFlags'], isFalse);
+    });
+
+    test('native config preserves preloadFeatureFlags when sync flags disabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      // enableSyncFeatureFlags defaults to false
+      await posthogFlutterIO.setup(testConfig);
+
+      final setupCall = log.firstWhere((c) => c.method == 'setup');
+      final args = Map<String, dynamic>.from(setupCall.arguments as Map);
+      expect(args['preloadFeatureFlags'], isTrue);
+    });
+
+    test(
+        'async isFeatureEnabled does NOT call native when sync flags enabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      testConfig.preloadFeatureFlags = false;
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      await posthogFlutterIO.isFeatureEnabled('test-flag');
+
+      // Should not have called native isFeatureEnabled
+      expect(log.any((c) => c.method == 'isFeatureEnabled'), isFalse);
+    });
+
+    test(
+        'async getFeatureFlag does NOT call native when sync flags enabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      testConfig.preloadFeatureFlags = false;
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      await posthogFlutterIO.getFeatureFlag(key: 'test-flag');
+
+      expect(log.any((c) => c.method == 'getFeatureFlag'), isFalse);
+    });
+
+    test(
+        'async getFeatureFlagPayload does NOT call native when sync flags enabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      testConfig.preloadFeatureFlags = false;
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      await posthogFlutterIO.getFeatureFlagPayload(key: 'test-flag');
+
+      expect(log.any((c) => c.method == 'getFeatureFlagPayload'), isFalse);
+    });
+
+    test(
+        'async getFeatureFlagResult does NOT call native when sync flags enabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      testConfig.preloadFeatureFlags = false;
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      await posthogFlutterIO.getFeatureFlagResult(key: 'test-flag');
+
+      expect(log.any((c) => c.method == 'getFeatureFlagResult'), isFalse);
+    });
+
+    test(
+        'reloadFeatureFlags does NOT call native when sync flags enabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      testConfig.preloadFeatureFlags = false;
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      await posthogFlutterIO.reloadFeatureFlags();
+
+      // Should call distinctId (for Dart reload) but NOT native reloadFeatureFlags
+      expect(log.any((c) => c.method == 'reloadFeatureFlags'), isFalse);
+    });
+
+    test('reloadFeatureFlags calls native when sync flags disabled', () async {
+      testConfig = PostHogConfig('test_api_key');
+      // enableSyncFeatureFlags defaults to false
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      await posthogFlutterIO.reloadFeatureFlags();
+
+      expect(log.any((c) => c.method == 'reloadFeatureFlags'), isTrue);
+    });
+
+    test('onFeatureFlagsCallback fires legacy callback directly when sync flags disabled',
+        () async {
+      bool callbackInvoked = false;
+      testConfig = PostHogConfig('test_api_key',
+          onFeatureFlags: () {
+        callbackInvoked = true;
+      });
+      await posthogFlutterIO.setup(testConfig);
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        channel.name,
+        channel.codec
+            .encodeMethodCall(const MethodCall('onFeatureFlagsCallback', {})),
+        (ByteData? data) {},
+      );
+
+      expect(callbackInvoked, isTrue);
+    });
+
+    test('featureFlags is null when sync flags disabled', () async {
+      testConfig = PostHogConfig('test_api_key');
+      await posthogFlutterIO.setup(testConfig);
+
+      expect(posthogFlutterIO.featureFlags, isNull);
+    });
+
+    test('featureFlags is created when sync flags enabled', () async {
+      testConfig = PostHogConfig('test_api_key');
+      testConfig.enableSyncFeatureFlags = true;
+      testConfig.preloadFeatureFlags = false;
+      await posthogFlutterIO.setup(testConfig);
+
+      expect(posthogFlutterIO.featureFlags, isNotNull);
+    });
+
+    test(
+        'async isFeatureEnabled calls native when sync flags disabled',
+        () async {
+      testConfig = PostHogConfig('test_api_key');
+      await posthogFlutterIO.setup(testConfig);
+
+      log.clear();
+      final result = await posthogFlutterIO.isFeatureEnabled('test-flag');
+
+      expect(log.any((c) => c.method == 'isFeatureEnabled'), isTrue);
+      expect(result, isTrue); // mock returns true
+    });
+  });
+
   group('PosthogFlutterIO beforeSend callback', () {
     test('capture sends event unchanged when no beforeSend registered',
         () async {


### PR DESCRIPTION
## Problem

The PostHog Flutter SDK wraps native iOS/Android SDKs via method channels, making **all feature flag reads async** (`Future<bool>`, `Future<Object?>`). This forces Flutter developers into `FutureBuilder`/`setState` patterns just to read a flag value:

```dart
// Current — awkward for UI code
FutureBuilder<bool>(
  future: Posthog().isFeatureEnabled('new-onboarding'),
  builder: (context, snapshot) {
    if (snapshot.data == true) { ... }
  },
)
```

There are other workarounds, like creating your own cache on top of the SDK when querying flags. However, these are all workarounds.

Most other PostHog SDKs (web, node, python, Android, iOS) provide **synchronous** flag reads. Flutter is the outlier. This is tracked across multiple issues: #241 (sync API), #231 (callback with data), #51 (pure Dart SDK).

## Solution

Fetch feature flags directly from PostHog's `/flags/?v=2&config=true` API on the Dart side using `package:http`, cache results in memory, and expose synchronous reads:

```dart
// New — use directly in build()
if (Posthog().isFeatureEnabledSync('new-onboarding')) {
  // show new flow
}
```

### New API

```dart
// Sync reads (Dart cache) — safe in build()
Posthog().isFeatureEnabledSync('my-flag')       // bool
Posthog().getFeatureFlagSync('my-flag')          // Object? (bool or variant string)
Posthog().getFeatureFlagResultSync('my-flag')    // PostHogFeatureFlagResult?
Posthog().getAllFeatureFlagResults()              // Map<String, PostHogFeatureFlagResult>
Posthog().isFeatureFlagsLoaded                   // bool

// New callback with flag data
config.onFeatureFlagsLoaded = (flags) { setState(() {}); };

// Existing API — completely unchanged
await Posthog().isFeatureEnabled('my-flag')      // still calls native
config.onFeatureFlags = () { ... };              // still works
```

## Architecture: Additive (not replacement)

The Dart cache runs **alongside** the native SDK — it does not replace it:

| | Async methods (`isFeatureEnabled`, etc.) | Sync methods (`isFeatureEnabledSync`, etc.) |
|---|---|---|
| **Source** | Native iOS/Android SDK (unchanged) | Dart-side HTTP cache (new) |
| **Populated by** | Native SDK lifecycle | Dart HTTP call to `/flags/?v=2` |
| **If Dart HTTP fails** | Still works from native | Returns `false`/`null` |

### Why additive instead of replacing native reads?

1. **Defensive** — if the Dart HTTP layer has a bug, existing integrations still work via native
2. **Observable** — no hidden behavioral change for existing users
3. **Reversible** — easy to switch later once the Dart path proves stable

The tradeoff is one extra HTTP call on startup (both native and Dart fetch flags independently). Open to feedback on whether we should instead replace the async methods to read from the Dart cache (single source of truth, fewer HTTP calls).

## Key Behaviors (following Android SDK patterns)

- **Request coalescing**: concurrent `reloadFeatureFlags()` calls are queued, not duplicated
- **Error merging**: when `errorsWhileComputingFlags=true`, only non-failed flags are merged into cache (preserving cached values for failed flags)
- **Quota limiting**: skips cache update when `feature_flags` is quota limited
- **Zero breaking changes**: all existing APIs and signatures preserved

## Test plan

- [x] 33 new unit tests (parsing, sync reads, HTTP, coalescing, error merging, quota limiting, callbacks)
- [x] All 126 tests pass (93 existing + 33 new)
- [x] `dart analyze` clean (only pre-existing warning)
- [ ] Manual test on iOS/Android example app
- [ ] Verify flags load on startup and sync reads work in `build()`
- [ ] Verify `identify()` triggers flag reload via native callback