### PR TITLE
feat(web): Override SDK info and set location properties on capture events

### DIFF
--- a/.changeset/warm-rivers-glow.md
+++ b/.changeset/warm-rivers-glow.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': minor
+---
+
+Web: Override SDK info via _overrideSDKInfo and set location properties on capture events

--- a/posthog_flutter/lib/src/posthog_flutter_version.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_version.dart
@@ -1,0 +1,3 @@
+// This file is auto-updated by scripts/bump-version.sh
+const postHogFlutterVersion = '5.20.0';
+const postHogFlutterSdkName = 'posthog-flutter';

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -4,6 +4,9 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
 import 'package:flutter/services.dart';
+import 'package:posthog_flutter/src/posthog_flutter_version.dart';
+
+import 'package:web/web.dart' as web;
 
 // Definition of the JS interface for PostHog
 @JS()
@@ -47,6 +50,8 @@ extension PostHogExtension on PostHog {
   external void stopSessionRecording();
   external bool sessionRecordingStarted();
   external SessionManager? get sessionManager;
+  // ignore: non_constant_identifier_names
+  external void _overrideSDKInfo(JSAny sdkName, JSAny sdkVersion);
 }
 
 // SessionManager JS interop
@@ -312,6 +317,34 @@ List<StackFrame> Function(String, [int]) createDefaultStackParser() {
   ]);
 }
 
+bool _sdkInfoOverridden = false;
+
+void _maybeOverrideSDKInfo() {
+  if (_sdkInfoOverridden) return;
+  _sdkInfoOverridden = true;
+  try {
+    posthog?._overrideSDKInfo(
+      stringToJSAny(postHogFlutterSdkName),
+      stringToJSAny(postHogFlutterVersion),
+    );
+  } catch (_) {
+    // The JS SDK version may not support _overrideSDKInfo yet
+  }
+}
+
+Map<String, String> _getLocationProperties() {
+  try {
+    final location = web.window.location;
+    return {
+      '\$current_url': location.href,
+      '\$host': location.host,
+      '\$pathname': location.pathname,
+    };
+  } catch (_) {
+    return {};
+  }
+}
+
 int _lastKeysCount = 0;
 final Set<String> _chunkIdsWithFilenames = {};
 final Map<String, String> _filenameToDebugIds = {};
@@ -364,6 +397,8 @@ Map<String, String>? getPosthogChunkIds() {
 }
 
 Future<dynamic> handleWebMethodCall(MethodCall call) async {
+  _maybeOverrideSDKInfo();
+
   final args = call.arguments;
 
   switch (call.method) {
@@ -401,6 +436,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
     case 'capture':
       final eventName = args['eventName'] as String;
       final properties = safeMapConversion(args['properties']);
+      properties.addAll(_getLocationProperties());
       final userProperties = safeMapConversion(args['userProperties']);
       final userPropertiesSetOnce = safeMapConversion(
         args['userPropertiesSetOnce'],
@@ -426,6 +462,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final screenName = args['screenName'] as String;
       final properties = safeMapConversion(args['properties']);
       properties['\$screen_name'] = screenName;
+      properties.addAll(_getLocationProperties());
 
       posthog?.capture(stringToJSAny('\$screen'), mapToJSAny(properties), null);
       break;
@@ -544,6 +581,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       break;
     case 'captureException':
       final properties = safeMapConversion(args['properties']);
+      properties.addAll(_getLocationProperties());
 
       posthog?.capture(
         stringToJSAny('\$exception'),

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,5 +16,8 @@ perl -pi -e "s/postHogFlutterVersion = \".*\"/postHogFlutterVersion = \"$NEW_VER
 # Replace Android `postHogVersion` with the given version
 perl -pi -e "s/postHogVersion = \".*\"/postHogVersion = \"$NEW_VERSION\"/" posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PostHogVersion.kt
 
+# Replace Web (Dart) `postHogFlutterVersion` with the given version
+perl -pi -e "s/postHogFlutterVersion = '.*'/postHogFlutterVersion = '$NEW_VERSION'/" posthog_flutter/lib/src/posthog_flutter_version.dart
+
 # Replace Flutter `version` with the given version
 perl -pi -e "s/^version: .*/version: $NEW_VERSION/" posthog_flutter/pubspec.yaml


### PR DESCRIPTION
## :bulb: Motivation and Context

Flutter Web uses the JS SDK underneath, which hardcodes `$lib` to `'web'` and `$lib_version` to the JS SDK version. This makes it impossible to attribute events to the Flutter wrapper SDK. Additionally, capture events from Flutter Web don't include browser location properties (`$current_url`, `$host`, `$pathname`).

Related: https://github.com/PostHog/posthog-js/pull/3240

## Changes

- **New `posthog_flutter_version.dart`**: Single Dart-side source of truth for the SDK name and version on web. Auto-updated by `bump-version.sh`.
- **`_overrideSDKInfo` call**: Added JS interop binding for the new `_overrideSDKInfo` method from posthog-js. Called once (guarded by a bool flag) at the start of `handleWebMethodCall`, wrapped in try-catch for backwards compatibility with older JS SDK versions.
- **Location properties on capture events**: `$current_url`, `$host`, and `$pathname` are now read from `window.location` and added to `capture`, `screen`, and `captureException` event properties.
- **Updated `bump-version.sh`**: Now also bumps the version in the new Dart version file. Native version files (Kotlin/Swift) are kept as-is since native SDKs can auto-initialize without going through Dart.

## :green_heart: How did you test it?

Manual testing on Flutter Web.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR