### PR TITLE
feat: enable captureApplicationLifecycleEvents by default and align Android config key

### DIFF
--- a/.changeset/warm-lions-glow.md
+++ b/.changeset/warm-lions-glow.md
@@ -2,4 +2,10 @@
 'posthog_flutter': minor
 ---
 
-Enable captureApplicationLifecycleEvents by default and align Android config key name
+Enable captureApplicationLifecycleEvents by default and align Android config key name.
+
+Application lifecycle events (`Application Opened`, `Application Backgrounded`, etc.) are now captured by default. If you don't want these events, you can disable them:
+
+- **Dart (recommended):** Set `config.captureApplicationLifecycleEvents = false` in your PostHog configuration.
+- **Android (manifest):** Add `<meta-data android:name="com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS" android:value="false" />` to your `AndroidManifest.xml`. The legacy key `com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS` is still supported.
+- **iOS/macOS (Info.plist):** Set `com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS` to `NO` in your `Info.plist`.

--- a/.changeset/warm-lions-glow.md
+++ b/.changeset/warm-lions-glow.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': minor
+---
+
+Enable captureApplicationLifecycleEvents by default and align Android config key name

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:name="com.posthog.posthog.POSTHOG_HOST"
             android:value="https://us.i.posthog.com" />
         <meta-data
-            android:name="com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS"
+            android:name="com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS"
             android:value="true" />
         <meta-data 
             android:name="com.posthog.posthog.DEBUG" 

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -67,7 +67,12 @@ class PosthogFlutterPlugin :
             }
 
             val host = bundle.getString("com.posthog.posthog.POSTHOG_HOST", PostHogConfig.DEFAULT_HOST)
-            val captureApplicationLifecycleEvents = bundle.getBoolean("com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS", false)
+            // Check new key first, then legacy key, default to true
+            val captureApplicationLifecycleEvents = if (bundle.containsKey("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS")) {
+                bundle.getBoolean("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS", true)
+            } else {
+                bundle.getBoolean("com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS", true)
+            }
             val debug = bundle.getBoolean("com.posthog.posthog.DEBUG", false)
 
             val posthogConfig = mutableMapOf<String, Any>()

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -60,7 +60,7 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         let apiKey = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") as? String ?? ""
 
         let host = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.POSTHOG_HOST") as? String ?? PostHogConfig.defaultHost
-        let captureApplicationLifecycleEvents = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS") as? Bool ?? false
+        let captureApplicationLifecycleEvents = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS") as? Bool ?? true
         let debug = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.DEBUG") as? Bool ?? false
 
         setupPostHog([

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -23,7 +23,7 @@ class PostHogConfig {
   var flushInterval = const Duration(seconds: 30);
   var sendFeatureFlagEvents = true;
   var preloadFeatureFlags = true;
-  var captureApplicationLifecycleEvents = false;
+  var captureApplicationLifecycleEvents = true;
 
   var debug = false;
   var optOut = false;


### PR DESCRIPTION
## :bulb: Motivation and Context

`captureApplicationLifecycleEvents` was disabled by default, requiring explicit opt-in. This changes the default to `true` so lifecycle events are captured out of the box.

Additionally, the Android manifest config key is aligned with iOS:
- **New key**: `com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS`
- **Legacy key**: `com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS` (still supported for backward compatibility)

The new key is checked first; if not present, the legacy key is used. If neither is set, defaults to `true`.

The changeset includes instructions on how to disable lifecycle events for users who don't want them.

## :green_heart: How did you test it?

Manual verification of manifest key resolution logic and default values on Android and iOS.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR