### PR TITLE
fix: prevent overlapping replay snapshot captures

### DIFF
--- a/.changeset/smooth-falcons-listen.md
+++ b/.changeset/smooth-falcons-listen.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Prevent overlapping session replay snapshot captures

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -25,6 +25,7 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
   Timer? _throttleTimer;
   bool _isThrottling = false;
+  bool _isCapturing = false;
   Duration _throttleDuration = const Duration(milliseconds: 1000);
 
   @override
@@ -81,8 +82,8 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
   // This works as onRootViewsChangedListeners
   void _onChangeDetected() {
-    if (_isThrottling) {
-      // If throttling is active, ignore this call
+    if (_isThrottling || _isCapturing) {
+      // If throttling is active or a snapshot is already in progress, ignore this call.
       return;
     }
 
@@ -102,25 +103,31 @@ class PostHogWidgetState extends State<PostHogWidget> {
   Future<void> _generateSnapshot() async {
     // Ensure no asynchronous calls occur before this function,
     // as it relies on a consistent state.
-    final imageInfo = await _screenshotCapturer?.captureScreenshot();
-    if (imageInfo == null) {
-      return;
-    }
+    _isCapturing = true;
 
-    if (imageInfo.shouldSendMetaEvent) {
-      await _nativeCommunicator?.sendMetaEvent(
-        width: imageInfo.width,
-        height: imageInfo.height,
-        screen: Posthog().currentScreen,
+    try {
+      final imageInfo = await _screenshotCapturer?.captureScreenshot();
+      if (imageInfo == null) {
+        return;
+      }
+
+      if (imageInfo.shouldSendMetaEvent) {
+        await _nativeCommunicator?.sendMetaEvent(
+          width: imageInfo.width,
+          height: imageInfo.height,
+          screen: Posthog().currentScreen,
+        );
+      }
+
+      await _nativeCommunicator?.sendFullSnapshot(
+        imageInfo.imageBytes,
+        id: imageInfo.id,
+        x: imageInfo.x,
+        y: imageInfo.y,
       );
+    } finally {
+      _isCapturing = false;
     }
-
-    await _nativeCommunicator?.sendFullSnapshot(
-      imageInfo.imageBytes,
-      id: imageInfo.id,
-      x: imageInfo.x,
-      y: imageInfo.y,
-    );
   }
 
   @override


### PR DESCRIPTION
## :bulb: Motivation and Context

`_generateSnapshot()` was kicked off without being awaited from the change detector path, so if a capture took longer than the 1s throttle window, another capture could start before the first one finished. That allowed overlapping session replay captures to allocate multiple large images and buffers concurrently.

This PR cherry-picks only the widget-side guard for that issue.

## :green_heart: How did you test it?

- `flutter analyze posthog_flutter`
- Manual review of the `PostHogWidget` capture flow

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR
