### PR TITLE
chore: add client libraries team as Dependabot reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot PRs should request reviews from `PostHog/team-client-libraries`, matching the setup added in PostHog/posthog-js#3675.

This adds `PostHog/team-client-libraries` as a reviewer in `.github/dependabot.yml`.

## :green_heart: How did you test it?
- Parsed `.github/dependabot.yml` with Ruby YAML.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
