### PR TITLE
chore: sign release workflow commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      committed: ${{ steps.commit-version-bump.outputs.committed }}
+      committed: ${{ steps.check-changes.outputs.committed }}
       new-version: ${{ steps.apply-changesets.outputs.new-version }}
     steps:
       - name: Notify Slack - Approved
@@ -110,37 +110,49 @@ jobs:
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
         run: ./scripts/bump-version.sh "$NEW_VERSION"
 
-      - name: Commit version bump
-        id: commit-version-bump
-        env:
-          GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
-          NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
+      - name: Check for version bump changes
+        id: check-changes
         run: |
-          git add -A
-          if git diff --staged --quiet; then
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release $NEW_VERSION [version bump]"
-            git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Commit version bump
+        id: commit-version-bump
+        if: steps.check-changes.outputs.committed == 'true'
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "chore: release ${{ steps.apply-changesets.outputs.new-version }} [version bump]"
+          repo: ${{ github.repository }}
+          branch: main
+        env:
+          GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
+
+      - name: Sync checkout to release commit
+        if: steps.commit-version-bump.outputs.commit-hash != ''
+        env:
+          COMMIT_HASH: ${{ steps.commit-version-bump.outputs.commit-hash }}
+        run: |
+          git fetch origin main
+          git reset --hard "$COMMIT_HASH"
       - name: Save Slack thread_ts to cache
-        if: steps.commit-version-bump.outputs.committed == 'true'
+        if: steps.check-changes.outputs.committed == 'true'
         env:
           SLACK_THREAD_TS: ${{ needs.notify-approval-needed.outputs.slack_ts }}
         run: echo "$SLACK_THREAD_TS" > .slack-thread-ts
 
       - name: Cache Slack thread_ts for publish workflow
-        if: steps.commit-version-bump.outputs.committed == 'true'
+        if: steps.check-changes.outputs.committed == 'true'
         uses: actions/cache/save@v5
         with:
           path: .slack-thread-ts
           key: slack-thread-ts-${{ steps.apply-changesets.outputs.new-version }}
 
       - name: Tag and push
-        if: steps.commit-version-bump.outputs.committed == 'true'
+        if: steps.check-changes.outputs.committed == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      committed: ${{ steps.check-changes.outputs.committed }}
+      committed: ${{ steps.commit-version-bump.outputs.commit-hash != '' }}
       new-version: ${{ steps.apply-changesets.outputs.new-version }}
     steps:
       - name: Notify Slack - Approved
@@ -139,20 +139,20 @@ jobs:
           git fetch origin main
           git reset --hard "$COMMIT_HASH"
       - name: Save Slack thread_ts to cache
-        if: steps.check-changes.outputs.committed == 'true'
+        if: steps.commit-version-bump.outputs.commit-hash != ''
         env:
           SLACK_THREAD_TS: ${{ needs.notify-approval-needed.outputs.slack_ts }}
         run: echo "$SLACK_THREAD_TS" > .slack-thread-ts
 
       - name: Cache Slack thread_ts for publish workflow
-        if: steps.check-changes.outputs.committed == 'true'
+        if: steps.commit-version-bump.outputs.commit-hash != ''
         uses: actions/cache/save@v5
         with:
           path: .slack-thread-ts
           key: slack-thread-ts-${{ steps.apply-changesets.outputs.new-version }}
 
       - name: Tag and push
-        if: steps.check-changes.outputs.committed == 'true'
+        if: steps.commit-version-bump.outputs.commit-hash != ''
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Release workflows commit version bump changes during automated releases. Raw `git commit` / `git push` can fail in repositories that require verified commit signatures, so the workflow should use `planetscale/ghcommit-action`, matching other SDK release workflows.

## :green_heart: How did you test it?

- Parsed the updated workflow YAML successfully.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
