### PR TITLE
chore: raise native dep versions for minimum recording duration

### DIFF
--- a/.changeset/tidy-pillows-record.md
+++ b/.changeset/tidy-pillows-record.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Raise the minimum `posthog-android` version to 3.44.0 to guarantee session replay minimum recording duration support.

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,8 +64,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.38.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.38.0,4.0.0]'
+        // + Version 3.44.0 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.44.0,4.0.0]'
     }
 
     testOptions {


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Docs PR: https://github.com/PostHog/posthog.com/pull/17015
Posthog PR: https://github.com/PostHog/posthog/pull/59942

Session replay's **minimum recording duration** feature is already implemented in native iOS and Android SDKs and works transparently through the Flutter wrapper. Flutter-captured `$snapshot` events flow through the native replay queue, which is gated by the same buffering logic and delegate that enforces the minimum duration. 

No additional Flutter-side code is required for the behavior.

However, the declared native dependency floors were inconsistent:

- iOS already pins `>= 3.56.0`, comfortably above the iOS feature floor (`3.53.0`).
- Android pins `>=3.38.0` which is **below** the Android feature floor (`3.44.0`).

## :green_heart: How did you test it?

- Tested that minimum recording duration is respected on both iOS and Android sample apps

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
