### PR TITLE
fix(web): accept Map args in startSessionRecording handler

### DIFF
--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -292,7 +292,14 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
     case 'isSessionReplayActive':
       return posthog?.sessionRecordingStarted() ?? false;
     case 'startSessionRecording':
-      final resumeCurrent = args as bool? ?? true;
+      // The platform interface sends a Map ({'resumeCurrent': bool}). Fall back
+      // to the legacy bool shape so older callers keep working.
+      final bool resumeCurrent;
+      if (args is Map) {
+        resumeCurrent = args['resumeCurrent'] as bool? ?? true;
+      } else {
+        resumeCurrent = args as bool? ?? true;
+      }
       if (!resumeCurrent) {
         // Reset session ID to start a new session
         posthog?.sessionManager?.resetSessionId();


### PR DESCRIPTION
## Summary

- Fixes a `TypeError` on Flutter Web when calling `Posthog().startSessionRecording()`: the platform interface dispatches a `Map<String, dynamic>` (`{'resumeCurrent': bool}`) but the web handler casts the arguments as `bool?`, crashing on every call.
- Reads `resumeCurrent` from the Map (matching every other `case` in the handler) and keeps the legacy `bool` path as a fallback so older callers still work.
- Closes #365.

## Details

`posthog_flutter/lib/posthog_flutter_web.dart`:

```dart
@override
Future<void> startSessionRecording({bool resumeCurrent = true}) async {
  return handleWebMethodCall(
    MethodCall('startSessionRecording', {'resumeCurrent': resumeCurrent}),
  );
}
```

`posthog_flutter/lib/src/posthog_flutter_web_handler.dart:295` (before):

```dart
case 'startSessionRecording':
  final resumeCurrent = args as bool? ?? true;  // crashes: args is a Map
```

After:

```dart
case 'startSessionRecording':
  final bool resumeCurrent;
  if (args is Map) {
    resumeCurrent = args['resumeCurrent'] as bool? ?? true;
  } else {
    resumeCurrent = args as bool? ?? true;
  }
```

## Test plan

- [x] Verified the failing cast is reached in release (dart2js) via a production Sentry stack trace: `_asBoolQ` → `handleWebMethodCall` at `posthog_flutter_web_handler.dart:295`.
- [x] Patched handler reads `resumeCurrent` from the Map sent by `PosthogFlutterWeb.startSessionRecording` and falls back to the legacy `bool` shape.
- [ ] Reviewers to confirm there is no other caller still passing a raw `bool` that relies on the previous cast.
