### PR TITLE
fix: cancel in-flight replay screenshot capture

### DIFF
--- a/.changeset/late-cobras-sleep.md
+++ b/.changeset/late-cobras-sleep.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Cancel in-flight session replay screenshot capture when stopping

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -22,6 +22,7 @@ class PostHogWidgetState extends State<PostHogWidget> {
   NativeCommunicator? _nativeCommunicator;
 
   bool _isCapturing = false;
+  bool _disposed = false;
 
   @override
   void initState() {
@@ -76,6 +77,7 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
   void _stopRecording() {
     _changeDetector?.stop();
+    _screenshotCapturer?.cancel();
   }
 
   // This works as onRootViewsChangedListeners
@@ -88,13 +90,17 @@ class PostHogWidgetState extends State<PostHogWidget> {
   }
 
   Future<void> _generateSnapshot() async {
+    if (_disposed) {
+      return;
+    }
+
     // Ensure no asynchronous calls occur before this function,
     // as it relies on a consistent state.
     _isCapturing = true;
 
     try {
       final imageInfo = await _screenshotCapturer?.captureScreenshot();
-      if (imageInfo == null) {
+      if (imageInfo == null || _disposed) {
         return;
       }
 
@@ -104,6 +110,10 @@ class PostHogWidgetState extends State<PostHogWidget> {
           height: imageInfo.height,
           screen: Posthog().currentScreen,
         );
+      }
+
+      if (_disposed) {
+        return;
       }
 
       await _nativeCommunicator?.sendFullSnapshot(
@@ -129,12 +139,15 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
   @override
   void dispose() {
+    _disposed = true;
+
     PostHogInternalEvents.sessionRecordingActive.removeListener(
       _onSessionRecordingChanged,
     );
 
     _changeDetector?.stop();
     _changeDetector = null;
+    _screenshotCapturer?.cancel();
     _screenshotCapturer = null;
     _nativeCommunicator = null;
 

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -51,7 +51,13 @@ class ScreenshotCapturer {
   final _nativeCommunicator = NativeCommunicator();
   final _snapshotManager = SnapshotManager();
 
+  bool _cancelled = false;
+
   ScreenshotCapturer(this._config);
+
+  void cancel() {
+    _cancelled = true;
+  }
 
   double _getPixelRatio({
     int? width,
@@ -101,6 +107,8 @@ class ScreenshotCapturer {
   }
 
   Future<ImageInfo?> captureScreenshot() {
+    _cancelled = false;
+
     final context = PostHogMaskController.instance.containerKey.currentContext;
     if (context == null) {
       return Future.value(null);
@@ -157,11 +165,22 @@ class ScreenshotCapturer {
       Future(() async {
         final isSessionReplayActive =
             await _nativeCommunicator.isSessionReplayActive();
+        if (_cancelled) {
+          completer.complete(null);
+          return;
+        }
 
         // wait the UI to settle
         await SchedulerBinding.instance.endOfFrame;
         image = await syncImage;
         final currentImage = image;
+        if (_cancelled) {
+          currentImage?.dispose();
+          image = null;
+          completer.complete(null);
+          return;
+        }
+
         if (currentImage == null ||
             !isSessionReplayActive ||
             !currentImage.isValidSize) {
@@ -187,6 +206,15 @@ class ScreenshotCapturer {
           currentImage,
           format: ui.ImageByteFormat.rawRgba,
         );
+        if (_cancelled) {
+          currentRecorder.endRecording().dispose();
+          recorder = null;
+          currentImage.dispose();
+          image = null;
+          completer.complete(null);
+          return;
+        }
+
         if (imageBytes == null || imageBytes.isEmpty) {
           printIfDebug(
             'Error: Failed to convert image byte data to Uint8List.',
@@ -221,6 +249,13 @@ class ScreenshotCapturer {
         } finally {
           currentImage.dispose();
           image = null;
+        }
+
+        if (_cancelled) {
+          currentRecorder.endRecording().dispose();
+          recorder = null;
+          completer.complete(null);
+          return;
         }
 
         if (replayConfig.maskAllTexts || replayConfig.maskAllImages) {
@@ -258,6 +293,13 @@ class ScreenshotCapturer {
           );
 
           final currentFinalImage = finalImage;
+          if (_cancelled) {
+            currentFinalImage?.dispose();
+            finalImage = null;
+            completer.complete(null);
+            return;
+          }
+
           if (currentFinalImage == null || !currentFinalImage.isValidSize) {
             currentFinalImage?.dispose();
             finalImage = null;
@@ -267,7 +309,7 @@ class ScreenshotCapturer {
 
           try {
             final pngBytes = await _getImageBytes(currentFinalImage);
-            if (pngBytes == null || pngBytes.isEmpty) {
+            if (_cancelled || pngBytes == null || pngBytes.isEmpty) {
               completer.complete(null);
               return;
             }


### PR DESCRIPTION
## :bulb: Motivation and Context

Stopping session replay previously stopped future polling, but did not cancel a screenshot capture that was already in flight. That meant capture work could continue allocating and processing images after recording had been stopped.

This PR adds cancellation checks inside `ScreenshotCapturer` and widget-side disposed guards so in-flight work exits early and no snapshot is sent after teardown.

## :green_heart: How did you test it?

- `flutter analyze posthog_flutter`
- Manual review of the cancellation and widget lifecycle flow

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR
