### PR TITLE
fix: reinstall autocapture on enable

### DIFF
--- a/.changeset/reinstall-autocapture-on-enable.md
+++ b/.changeset/reinstall-autocapture-on-enable.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Reinstall Flutter error autocapture handlers when re-enabling data collection.

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -58,7 +58,8 @@ class Posthog {
   void _installFlutterIntegrations(PostHogConfig config) {
     // Install exception autocapture if enabled
     if (config.errorTrackingConfig.captureFlutterErrors ||
-        config.errorTrackingConfig.capturePlatformDispatcherErrors) {
+        config.errorTrackingConfig.capturePlatformDispatcherErrors ||
+        config.errorTrackingConfig.captureIsolateErrors) {
       PostHogErrorTrackingAutoCaptureIntegration.install(
         config: config.errorTrackingConfig,
         posthog: _posthog,
@@ -209,7 +210,14 @@ class Posthog {
   }
 
   /// Enable data collection for a user
-  Future<void> enable() => _posthog.enable();
+  Future<void> enable() {
+    final config = _config;
+    if (config != null) {
+      _installFlutterIntegrations(config);
+    }
+
+    return _posthog.enable();
+  }
 
   /// Check if the user has opted out of data collection
   Future<bool> isOptOut() => _posthog.isOptOut();

--- a/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
+++ b/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
@@ -63,6 +63,12 @@ class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
   }
 
   @override
+  Future<void> disable() async {}
+
+  @override
+  Future<void> enable() async {}
+
+  @override
   Future<void> setPersonProperties({
     Map<String, Object>? userPropertiesToSet,
     Map<String, Object>? userPropertiesToSetOnce,

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
@@ -32,6 +33,52 @@ void main() {
           fakePlatformInterface.registeredOnFeatureFlagsCallback,
           equals(testCallback),
         );
+      },
+    );
+
+    test(
+      'enable reinstalls Flutter error autocapture after disable',
+      () async {
+        final originalFlutterErrorHandler = FlutterError.onError;
+        FlutterError.onError = (_) {};
+
+        try {
+          final config = PostHogConfig('test_project_token');
+          config.errorTrackingConfig.captureFlutterErrors = true;
+          await Posthog().setup(config);
+
+          FlutterError.reportError(
+            FlutterErrorDetails(
+              exception: Exception('before-disable'),
+              context: ErrorDescription('issue 381 repro'),
+            ),
+          );
+          expect(fakePlatformInterface.capturedExceptions.length, 1);
+
+          fakePlatformInterface.capturedExceptions.clear();
+          await Posthog().disable();
+
+          FlutterError.reportError(
+            FlutterErrorDetails(
+              exception: Exception('while-disabled'),
+              context: ErrorDescription('issue 381 repro'),
+            ),
+          );
+          expect(fakePlatformInterface.capturedExceptions, isEmpty);
+
+          await Posthog().enable();
+
+          FlutterError.reportError(
+            FlutterErrorDetails(
+              exception: Exception('after-enable'),
+              context: ErrorDescription('issue 381 repro'),
+            ),
+          );
+          expect(fakePlatformInterface.capturedExceptions.length, 1);
+        } finally {
+          await Posthog().disable();
+          FlutterError.onError = originalFlutterErrorHandler;
+        }
       },
     );
   });


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/PostHog/posthog-flutter/issues/381.

Disabling the SDK uninstalls Flutter/Dart error autocapture handlers, but enabling it again did not reinstall them. This meant users who toggled data collection off and back on during a session would permanently lose automatic error capture until app restart.


## :green_heart: How did you test it?
- `cd posthog_flutter && flutter test`
- `cd posthog_flutter && flutter analyze`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
