### PR TITLE
fix: prefer projectToken for Darwin config

### DIFF
--- a/.changeset/gentle-foxes-drum.md
+++ b/.changeset/gentle-foxes-drum.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Prefer projectToken when configuring PostHog on Darwin platforms.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - Flutter (1.0.0)
-  - PostHog (3.50.0)
+  - PostHog (3.56.0)
   - posthog_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - PostHog (< 4.0.0, >= 3.50.0)
+    - PostHog (< 4.0.0, >= 3.56.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  PostHog: 38e00e9376b90f0d92de958105029e4736ffe7f9
-  posthog_flutter: 789630788986be1f728624d10f4b4e753f83c39f
+  PostHog: 646b20ce2db3f07f71ce7fb004a9b3a4ba4afa4b
+  posthog_flutter: 03b15ff7a78e2a4162baaf11f8db37b079412106
 
 PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - PostHog (3.50.0)
+  - PostHog (3.56.0)
   - posthog_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - PostHog (< 4.0.0, >= 3.50.0)
+    - PostHog (< 4.0.0, >= 3.56.0)
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  PostHog: 38e00e9376b90f0d92de958105029e4736ffe7f9
-  posthog_flutter: 789630788986be1f728624d10f4b4e753f83c39f
+  PostHog: 646b20ce2db3f07f71ce7fb004a9b3a4ba4afa4b
+  posthog_flutter: 03b15ff7a78e2a4162baaf11f8db37b079412106
 
 PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3
 

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.50.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.50.0', '< 4.0.0'
+  # ~> Version 3.56.0 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.56.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.50.0"..<"4.0.0")
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.56.0"..<"4.0.0")
     ],
     targets: [
         .target(

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -104,7 +104,7 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         let host = normalizedHost.isEmpty ? PostHogConfig.defaultHost : normalizedHost
 
         let config = PostHogConfig(
-            apiKey: projectToken,
+            projectToken: projectToken,
             host: host
         )
         config.captureScreenViews = false


### PR DESCRIPTION
## :bulb: Motivation and Context

The iOS PostHog SDK config API now refers to the token as `projectToken` instead of `apiKey`. The Flutter Darwin plugin should use the new initializer while preserving the existing backwards-compatible config behavior that checks `projectToken` first and falls back to `apiKey`.

## :green_heart: How did you test it?

Not run; small Darwin native config/dependency update only.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
