### PR TITLE
chore: add release Slack reaction

### DIFF
--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -175,6 +175,7 @@ jobs:
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
           thread_ts: ${{ steps.slack-thread.outputs.thread_ts }}
           message: '🚀 `posthog_flutter@${{ steps.get-version.outputs.version }}` released successfully!'
+          emoji_reaction: "rocket"
 
       - name: Notify Slack - Failed
         if: needs.publish.result == 'failure'


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add a rocket reaction to the successful pub.dev release Slack notification so the release thread gets a quick visual confirmation.

## :green_heart: How did you test it?

Ran `git diff --check`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
