### PR TITLE
feat(surveys): bump native sdks to support event property filtering

### DIFF
--- a/.changeset/rare-aliens-draw.md
+++ b/.changeset/rare-aliens-draw.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": minor
+---
+
+bump native sdk versions to support survey event property filters

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,49 @@
 ## Contributing
 
 If you wish to contribute a change to this repo, please send a [pull request](https://github.com/posthog/posthog-flutter/pulls).
+
+## Testing with local native SDKs
+
+### iOS
+
+- Update `example/ios/Podfile` to override the `PostHog` pod with your local path:
+
+```ruby
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # add this
+  pod 'PostHog', :path => File.expand_path('~/posthog-ios')
+end
+```
+
+- Run `cd example/ios && pod install` to install the local pod
+- Open iOS simulator
+- Run the app with `flutter run`
+
+
+### Android
+
+In your local `posthog-android` repo:
+
+- Run `make dryRelease` to build & publish the package to Maven local
+
+In the `posthog-flutter` repo:
+
+- Update `/android/build.gradle` to add `mavenLocal()` as a repository:
+
+```gradle
+allprojects {
+    repositories {
+        mavenLocal() // add this
+        google()
+        mavenCentral()
+    }
+}
+```
+
+- Open Android simulator
+- Run the app with `flutter run`

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -53,8 +53,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.31.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.35.0,4.0.0]'
+        // + Version 3.38.0 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.38.0,4.0.0]'
     }
 
     testOptions {

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.40.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.44.0', '< 4.0.0'
+  # ~> Version 3.47.0 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.47.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.44.0"..<"4.0.0")
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.47.0"..<"4.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## :bulb: Motivation and Context

ios and android now support event property filters:

https://github.com/PostHog/posthog-android/releases/tag/android-v3.38.0

https://github.com/PostHog/posthog-ios/releases/tag/3.47.0

updating flutter min version requirements, so flutter works too :muscle:

closes https://github.com/PostHog/posthog-flutter/issues/263

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

manual testing

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->