### PR TITLE
chore(ci): switch from subosito/flutter-action to axi92's pinned fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
           cache: true
@@ -45,7 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
           cache: true
@@ -72,7 +78,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
           cache: true
@@ -105,7 +114,10 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
           cache: true
@@ -123,7 +135,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
           cache: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,10 @@ jobs:
 
       - name: Setup Flutter (Swift)
         if: matrix.language == 'swift'
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+        # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+        # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+        uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
 
@@ -57,7 +60,10 @@ jobs:
 
       - name: Setup Flutter (Java/Kotlin)
         if: matrix.language == 'java-kotlin'
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+        # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+        # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+        uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
 

--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -54,7 +54,10 @@ jobs:
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+        # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+        # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+        uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
         with:
           channel: 'stable'
 


### PR DESCRIPTION
Required to enable "Require actions to be pinned to a full-length commit SHA" setting.

I was going to fork subosito/flutter-action and pin its dependencies, but axi92/flutter-action has already done exactly that. The [diff](https://github.com/subosito/flutter-action/compare/main...axi92:flutter-action:feature/pin-action-sha) looks safe and matches the genuine commit hash for [actions/cache v5.0.4](https://github.com/actions/cache/releases/tag/v5.0.4).