### PR TITLE
Rename apiKey to projectToken with aliases

### DIFF
--- a/.changeset/smooth-birds-smile.md
+++ b/.changeset/smooth-birds-smile.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': minor
+---
+
+Rename apiKey to projectToken with backward-compatible aliases

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -30,12 +30,12 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-        <!-- Set your Posthog write key and change the automatic event tracking
+        <!-- Set your PostHog project token and change the automatic event tracking
     on if you wish the library to take care of it for you.
     Remember that the application lifecycle events won't have any
     special context set for you by the time it is initialized. -->
         <meta-data
-            android:name="com.posthog.posthog.API_KEY"
+            android:name="com.posthog.posthog.PROJECT_TOKEN"
             android:value="phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D" />
         <meta-data
             android:name="com.posthog.posthog.POSTHOG_HOST"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,7 +43,7 @@
 	</array>
 	<key>com.posthog.posthog.POSTHOG_HOST</key>
 	<string>https://us.i.posthog.com</string>
-	<key>com.posthog.posthog.API_KEY</key>
+	<key>com.posthog.posthog.PROJECT_TOKEN</key>
 	<string>phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D</string>
 	<key>com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS</key>
 	<true/>

--- a/example/macos/Runner/Info.plist
+++ b/example/macos/Runner/Info.plist
@@ -31,7 +31,7 @@
 	<!-- posthog config -->
 	<key>com.posthog.posthog.POSTHOG_HOST</key>
 	<string>https://us.i.posthog.com</string>
-	<key>com.posthog.posthog.API_KEY</key>
+	<key>com.posthog.posthog.PROJECT_TOKEN</key>
 	<string>phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D</string>
 	<key>com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS</key>
 	<true/>

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -59,10 +59,13 @@ class PosthogFlutterPlugin :
                 return
             }
 
-            val apiKey = bundle.getString("com.posthog.posthog.API_KEY")?.trim()
+            val projectToken =
+                (bundle.getString("com.posthog.posthog.PROJECT_TOKEN")
+                    ?: bundle.getString("com.posthog.posthog.API_KEY"))
+                    ?.trim()
 
-            if (apiKey.isNullOrEmpty()) {
-                Log.e("PostHog", "com.posthog.posthog.API_KEY is missing!")
+            if (projectToken.isNullOrEmpty()) {
+                Log.e("PostHog", "com.posthog.posthog.PROJECT_TOKEN/com.posthog.posthog.API_KEY is missing!")
                 return
             }
 
@@ -79,7 +82,8 @@ class PosthogFlutterPlugin :
             val debug = bundle.getBoolean("com.posthog.posthog.DEBUG", false)
 
             val posthogConfig = mutableMapOf<String, Any>()
-            posthogConfig["apiKey"] = apiKey
+            posthogConfig["projectToken"] = projectToken
+            posthogConfig["apiKey"] = projectToken
             posthogConfig["host"] = host
             posthogConfig["captureApplicationLifecycleEvents"] = captureApplicationLifecycleEvents
             posthogConfig["debug"] = debug
@@ -282,9 +286,12 @@ class PosthogFlutterPlugin :
     }
 
     private fun setupPostHog(posthogConfig: Map<String, Any>) {
-        val apiKey = (posthogConfig["apiKey"] as String?)?.trim()
-        if (apiKey.isNullOrEmpty()) {
-            Log.e("PostHog", "apiKey is missing!")
+        val projectToken =
+            ((posthogConfig["projectToken"] as String?)
+                ?: (posthogConfig["apiKey"] as String?))
+                ?.trim()
+        if (projectToken.isNullOrEmpty()) {
+            Log.e("PostHog", "projectToken/apiKey is missing!")
             return
         }
 
@@ -295,7 +302,7 @@ class PosthogFlutterPlugin :
                 ?: PostHogConfig.DEFAULT_HOST
 
         val config =
-            PostHogAndroidConfig(apiKey, host).apply {
+            PostHogAndroidConfig(projectToken, host).apply {
                 captureScreenViews = false
                 captureDeepLinks = false
                 posthogConfig.getIfNotNull<Boolean>("captureApplicationLifecycleEvents") {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -64,8 +64,15 @@ class PosthogFlutterPlugin :
                     ?: bundle.getString("com.posthog.posthog.API_KEY"))
                     ?.trim()
 
+            if (!bundle.containsKey("com.posthog.posthog.PROJECT_TOKEN") && bundle.containsKey("com.posthog.posthog.API_KEY")) {
+                Log.w(
+                    "PostHog",
+                    "com.posthog.posthog.API_KEY is deprecated and will be removed in the next major version. Use com.posthog.posthog.PROJECT_TOKEN instead!"
+                )
+            }
+
             if (projectToken.isNullOrEmpty()) {
-                Log.e("PostHog", "com.posthog.posthog.PROJECT_TOKEN/com.posthog.posthog.API_KEY is missing!")
+                Log.e("PostHog", "Either com.posthog.posthog.PROJECT_TOKEN or com.posthog.posthog.API_KEY must be provided!")
                 return
             }
 
@@ -290,8 +297,14 @@ class PosthogFlutterPlugin :
             ((posthogConfig["projectToken"] as String?)
                 ?: (posthogConfig["apiKey"] as String?))
                 ?.trim()
+        if (!posthogConfig.containsKey("projectToken") && posthogConfig.containsKey("apiKey")) {
+            Log.w(
+                "PostHog",
+                "apiKey is deprecated and will be removed in the next major version. Use projectToken instead!"
+            )
+        }
         if (projectToken.isNullOrEmpty()) {
-            Log.e("PostHog", "projectToken/apiKey is missing!")
+            Log.e("PostHog", "Either projectToken or apiKey must be provided!")
             return
         }
 

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -57,7 +57,7 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let apiKey = (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") as? String ?? "")
+        let projectToken = ((Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.PROJECT_TOKEN") as? String) ?? (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") as? String) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         let host = (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.POSTHOG_HOST") as? String ?? PostHogConfig.defaultHost)
@@ -66,7 +66,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         let debug = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.DEBUG") as? Bool ?? false
 
         setupPostHog([
-            "apiKey": apiKey,
+            "projectToken": projectToken,
+            "apiKey": projectToken,
             "host": host,
             "captureApplicationLifecycleEvents": captureApplicationLifecycleEvents,
             "debug": debug,
@@ -78,10 +79,10 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             print("[PostHog] Plugin instance not found!")
             return
         }
-        let apiKey = (posthogConfig["apiKey"] as? String ?? "")
+        let projectToken = ((posthogConfig["projectToken"] as? String) ?? (posthogConfig["apiKey"] as? String) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if apiKey.isEmpty {
-            print("[PostHog] apiKey is missing!")
+        if projectToken.isEmpty {
+            print("[PostHog] projectToken/apiKey is missing!")
             return
         }
 
@@ -90,7 +91,7 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         let host = normalizedHost.isEmpty ? PostHogConfig.defaultHost : normalizedHost
 
         let config = PostHogConfig(
-            apiKey: apiKey,
+            apiKey: projectToken,
             host: host
         )
         config.captureScreenViews = false

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -60,6 +60,16 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         let projectToken = ((Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.PROJECT_TOKEN") as? String) ?? (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") as? String) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
+        if Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.PROJECT_TOKEN") == nil,
+           Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") != nil {
+            print("[PostHog] com.posthog.posthog.API_KEY is deprecated and will be removed in the next major version. Use com.posthog.posthog.PROJECT_TOKEN instead!")
+        }
+
+        if projectToken.isEmpty {
+            print("[PostHog] Either com.posthog.posthog.PROJECT_TOKEN or com.posthog.posthog.API_KEY must be provided!")
+            return
+        }
+
         let host = (Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.POSTHOG_HOST") as? String ?? PostHogConfig.defaultHost)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let captureApplicationLifecycleEvents = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS") as? Bool ?? true
@@ -81,8 +91,11 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         }
         let projectToken = ((posthogConfig["projectToken"] as? String) ?? (posthogConfig["apiKey"] as? String) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        if posthogConfig["projectToken"] == nil, posthogConfig["apiKey"] != nil {
+            print("[PostHog] apiKey is deprecated and will be removed in the next major version. Use projectToken instead!")
+        }
         if projectToken.isEmpty {
-            print("[PostHog] projectToken/apiKey is missing!")
+            print("[PostHog] Either projectToken or apiKey must be provided!")
             return
         }
 

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -58,13 +58,13 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
     // It's assumed posthog-js is initialized by the user in their HTML.
     // This setup primarily hooks into the existing posthog-js instance.
 
-    // If apiKey and host are in config, and posthog.init is to be handled by plugin:
+    // If projectToken and host are in config, and posthog.init is to be handled by plugin:
     // This is an example if we wanted the plugin to also call posthog.init()
     // final jsOptions = <String, dynamic>{
     //   'api_host': config.host,
     //   // Add other relevant options from PostHogConfig if needed for JS init
     // }.jsify();
-    // posthog?.callMethod('init'.toJS, config.apiKey.toJS, jsOptions);
+    // posthog?.callMethod('init'.toJS, config.projectToken.toJS, jsOptions);
 
     final ph = posthog;
     _config = config;

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -28,12 +28,12 @@ class Posthog {
   ///
   /// This method sets up the connection to your PostHog instance and prepares the SDK for tracking events and feature flags.
   ///
-  /// - [config]: The [PostHogConfig] object containing your API key, host, and other settings.
+  /// - [config]: The [PostHogConfig] object containing your project token, host, and other settings.
   ///   To listen for feature flag load events, provide an `onFeatureFlags` callback in the [PostHogConfig].
   ///
   /// **Example:**
   /// ```dart
-  /// final config = PostHogConfig('YOUR_API_KEY');
+  /// final config = PostHogConfig('YOUR_PROJECT_TOKEN');
   /// config.host = 'YOUR_POSTHOG_HOST';
   /// config.onFeatureFlags = () {
   ///   // Feature flags are now loaded, you can read flag values here

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -25,7 +25,7 @@ class PostHogConfig {
   /// This field was formerly named [apiKey].
   final String projectToken;
 
-  @Deprecated('Deprecated in favor of [projectToken].')
+  @Deprecated('Deprecated in favor of [projectToken]. This will be removed in the next major version.')
   String get apiKey => projectToken;
 
   String _host = _defaultHost;

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -17,7 +17,17 @@ enum PostHogDataMode { wifi, cellular, any }
 class PostHogConfig {
   static const _defaultHost = 'https://us.i.posthog.com';
 
-  final String apiKey;
+  /// Your PostHog project token.
+  ///
+  /// You can find it at:
+  /// https://us.posthog.com/settings/project-details#variables
+  ///
+  /// This field was formerly named [apiKey].
+  final String projectToken;
+
+  @Deprecated('Deprecated in favor of [projectToken].')
+  String get apiKey => projectToken;
+
   String _host = _defaultHost;
   String get host => _host;
   set host(String value) => _host = _normalizeHost(value);
@@ -136,10 +146,10 @@ class PostHogConfig {
   // TODO: missing getAnonymousId, propertiesSanitizer, captureDeepLinks integrations
 
   PostHogConfig(
-    String apiKey, {
+    String projectToken, {
     this.onFeatureFlags,
     List<BeforeSendCallback>? beforeSend,
-  })  : apiKey = apiKey.trim(),
+  })  : projectToken = projectToken.trim(),
         beforeSend = beforeSend ?? [];
 
   static String _normalizeHost(String host) {
@@ -149,7 +159,8 @@ class PostHogConfig {
 
   Map<String, dynamic> toMap() {
     return {
-      'apiKey': apiKey,
+      'projectToken': projectToken,
+      'apiKey': projectToken,
       'host': host,
       'flushAt': flushAt,
       'maxQueueSize': maxQueueSize,

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -25,7 +25,8 @@ class PostHogConfig {
   /// This field was formerly named [apiKey].
   final String projectToken;
 
-  @Deprecated('Deprecated in favor of [projectToken]. This will be removed in the next major version.')
+  @Deprecated(
+      'Deprecated in favor of [projectToken]. This will be removed in the next major version.')
   String get apiKey => projectToken;
 
   String _host = _defaultHost;

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -69,6 +69,16 @@ void main() {
       },
     );
 
+    test('setup sends projectToken and deprecated apiKey alias', () async {
+      testConfig = PostHogConfig(' \n test_api_key\t ');
+      await posthogFlutterIO.setup(testConfig);
+
+      final call = log.firstWhere((c) => c.method == 'setup');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['projectToken'], equals('test_api_key'));
+      expect(args['apiKey'], equals('test_api_key'));
+    });
+
     test(
       'invokes callback when native sends onFeatureFlagsCallback event',
       () async {

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -41,8 +41,10 @@ void main() {
       final config = PostHogConfig(' \n test_api_key\t ');
       config.host = ' \nhttps://eu.i.posthog.com/\t ';
 
+      expect(config.projectToken, equals('test_api_key'));
       expect(config.apiKey, equals('test_api_key'));
       expect(config.host, equals('https://eu.i.posthog.com/'));
+      expect(config.toMap()['projectToken'], equals('test_api_key'));
       expect(config.toMap()['apiKey'], equals('test_api_key'));
       expect(config.toMap()['host'], equals('https://eu.i.posthog.com/'));
     });


### PR DESCRIPTION
## :bulb: Motivation and Context

The Flutter SDK used `apiKey` for the project credential while other SDKs are moving toward more explicit naming. This change introduces `projectToken` as the preferred name in the Dart API and native auto-init configuration, while keeping the previous `apiKey` / `API_KEY` names as fallbacks for backwards compatibility.

This follow-up also improves deprecation logging for legacy `apiKey` / `API_KEY` usage and makes missing-key logs clearer by explicitly saying either the new or legacy key must be provided.

## :green_heart: How did you test it?

- Ran `flutter test test/posthog_test.dart test/posthog_flutter_io_test.dart` in `posthog_flutter/`
- Ran `flutter analyze lib test` in `posthog_flutter/`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
