### PR TITLE
fix(web): accept Map args in startSessionRecording handler

### DIFF
--- a/.changeset/brave-otters-jump.md
+++ b/.changeset/brave-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Accept Map args in the web session recording start handler

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -292,7 +292,14 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
     case 'isSessionReplayActive':
       return posthog?.sessionRecordingStarted() ?? false;
     case 'startSessionRecording':
-      final resumeCurrent = args as bool? ?? true;
+      // The platform interface sends a Map ({'resumeCurrent': bool}). Fall back
+      // to the legacy bool shape so older callers keep working.
+      final bool resumeCurrent;
+      if (args is Map) {
+        resumeCurrent = args['resumeCurrent'] as bool? ?? true;
+      } else {
+        resumeCurrent = args as bool? ?? true;
+      }
       if (!resumeCurrent) {
         // Reset session ID to start a new session
         posthog?.sessionManager?.resetSessionId();


### PR DESCRIPTION
## :bulb: Motivation and Context
Flutter Web was crashing when `startSessionRecording` was triggered because the web handler expected a raw `bool` argument, while the platform interface now sends a Map with `resumeCurrent`.
Closes https://github.com/PostHog/posthog-flutter/issues/365

## :green_heart: How did you test it?
- Ran `flutter analyze lib/src/posthog_flutter_web_handler.dart` from `posthog_flutter/`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR