### PR TITLE
chore(web): update posthog-js snippet and improve SDK override error logging

### DIFF
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -34,7 +34,7 @@
   <link rel="manifest" href="manifest.json">
 
   <script async>
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.full.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init(
       'phc_6lqCaCDCBEWdIGieihq5R2dZpPVbAUFISA75vFZow06',
       {
@@ -48,6 +48,7 @@
         capture_dead_clicks: false,
         capture_pageview: false,
         capture_pageleave: false,
+        capture_exceptions: false,
       }
     )
   </script>

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -5,6 +5,7 @@ import 'dart:js_interop_unsafe';
 
 import 'package:flutter/services.dart';
 import 'package:posthog_flutter/src/posthog_flutter_version.dart';
+import 'package:posthog_flutter/src/util/logging.dart';
 
 import 'package:web/web.dart' as web;
 
@@ -327,8 +328,10 @@ void _maybeOverrideSDKInfo() {
       stringToJSAny(postHogFlutterSdkName),
       stringToJSAny(postHogFlutterVersion),
     );
-  } catch (_) {
+  } catch (error) {
     // The JS SDK version may not support _overrideSDKInfo yet
+    printIfDebug(
+        'Warning: Unable to override SDK info. Please ensure you are using posthog-js version 1.361.1 or later for better Flutter Web support., error: $error');
   }
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

- Update the posthog-js snippet in the web example to use the latest version (uses asset-optimized CDN URL and updated stub methods list).
- Add `capture_exceptions: false` to the example web config for consistency.
- Improve error logging in `_maybeOverrideSDKInfo` to provide a helpful warning message with the minimum required posthog-js version when the override fails, instead of silently catching the error.

## :green_heart: How did you test it?

Manual verification on the web example.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR