### PR TITLE
fix: trim whitespace from API keys and host config

### DIFF
--- a/.changeset/trim-whitespace-config-values.md
+++ b/.changeset/trim-whitespace-config-values.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Trim surrounding whitespace from API keys and host config before passing them to the native SDKs.

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -59,7 +59,7 @@ class PosthogFlutterPlugin :
                 return
             }
 
-            val apiKey = bundle.getString("com.posthog.posthog.API_KEY")
+            val apiKey = bundle.getString("com.posthog.posthog.API_KEY")?.trim()
 
             if (apiKey.isNullOrEmpty()) {
                 Log.e("PostHog", "com.posthog.posthog.API_KEY is missing!")
@@ -67,6 +67,9 @@ class PosthogFlutterPlugin :
             }
 
             val host = bundle.getString("com.posthog.posthog.POSTHOG_HOST", PostHogConfig.DEFAULT_HOST)
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?: PostHogConfig.DEFAULT_HOST
             // Check new key first, then legacy key, default to true
             val captureApplicationLifecycleEvents = if (bundle.containsKey("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS")) {
                 bundle.getBoolean("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS", true)
@@ -279,13 +282,17 @@ class PosthogFlutterPlugin :
     }
 
     private fun setupPostHog(posthogConfig: Map<String, Any>) {
-        val apiKey = posthogConfig["apiKey"] as String?
+        val apiKey = (posthogConfig["apiKey"] as String?)?.trim()
         if (apiKey.isNullOrEmpty()) {
             Log.e("PostHog", "apiKey is missing!")
             return
         }
 
-        val host = posthogConfig["host"] as String? ?: PostHogConfig.DEFAULT_HOST
+        val host =
+            (posthogConfig["host"] as String?)
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?: PostHogConfig.DEFAULT_HOST
 
         val config =
             PostHogAndroidConfig(apiKey, host).apply {

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -57,9 +57,11 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let apiKey = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") as? String ?? ""
+        let apiKey = (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") as? String ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let host = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.POSTHOG_HOST") as? String ?? PostHogConfig.defaultHost
+        let host = (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.POSTHOG_HOST") as? String ?? PostHogConfig.defaultHost)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let captureApplicationLifecycleEvents = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS") as? Bool ?? true
         let debug = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.DEBUG") as? Bool ?? false
 
@@ -76,13 +78,16 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             print("[PostHog] Plugin instance not found!")
             return
         }
-        let apiKey = posthogConfig["apiKey"] as? String ?? ""
+        let apiKey = (posthogConfig["apiKey"] as? String ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         if apiKey.isEmpty {
             print("[PostHog] apiKey is missing!")
             return
         }
 
-        let host = posthogConfig["host"] as? String ?? PostHogConfig.defaultHost
+        let normalizedHost = (posthogConfig["host"] as? String ?? PostHogConfig.defaultHost)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let host = normalizedHost.isEmpty ? PostHogConfig.defaultHost : normalizedHost
 
         let config = PostHogConfig(
             apiKey: apiKey,

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -7,18 +7,18 @@ import 'posthog_flutter_platform_interface.dart';
 ///
 /// Return a possibly modified event to send it, or return `null` to drop it.
 /// Callbacks can be synchronous or asynchronous (returning `FutureOr<PostHogEvent?>`).
-typedef BeforeSendCallback =
-    FutureOr<PostHogEvent?> Function(PostHogEvent event);
+typedef BeforeSendCallback = FutureOr<PostHogEvent?> Function(
+    PostHogEvent event);
 
 enum PostHogPersonProfiles { never, always, identifiedOnly }
 
 enum PostHogDataMode { wifi, cellular, any }
 
 class PostHogConfig {
-  static const defaultHost = 'https://us.i.posthog.com';
+  static const _defaultHost = 'https://us.i.posthog.com';
 
   final String apiKey;
-  String _host = defaultHost;
+  String _host = _defaultHost;
   String get host => _host;
   set host(String value) => _host = _normalizeHost(value);
   var flushAt = 20;
@@ -139,12 +139,12 @@ class PostHogConfig {
     String apiKey, {
     this.onFeatureFlags,
     List<BeforeSendCallback>? beforeSend,
-  }) : apiKey = apiKey.trim(),
-       beforeSend = beforeSend ?? [];
+  })  : apiKey = apiKey.trim(),
+        beforeSend = beforeSend ?? [];
 
   static String _normalizeHost(String host) {
     final trimmedHost = host.trim();
-    return trimmedHost.isEmpty ? defaultHost : trimmedHost;
+    return trimmedHost.isEmpty ? _defaultHost : trimmedHost;
   }
 
   Map<String, dynamic> toMap() {

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -15,8 +15,10 @@ enum PostHogPersonProfiles { never, always, identifiedOnly }
 enum PostHogDataMode { wifi, cellular, any }
 
 class PostHogConfig {
+  static const defaultHost = 'https://us.i.posthog.com';
+
   final String apiKey;
-  var host = 'https://us.i.posthog.com';
+  var host = defaultHost;
   var flushAt = 20;
   var maxQueueSize = 1000;
   var maxBatchSize = 50;
@@ -132,15 +134,16 @@ class PostHogConfig {
   // TODO: missing getAnonymousId, propertiesSanitizer, captureDeepLinks integrations
 
   PostHogConfig(
-    this.apiKey, {
+    String apiKey, {
     this.onFeatureFlags,
     List<BeforeSendCallback>? beforeSend,
-  }) : beforeSend = beforeSend ?? [];
+  })  : apiKey = apiKey.trim(),
+        beforeSend = beforeSend ?? [];
 
   Map<String, dynamic> toMap() {
     return {
       'apiKey': apiKey,
-      'host': host,
+      'host': host.trim().isEmpty ? defaultHost : host.trim(),
       'flushAt': flushAt,
       'maxQueueSize': maxQueueSize,
       'maxBatchSize': maxBatchSize,

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -7,8 +7,8 @@ import 'posthog_flutter_platform_interface.dart';
 ///
 /// Return a possibly modified event to send it, or return `null` to drop it.
 /// Callbacks can be synchronous or asynchronous (returning `FutureOr<PostHogEvent?>`).
-typedef BeforeSendCallback = FutureOr<PostHogEvent?> Function(
-    PostHogEvent event);
+typedef BeforeSendCallback =
+    FutureOr<PostHogEvent?> Function(PostHogEvent event);
 
 enum PostHogPersonProfiles { never, always, identifiedOnly }
 
@@ -18,7 +18,9 @@ class PostHogConfig {
   static const defaultHost = 'https://us.i.posthog.com';
 
   final String apiKey;
-  var host = defaultHost;
+  String _host = defaultHost;
+  String get host => _host;
+  set host(String value) => _host = _normalizeHost(value);
   var flushAt = 20;
   var maxQueueSize = 1000;
   var maxBatchSize = 50;
@@ -137,13 +139,18 @@ class PostHogConfig {
     String apiKey, {
     this.onFeatureFlags,
     List<BeforeSendCallback>? beforeSend,
-  })  : apiKey = apiKey.trim(),
-        beforeSend = beforeSend ?? [];
+  }) : apiKey = apiKey.trim(),
+       beforeSend = beforeSend ?? [];
+
+  static String _normalizeHost(String host) {
+    final trimmedHost = host.trim();
+    return trimmedHost.isEmpty ? defaultHost : trimmedHost;
+  }
 
   Map<String, dynamic> toMap() {
     return {
       'apiKey': apiKey,
-      'host': host.trim().isEmpty ? defaultHost : host.trim(),
+      'host': host,
       'flushAt': flushAt,
       'maxQueueSize': maxQueueSize,
       'maxBatchSize': maxBatchSize,

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -51,8 +51,8 @@ void main() {
       final config = PostHogConfig('test_api_key');
       config.host = ' \n\t ';
 
-      expect(config.host, equals(PostHogConfig.defaultHost));
-      expect(config.toMap()['host'], equals(PostHogConfig.defaultHost));
+      expect(config.host, equals('https://us.i.posthog.com'));
+      expect(config.toMap()['host'], equals('https://us.i.posthog.com'));
     });
   });
 
@@ -186,8 +186,7 @@ void main() {
       expect(fakePlatformInterface.setPersonPropertiesCalls.length, 1);
       expect(
         fakePlatformInterface
-            .setPersonPropertiesCalls
-            .last['userPropertiesToSet'],
+            .setPersonPropertiesCalls.last['userPropertiesToSet'],
         {'name': 'John Doe', 'email': 'john@example.com'},
       );
     });
@@ -200,8 +199,7 @@ void main() {
       expect(fakePlatformInterface.setPersonPropertiesCalls.length, 1);
       expect(
         fakePlatformInterface
-            .setPersonPropertiesCalls
-            .last['userPropertiesToSetOnce'],
+            .setPersonPropertiesCalls.last['userPropertiesToSetOnce'],
         {'date_of_first_login': '2024-03-01'},
       );
     });

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -37,10 +37,12 @@ void main() {
   });
 
   group('PostHogConfig', () {
-    test('trims whitespace-sensitive config values in toMap', () {
+    test('trims whitespace-sensitive config values in config and toMap', () {
       final config = PostHogConfig(' \n test_api_key\t ');
       config.host = ' \nhttps://eu.i.posthog.com/\t ';
 
+      expect(config.apiKey, equals('test_api_key'));
+      expect(config.host, equals('https://eu.i.posthog.com/'));
       expect(config.toMap()['apiKey'], equals('test_api_key'));
       expect(config.toMap()['host'], equals('https://eu.i.posthog.com/'));
     });
@@ -49,6 +51,7 @@ void main() {
       final config = PostHogConfig('test_api_key');
       config.host = ' \n\t ';
 
+      expect(config.host, equals(PostHogConfig.defaultHost));
       expect(config.toMap()['host'], equals(PostHogConfig.defaultHost));
     });
   });
@@ -183,7 +186,8 @@ void main() {
       expect(fakePlatformInterface.setPersonPropertiesCalls.length, 1);
       expect(
         fakePlatformInterface
-            .setPersonPropertiesCalls.last['userPropertiesToSet'],
+            .setPersonPropertiesCalls
+            .last['userPropertiesToSet'],
         {'name': 'John Doe', 'email': 'john@example.com'},
       );
     });
@@ -196,7 +200,8 @@ void main() {
       expect(fakePlatformInterface.setPersonPropertiesCalls.length, 1);
       expect(
         fakePlatformInterface
-            .setPersonPropertiesCalls.last['userPropertiesToSetOnce'],
+            .setPersonPropertiesCalls
+            .last['userPropertiesToSetOnce'],
         {'date_of_first_login': '2024-03-01'},
       );
     });

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -36,6 +36,23 @@ void main() {
     );
   });
 
+  group('PostHogConfig', () {
+    test('trims whitespace-sensitive config values in toMap', () {
+      final config = PostHogConfig(' \n test_api_key\t ');
+      config.host = ' \nhttps://eu.i.posthog.com/\t ';
+
+      expect(config.toMap()['apiKey'], equals('test_api_key'));
+      expect(config.toMap()['host'], equals('https://eu.i.posthog.com/'));
+    });
+
+    test('defaults a blank host after trimming whitespace', () {
+      final config = PostHogConfig('test_api_key');
+      config.host = ' \n\t ';
+
+      expect(config.toMap()['host'], equals(PostHogConfig.defaultHost));
+    });
+  });
+
   group('getFeatureFlagResult', () {
     late PosthogFlutterPlatformFake fakePlatformInterface;
 


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the whitespace-trimming fix from `posthog-go` to `posthog-flutter`. It trims surrounding spaces and line breaks from the project API key and host before forwarding config through Dart and the native Android/iOS plugin entry points, so the SDK does not silently initialize with invalid tokens or malformed hosts.

## :green_heart: How did you test it?
- `flutter test test/posthog_test.dart test/posthog_flutter_io_test.dart`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
