### PR TITLE
fix: reduce session replay frame callback overhead

### DIFF
--- a/.changeset/fresh-lizards-visit.md
+++ b/.changeset/fresh-lizards-visit.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Reduce session replay frame callback overhead

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:posthog_flutter/src/posthog_internal_events.dart';
@@ -23,10 +21,7 @@ class PostHogWidgetState extends State<PostHogWidget> {
   ScreenshotCapturer? _screenshotCapturer;
   NativeCommunicator? _nativeCommunicator;
 
-  Timer? _throttleTimer;
-  bool _isThrottling = false;
   bool _isCapturing = false;
-  Duration _throttleDuration = const Duration(milliseconds: 1000);
 
   @override
   void initState() {
@@ -49,10 +44,13 @@ class PostHogWidgetState extends State<PostHogWidget> {
   }
 
   void _initComponents(PostHogConfig config) {
-    _throttleDuration = config.sessionReplayConfig.throttleDelay;
+    final throttleDelay = config.sessionReplayConfig.throttleDelay;
     _screenshotCapturer = ScreenshotCapturer(config);
     _nativeCommunicator = NativeCommunicator();
-    _changeDetector = ChangeDetector(_onChangeDetected);
+    _changeDetector = ChangeDetector(
+      _onChangeDetected,
+      interval: throttleDelay,
+    );
   }
 
   void _onSessionRecordingChanged() {
@@ -82,22 +80,11 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
   // This works as onRootViewsChangedListeners
   void _onChangeDetected() {
-    if (_isThrottling || _isCapturing) {
-      // If throttling is active or a snapshot is already in progress, ignore this call.
+    if (_isCapturing) {
       return;
     }
 
-    // Start throttling
-    _isThrottling = true;
-
-    // Execute the snapshot generation
     _generateSnapshot();
-
-    _throttleTimer?.cancel();
-    // Reset throttling after the duration
-    _throttleTimer = Timer(_throttleDuration, () {
-      _isThrottling = false;
-    });
   }
 
   Future<void> _generateSnapshot() async {
@@ -146,8 +133,6 @@ class PostHogWidgetState extends State<PostHogWidget> {
       _onSessionRecordingChanged,
     );
 
-    _throttleTimer?.cancel();
-    _throttleTimer = null;
     _changeDetector?.stop();
     _changeDetector = null;
     _screenshotCapturer = null;

--- a/posthog_flutter/lib/src/replay/change_detector.dart
+++ b/posthog_flutter/lib/src/replay/change_detector.dart
@@ -1,10 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 
 /// A class that detects changes in the UI and executes a callback when changes occur.
 ///
-/// The `ChangeDetector` continuously monitors the Flutter widget tree by scheduling
-/// a callback after each frame is rendered. This is useful when you need to perform
-/// an action whenever the UI updates.
+/// The `ChangeDetector` monitors the Flutter widget tree by scheduling
+/// a callback after a frame is rendered. To avoid unnecessary overhead,
+/// it only listens for frame callbacks while actively polling at a fixed interval.
 ///
 /// **Usage:**
 /// ```dart
@@ -16,47 +18,54 @@ import 'package:flutter/widgets.dart';
 /// changeDetector.start();
 /// ```
 ///
-/// **Note:** Since the `onChange` callback is called after every frame, ensure that
+/// **Note:** Since the `onChange` callback is called periodically, ensure that
 /// the operations performed are efficient to avoid impacting app performance.
 class ChangeDetector {
   final VoidCallback onChange;
+  final Duration interval;
   bool _isRunning = false;
+  Timer? _timer;
 
   /// Creates a [ChangeDetector] with the given [onChange] callback.
-  ChangeDetector(this.onChange);
+  ///
+  /// [interval] controls how often to check for changes.
+  ChangeDetector(this.onChange, {this.interval = const Duration(seconds: 1)});
 
   /// Starts the change detection process.
   ///
-  /// This method schedules the [_onFrameRendered] callback to be called
-  /// after each frame is rendered.
+  /// This method schedules periodic checks that trigger the [onChange] callback
+  /// after the next frame is rendered.
   void start() {
-    if (!_isRunning) {
-      _isRunning = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _onFrameRendered();
-      });
+    if (_isRunning) {
+      return;
     }
+
+    _isRunning = true;
+    _scheduleFrameCallback();
+    _timer = Timer.periodic(interval, (_) {
+      _scheduleFrameCallback();
+    });
   }
 
   /// Stops the change detection process.
   ///
-  /// This prevents the [onChange] callback from being called after each frame.
+  /// This prevents the [onChange] callback from being called.
   void stop() {
     _isRunning = false;
+    _timer?.cancel();
+    _timer = null;
   }
 
-  /// Internal method called after each frame is rendered.
-  ///
-  /// Executes the [onChange] callback and schedules itself for the next frame
-  /// if the change detector is still running.
-  void _onFrameRendered() {
+  /// Schedules a single post-frame callback to invoke [onChange].
+  void _scheduleFrameCallback() {
     if (!_isRunning) {
       return;
     }
 
-    onChange();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _onFrameRendered();
+      if (_isRunning) {
+        onChange();
+      }
     });
   }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

`ChangeDetector` previously registered an `addPostFrameCallback` after every rendered frame, even though session replay only attempted a capture at the configured throttle interval. That meant the app was still doing scheduler work roughly every frame just to reject most callbacks in `PostHogWidget`.

This change moves cadence into `ChangeDetector` itself so it only schedules post-frame callbacks at the configured interval, while `PostHogWidget` keeps only the in-flight capture guard.

## :green_heart: How did you test it?

- `flutter analyze posthog_flutter`
- Manual review of the `ChangeDetector` polling flow and `PostHogWidget` capture guard

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR
