### PR TITLE
docs(example): show --release-name, --release-version, and --build in sourcemap upload

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -21,11 +21,11 @@ samples, guidance on mobile development, and a full API reference.
 # release mode
 rm -rf build/web
 flutter build web --source-maps
-posthog-cli sourcemap inject --directory build/web
+posthog-cli sourcemap inject --directory build/web --release-name posthog_flutter_example --release-version 1.0.0 --build 42
 # check the sourcemaps has chunk_id and release_id injected (*.js.map file)
 # check the js file has _posthogChunkIds injected (*.js file)
 # check the chunk_id and _posthogChunkIds match
-posthog-cli sourcemap upload --directory build/web
+posthog-cli sourcemap upload --directory build/web --release-name posthog_flutter_example --release-version 1.0.0 --build 42
 cd build/web
 # https://pub.dev/packages/dhttpd
 dhttpd


### PR DESCRIPTION
Explicit release args are recommended for CI release workflows so uploads associate with a stable identity rather than relying on git auto-detection. --build requires posthog-cli >= 0.7.8. Matches the posthog.com CLI docs pattern.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
