### PR TITLE
docs: add Dartdoc for public APIs

### DIFF
--- a/posthog_flutter/lib/posthog_flutter.dart
+++ b/posthog_flutter/lib/posthog_flutter.dart
@@ -1,3 +1,4 @@
+/// Public Flutter API for the PostHog SDK.
 library posthog_flutter;
 
 export 'src/feature_flag_result.dart';

--- a/posthog_flutter/lib/src/feature_flag_result.dart
+++ b/posthog_flutter/lib/src/feature_flag_result.dart
@@ -18,6 +18,18 @@ class PostHogFeatureFlagResult {
   /// The JSON payload associated with the flag, if any.
   final Object? payload;
 
+  /// Creates a feature flag evaluation result.
+  ///
+  /// The [key] is the feature flag key that was evaluated.
+  ///
+  /// The [enabled] value is the boolean result for boolean flags. For
+  /// multivariate flags, it is `true` when the flag evaluates to a variant and
+  /// `false` when it does not match.
+  ///
+  /// The optional [variant] is the variant key for multivariate flags.
+  ///
+  /// The optional [payload] is the JSON payload configured for the matched flag
+  /// or variant.
   const PostHogFeatureFlagResult({
     required this.key,
     required this.enabled,
@@ -44,9 +56,11 @@ class PostHogFeatureFlagResult {
 
   /// Creates a [PostHogFeatureFlagResult] from a native SDK response map.
   ///
-  /// The [map] should contain: key, enabled, variant, payload.
-  /// Falls back to [fallbackKey] if the map doesn't include a key.
-  /// Returns null if [result] is null or not a Map.
+  /// The [result] should be a map containing `key`, `enabled`, `variant`, and
+  /// `payload` entries. Falls back to [fallbackKey] if the map does not include
+  /// a key.
+  ///
+  /// Returns `null` if [result] is `null` or is not a [Map].
   static PostHogFeatureFlagResult? fromMap(Object? result, String fallbackKey) {
     if (result == null) return null;
     if (result is! Map) return null;

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -137,6 +137,7 @@ class Posthog {
   /// do not overwrite existing values.
   ///
   /// Returns a [Future] that completes when the update has been queued.
+  /// If both property maps are null or empty, no event is queued.
   ///
   /// **Example:**
   /// ```dart

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -10,6 +10,10 @@ import 'posthog_flutter_platform_interface.dart';
 import 'posthog_internal_events.dart';
 import 'posthog_observer.dart';
 
+/// Entry point for the PostHog Flutter SDK.
+///
+/// Use the singleton returned by [Posthog] to set up the SDK, capture events,
+/// identify users, evaluate feature flags, and control session replay.
 class Posthog {
   static PosthogFlutterPlatformInterface get _posthog =>
       PosthogFlutterPlatformInterface.instance;
@@ -18,6 +22,7 @@ class Posthog {
 
   PostHogConfig? _config;
 
+  /// Returns the singleton PostHog client instance.
   factory Posthog() {
     return _instance;
   }
@@ -26,10 +31,14 @@ class Posthog {
 
   /// Initializes the PostHog SDK.
   ///
-  /// This method sets up the connection to your PostHog instance and prepares the SDK for tracking events and feature flags.
+  /// This method sets up the connection to your PostHog instance and prepares
+  /// the SDK for tracking events and feature flags.
   ///
-  /// - [config]: The [PostHogConfig] object containing your project token, host, and other settings.
-  ///   To listen for feature flag load events, provide an `onFeatureFlags` callback in the [PostHogConfig].
+  /// The [config] object contains your project token, host, and other settings.
+  /// To listen for feature flag load events, provide an `onFeatureFlags`
+  /// callback in the [PostHogConfig].
+  ///
+  /// Returns a [Future] that completes when platform setup has finished.
   ///
   /// **Example:**
   /// ```dart
@@ -42,7 +51,8 @@ class Posthog {
   /// ```
   ///
   /// For Android and iOS, if you are performing a manual setup,
-  /// ensure `com.posthog.posthog.AUTO_INIT: false` is set in your native configuration.
+  /// ensure `com.posthog.posthog.AUTO_INIT: false` is set in your native
+  /// configuration.
   Future<void> setup(PostHogConfig config) {
     _config = config; // Store the config
 
@@ -72,19 +82,29 @@ class Posthog {
     PostHogErrorTrackingAutoCaptureIntegration.uninstall();
   }
 
+  /// The active SDK configuration, if [setup] has completed.
+  ///
+  /// For internal use by Flutter integrations.
   @internal
   PostHogConfig? get config => _config;
 
-  /// Returns the current screen name (or route name)
-  /// Only returns a value if [PosthogObserver] is used
+  /// Returns the current screen name or route name.
+  ///
+  /// Only returns a value if [PosthogObserver] is used.
   @internal
   String? get currentScreen => _currentScreen;
 
-  /// Can associate events with specific users
+  /// Associates events with a specific user.
   ///
-  /// - [userId] A unique identifier for your user. Typically either their email or database ID.
-  /// - [userProperties] the user properties, set as a "$set" property,
-  /// - [userPropertiesSetOnce] the user properties to set only once, set as a "$set_once" property.
+  /// The [userId] is a unique identifier for your user, typically their email or
+  /// database ID.
+  ///
+  /// The optional [userProperties] are person properties set with `$set`.
+  ///
+  /// The optional [userPropertiesSetOnce] are person properties set with
+  /// `$set_once`.
+  ///
+  /// Returns a [Future] that completes when the identify call has been queued.
   ///
   /// **Example:**
   /// ```dart
@@ -107,12 +127,16 @@ class Posthog {
 
   /// Sets person properties for the current user without requiring identify.
   ///
-  /// This method sends a `$set` event to update person properties.
+  /// This method sends person property updates without changing the current
+  /// distinct ID.
   ///
-  /// - [userPropertiesToSet] the user properties to set, will overwrite existing values
-  /// - [userPropertiesToSetOnce] the user properties to set only once, will not overwrite existing values
+  /// The optional [userPropertiesToSet] values are set with `$set` and overwrite
+  /// existing values.
   ///
-  /// Returns early without sending an event if both property maps are null or empty.
+  /// The optional [userPropertiesToSetOnce] values are set with `$set_once` and
+  /// do not overwrite existing values.
+  ///
+  /// Returns a [Future] that completes when the update has been queued.
   ///
   /// **Example:**
   /// ```dart
@@ -130,18 +154,23 @@ class Posthog {
         userPropertiesToSetOnce: userPropertiesToSetOnce,
       );
 
-  /// Captures events.
-  /// Docs https://posthog.com/docs/product-analytics/user-properties
+  /// Captures a custom event.
   ///
-  /// We recommend using a [object] [verb] format for your event names,
-  /// where [object] is the entity that the behavior relates to,
-  /// and [verb] is the behavior itself.
-  /// For example, project created, user signed up, or invite sent.
+  /// Docs: https://posthog.com/docs/product-analytics/user-properties
   ///
-  /// - [eventName] name of event
-  /// - [properties] the custom properties
-  /// - [userProperties] the user properties, set as a "$set" property,
-  /// - [userPropertiesSetOnce] the user properties to set only once, set as a "$set_once" property.
+  /// We recommend using an `[object] [verb]` format for [eventName], where the
+  /// object is the entity that the behavior relates to and the verb is the
+  /// behavior itself. For example: `project created`, `user signed up`, or
+  /// `invite sent`.
+  ///
+  /// The optional [properties] are event properties.
+  ///
+  /// The optional [userProperties] are person properties set with `$set`.
+  ///
+  /// The optional [userPropertiesSetOnce] are person properties set with
+  /// `$set_once`.
+  ///
+  /// Returns a [Future] that completes when the event has been queued.
   ///
   /// **Example**
   /// ```dart
@@ -175,10 +204,13 @@ class Posthog {
     );
   }
 
-  /// Captures a screen view event
+  /// Captures a screen view event.
   ///
-  /// - [screenName] the screen title
-  /// - [properties] the custom properties
+  /// The [screenName] is the screen title or route name.
+  ///
+  /// The optional [properties] are additional screen event properties.
+  ///
+  /// Returns a [Future] that completes when the screen event has been queued.
   Future<void> screen({
     required String screenName,
     Map<String, Object>? properties,
@@ -187,21 +219,31 @@ class Posthog {
     return _posthog.screen(screenName: screenName, properties: properties);
   }
 
-  /// Creates an alias for the user.
-  /// Docs https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user
+  /// Creates an alias for the current user.
   ///
-  /// - [alias] the alias
+  /// Docs:
+  /// https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user
+  ///
+  /// The [alias] is the additional distinct ID to associate with the user.
+  ///
+  /// Returns a [Future] that completes when the alias call has been queued.
   Future<void> alias({required String alias}) => _posthog.alias(alias: alias);
 
-  /// Returns the registered `distinctId` property
+  /// Returns the registered `distinctId` property.
+  ///
+  /// Returns an empty string if the platform cannot provide a distinct ID.
   Future<String> getDistinctId() => _posthog.getDistinctId();
 
-  /// Resets all the cached properties including the `distinctId`.
+  /// Resets all cached properties including the `distinctId`.
   ///
-  /// The SDK will behave as its been [setup] for the first time
+  /// The SDK will behave as if it has been [setup] for the first time.
+  ///
+  /// Returns a [Future] that completes when the reset request has been queued.
   Future<void> reset() => _posthog.reset();
 
-  /// Disable data collection for a user
+  /// Disables data collection for the current user.
+  ///
+  /// Returns a [Future] that completes when the opt-out request has been queued.
   Future<void> disable() {
     // Uninstall Flutter-specific integrations when disabling
     _uninstallFlutterIntegrations();
@@ -209,7 +251,9 @@ class Posthog {
     return _posthog.disable();
   }
 
-  /// Enable data collection for a user
+  /// Enables data collection for the current user.
+  ///
+  /// Returns a [Future] that completes when the opt-in request has been queued.
   Future<void> enable() {
     final config = _config;
     if (config != null) {
@@ -219,43 +263,58 @@ class Posthog {
     return _posthog.enable();
   }
 
-  /// Check if the user has opted out of data collection
+  /// Returns whether the current user has opted out of data collection.
   Future<bool> isOptOut() => _posthog.isOptOut();
 
-  /// Enable or disable verbose logs about the inner workings of the SDK.
+  /// Enables or disables verbose logs about the inner workings of the SDK.
   ///
-  /// - [enabled] whether to enable or disable debug logs
+  /// Set [enabled] to `true` to enable debug logs, or `false` to disable them.
+  ///
+  /// Returns a [Future] that completes when the debug setting has been applied.
   Future<void> debug(bool enabled) => _posthog.debug(enabled);
 
-  /// Register a property to always be sent with all the following events until you call
-  /// [unregister] with the same key.
+  /// Registers a super property sent with all following events.
   ///
-  /// - [key] the Key
-  /// - [value] the Value
+  /// The property remains active until [unregister] is called with the same
+  /// [key]. The [value] must be supported by the platform channel serializer.
+  ///
+  /// Returns a [Future] that completes when the property has been registered.
   Future<void> register(String key, Object value) =>
       _posthog.register(key, value);
 
-  /// Unregisters the previously set property to be sent with all the following events
+  /// Unregisters a previously registered super property.
   ///
-  /// [key] the Key
+  /// The [key] identifies the property to stop sending with future events.
+  ///
+  /// Returns a [Future] that completes when the property has been removed.
   Future<void> unregister(String key) => _posthog.unregister(key);
 
-  /// Returns if a feature flag is enabled, the feature flag must be a Boolean
+  /// Returns whether a boolean feature flag is enabled.
   ///
-  /// Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+  /// Docs: https://posthog.com/docs/feature-flags and
+  /// https://posthog.com/docs/experiments
   ///
-  /// - [key] the Key of the feature
+  /// The [key] is the feature flag key.
+  ///
+  /// Returns `false` when the flag is disabled, missing, or not a boolean flag.
   Future<bool> isFeatureEnabled(String key) => _posthog.isFeatureEnabled(key);
 
-  /// Reloads the feature flags
+  /// Reloads feature flags for the current user.
+  ///
+  /// Returns a [Future] that completes when the reload request has been queued.
   Future<void> reloadFeatureFlags() => _posthog.reloadFeatureFlags();
 
-  /// Creates a group.
-  /// Docs https://posthog.com/docs/product-analytics/group-analytics
+  /// Associates the current user with a group.
   ///
-  /// - [groupType] the Group type
-  /// - [groupKey] the Group key
-  /// - [groupProperties] the Group properties, set as a "$group_set" property.
+  /// Docs: https://posthog.com/docs/product-analytics/group-analytics
+  ///
+  /// The [groupType] is the group type, such as `company`.
+  ///
+  /// The [groupKey] is the unique key for the group.
+  ///
+  /// The optional [groupProperties] are group properties set with `$group_set`.
+  ///
+  /// Returns a [Future] that completes when the group call has been queued.
   ///
   /// **Example:**
   /// ```dart
@@ -277,21 +336,23 @@ class Posthog {
         groupProperties: groupProperties,
       );
 
-  /// Returns the feature flag value for the given key.
+  /// Returns the feature flag value for [key].
   ///
-  /// Returns `null` if the flag doesn't exist.
-  /// For boolean flags, returns `true` or `false`.
-  /// For multivariate flags, returns the variant string.
+  /// Returns `null` if the flag does not exist or cannot be loaded. For boolean
+  /// flags, returns `true` or `false`. For multivariate flags, returns the
+  /// variant key.
   Future<Object?> getFeatureFlag(String key) =>
       _posthog.getFeatureFlag(key: key);
 
-  /// Returns the full feature flag result including value and payload.
+  /// Returns the full feature flag result for [key], including value and
+  /// payload.
   ///
   /// This is the canonical method for getting feature flag data.
-  /// Returns `null` if the flag doesn't exist.
+  /// Returns `null` if the flag does not exist or cannot be loaded.
   ///
   /// Set [sendEvent] to `false` to suppress the `$feature_flag_called` event.
-  /// This is useful when you only need the payload and don't want to emit the event.
+  /// This is useful when you only need the payload and do not want to emit the
+  /// event.
   ///
   /// **Example:**
   /// ```dart
@@ -307,20 +368,31 @@ class Posthog {
   }) =>
       _posthog.getFeatureFlagResult(key: key, sendEvent: sendEvent);
 
-  /// Returns the payload for a feature flag.
+  /// Returns the payload for the feature flag [key].
+  ///
+  /// Returns `null` when the flag does not exist, has no payload, or the payload
+  /// cannot be loaded.
   @Deprecated(
     'Use getFeatureFlagResult instead, which returns both value and payload.',
   )
   Future<Object?> getFeatureFlagPayload(String key) =>
       _posthog.getFeatureFlagPayload(key: key);
 
+  /// Flushes queued events immediately where supported by the platform.
+  ///
+  /// Returns a [Future] that completes when the flush request has finished.
   Future<void> flush() => _posthog.flush();
 
-  /// Captures exceptions with optional custom properties
+  /// Captures an exception with optional custom properties.
   ///
-  /// - [error] - The error/exception to capture
-  /// - [stackTrace] - Optional stack trace (if not provided, current stack trace will be used)
-  /// - [properties] - Optional custom properties to attach to the exception event
+  /// The [error] is the error or exception to capture.
+  ///
+  /// The optional [stackTrace] is attached to the exception. If omitted, the
+  /// current stack trace is used by the exception processor where possible.
+  ///
+  /// The optional [properties] are added to the `$exception` event.
+  ///
+  /// Returns a [Future] that completes when the exception event has been queued.
   Future<void> captureException({
     required Object error,
     StackTrace? stackTrace,
@@ -332,12 +404,18 @@ class Posthog {
         properties: properties,
       );
 
-  /// Captures runZonedGuarded exceptions with optional custom properties
-  /// https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html
+  /// Captures a `runZonedGuarded` error with optional custom properties.
   ///
-  /// - [error] - The error/exception to capture
-  /// - [stackTrace] - Optional stack trace (if not provided, current stack trace will be used)
-  /// - [properties] - Optional custom properties to attach to the exception event
+  /// See: https://api.flutter.dev/flutter/dart-async/runZonedGuarded.html
+  ///
+  /// The [error] is the error or exception received by `runZonedGuarded`.
+  ///
+  /// The optional [stackTrace] is attached to the exception. If omitted, the
+  /// current stack trace is used by the exception processor where possible.
+  ///
+  /// The optional [properties] are added to the `$exception` event.
+  ///
+  /// Returns a [Future] that completes when the exception event has been queued.
   Future<void> captureRunZonedGuardedError({
     required Object error,
     StackTrace? stackTrace,
@@ -357,7 +435,10 @@ class Posthog {
 
   /// Closes the PostHog SDK and cleans up resources.
   ///
-  /// Note: Please note that after calling close(), surveys will not be rendered until the SDK is re-initialized and the next navigation event occurs.
+  /// Returns a [Future] that completes when platform resources have been closed.
+  ///
+  /// **Note:** After calling `close()`, surveys will not be rendered until the
+  /// SDK is re-initialized and the next navigation event occurs.
   Future<void> close() {
     _config = null;
     _currentScreen = null;
@@ -370,7 +451,10 @@ class Posthog {
     return _posthog.close();
   }
 
-  /// Returns the session Id if a session is active
+  /// Returns the session ID if a session is active.
+  ///
+  /// Returns `null` when no session is active or the platform cannot provide a
+  /// session ID.
   Future<String?> getSessionId() => _posthog.getSessionId();
 
   /// Starts session recording.
@@ -378,8 +462,10 @@ class Posthog {
   /// This method will have no effect if PostHog is not enabled, or if session
   /// replay is disabled in your project settings.
   ///
-  /// [resumeCurrent] - If true (default), resumes recording of the current session.
-  /// If false, starts a new session and begins recording.
+  /// Set [resumeCurrent] to `true` (the default) to resume recording the current
+  /// session. Set it to `false` to start a new session and begin recording.
+  ///
+  /// Returns a [Future] that completes when the start request has been sent.
   Future<void> startSessionRecording({bool resumeCurrent = true}) async {
     await _posthog.startSessionRecording(resumeCurrent: resumeCurrent);
     PostHogInternalEvents.sessionRecordingActive.value = true;
@@ -388,12 +474,17 @@ class Posthog {
   /// Stops the current session recording if one is in progress.
   ///
   /// This method will have no effect if PostHog is not enabled.
+  ///
+  /// Returns a [Future] that completes when the stop request has been sent.
   Future<void> stopSessionRecording() async {
     await _posthog.stopSessionRecording();
     PostHogInternalEvents.sessionRecordingActive.value = false;
   }
 
   /// Returns whether session replay is currently active.
+  ///
+  /// Returns `false` when session replay is inactive or unsupported by the
+  /// current platform.
   Future<bool> isSessionReplayActive() => _posthog.isSessionReplayActive();
 
   Posthog._internal();

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -5,15 +5,46 @@ import 'posthog_flutter_platform_interface.dart';
 
 /// Callback to intercept and modify events before they are sent to PostHog.
 ///
-/// Return a possibly modified event to send it, or return `null` to drop it.
-/// Callbacks can be synchronous or asynchronous (returning `FutureOr<PostHogEvent?>`).
+/// The [event] argument contains the event name and user-provided properties
+/// that are about to be captured. Return a possibly modified event to send it,
+/// or return `null` to drop it.
+///
+/// Callbacks can be synchronous or asynchronous (returning
+/// `FutureOr<PostHogEvent?>`).
 typedef BeforeSendCallback = FutureOr<PostHogEvent?> Function(
-    PostHogEvent event);
+  PostHogEvent event,
+);
 
-enum PostHogPersonProfiles { never, always, identifiedOnly }
+/// Controls whether events create or update PostHog person profiles.
+enum PostHogPersonProfiles {
+  /// Never create person profiles from captured events.
+  never,
 
-enum PostHogDataMode { wifi, cellular, any }
+  /// Create or update person profiles for all captured events.
+  always,
 
+  /// Create or update person profiles only after the user has been identified.
+  identifiedOnly,
+}
+
+/// Controls which network connection types can be used for sending data.
+///
+/// This setting is currently applied only on Apple platforms.
+enum PostHogDataMode {
+  /// Send data only on Wi-Fi connections.
+  wifi,
+
+  /// Send data only on cellular connections.
+  cellular,
+
+  /// Send data on any available connection.
+  any,
+}
+
+/// Configuration used to initialize the PostHog Flutter SDK.
+///
+/// Create an instance with your project token, customize any options, and pass
+/// it to `Posthog().setup(config)`.
 class PostHogConfig {
   static const _defaultHost = 'https://us.i.posthog.com';
 
@@ -25,50 +56,105 @@ class PostHogConfig {
   /// This field was formerly named [apiKey].
   final String projectToken;
 
+  /// Deprecated alias for [projectToken].
   @Deprecated(
-      'Deprecated in favor of [projectToken]. This will be removed in the next major version.')
+    'Deprecated in favor of [projectToken]. This will be removed in the next major version.',
+  )
   String get apiKey => projectToken;
 
   String _host = _defaultHost;
+
+  /// The PostHog ingestion host.
+  ///
+  /// Defaults to `https://us.i.posthog.com`. The setter trims surrounding
+  /// whitespace and falls back to the default host when assigned a blank value.
   String get host => _host;
   set host(String value) => _host = _normalizeHost(value);
+
+  /// Number of queued events that triggers an automatic flush.
+  ///
+  /// Defaults to `20`.
   var flushAt = 20;
+
+  /// Maximum number of events stored in the local queue.
+  ///
+  /// When the queue is full, the oldest events may be dropped by the native SDK.
+  /// Defaults to `1000`.
   var maxQueueSize = 1000;
+
+  /// Maximum number of events sent in a single batch.
+  ///
+  /// Defaults to `50`.
   var maxBatchSize = 50;
+
+  /// Maximum time between automatic flush attempts.
+  ///
+  /// Defaults to 30 seconds.
   var flushInterval = const Duration(seconds: 30);
+
+  /// Whether calls that evaluate feature flags capture `$feature_flag_called`.
+  ///
+  /// Defaults to `true`.
   var sendFeatureFlagEvents = true;
+
+  /// Whether feature flags are loaded when the SDK starts.
+  ///
+  /// Defaults to `true`.
   var preloadFeatureFlags = true;
+
+  /// Whether the SDK captures application lifecycle events automatically.
+  ///
+  /// Captured events include app opened, backgrounded, installed, and updated
+  /// events where supported by the platform. Defaults to `true`.
   var captureApplicationLifecycleEvents = true;
 
+  /// Whether the SDK emits verbose debug logs.
+  ///
+  /// Defaults to `false`.
   var debug = false;
+
+  /// Whether the SDK starts with data collection disabled.
+  ///
+  /// Defaults to `false`. Use `Posthog().disable()` and `Posthog().enable()` to
+  /// change this setting at runtime.
   var optOut = false;
+
+  /// Controls whether captured events create or update person profiles.
+  ///
+  /// Defaults to [PostHogPersonProfiles.identifiedOnly].
   var personProfiles = PostHogPersonProfiles.identifiedOnly;
 
-  /// Enable Recording of Session replay for Android and iOS.
-  /// Requires Record user sessions to be enabled in the PostHog Project Settings.
-  /// Defaults to false.
+  /// Whether mobile session replay is enabled for Android and iOS.
+  ///
+  /// Requires Record user sessions to be enabled in PostHog project settings.
+  /// Defaults to `false`.
   var sessionReplay = false;
 
-  /// Configurations for Session replay.
-  /// [sessionReplay] has to be enabled for this to take effect.
+  /// Configuration for mobile session replay.
+  ///
+  /// [sessionReplay] must be enabled for these options to take effect.
   var sessionReplayConfig = PostHogSessionReplayConfig();
 
-  /// iOS only
+  /// Network connection types that can be used to send data on Apple platforms.
+  ///
+  /// Defaults to [PostHogDataMode.any].
   var dataMode = PostHogDataMode.any;
 
   /// Enable Surveys
   ///
   /// **Notes:**
-  /// - After calling `Posthog().close()`, surveys will not be rendered until the SDK is re-initialized and the next navigation event occurs.
-  /// - You must install `PosthogObserver` in your app for surveys to display
+  /// - After calling `Posthog().close()`, surveys will not be rendered until the
+  ///   SDK is re-initialized and the next navigation event occurs.
+  /// - You must install `PosthogObserver` in your app for surveys to display.
   ///   - See: https://posthog.com/docs/surveys/installation?tab=Flutter#step-two-install-posthogobserver
-  /// - For Flutter web, this setting will be ignored. Surveys on web use the JavaScript Web SDK instead.
+  /// - For Flutter web, this setting will be ignored. Surveys on web use the
+  ///   JavaScript Web SDK instead.
   ///   - See: https://posthog.com/docs/surveys/installation?tab=Web
   ///
   /// Defaults to true.
   var surveys = true;
 
-  /// Configuration for error tracking and exception capture
+  /// Configuration for error tracking and exception capture.
   final errorTrackingConfig = PostHogErrorTrackingConfig();
 
   /// Callback to be invoked when feature flags are loaded.
@@ -82,7 +168,8 @@ class PostHogConfig {
   /// Callbacks are invoked in order for events captured via Dart APIs:
   /// - `Posthog().capture()` - custom events
   /// - `Posthog().screen()` - screen events (event name will be `$screen`)
-  /// - `Posthog().captureException()` - exception events (event name will be `$exception`)
+  /// - `Posthog().captureException()` - exception events (event name will be
+  ///   `$exception`)
   ///
   /// Each callback receives the event (possibly modified by previous callbacks).
   /// Return a possibly modified event to continue, or return `null` to drop it.
@@ -130,22 +217,38 @@ class PostHogConfig {
   ///
   /// **Limitations:**
   /// - These callbacks do NOT intercept native-initiated events such as:
-  ///   - Session replay events (`$snapshot`) when `config.sessionReplay` is enabled
-  ///   - Application lifecycle events (`Application Opened`, etc.) when `config.captureApplicationLifecycleEvents` is enabled
-  ///   - Feature flag events (`$feature_flag_called`) when `config.sendFeatureFlagEvents` is enabled
+  ///   - Session replay events (`$snapshot`) when `config.sessionReplay` is
+  ///     enabled
+  ///   - Application lifecycle events (`Application Opened`, etc.) when
+  ///     `config.captureApplicationLifecycleEvents` is enabled
+  ///   - Feature flag events (`$feature_flag_called`) when
+  ///     `config.sendFeatureFlagEvents` is enabled
   ///   - Identity events (`$set`) when `identify` is called
   ///   - Survey events (`survey shown`, etc.) when `config.surveys` is enabled
-  /// - Only user-provided properties are available; system properties
-  ///   (like `$device_type`, `$session_id`) are added by the native SDK at a later stage.
+  /// - Only user-provided properties are available; system properties (like
+  ///   `$device_type`, `$session_id`) are added by the native SDK at a later
+  ///   stage.
   ///
   /// **Note:**
-  /// - Callbacks can be synchronous or asynchronous (via `FutureOr<PostHogEvent?>`)
-  /// - Exceptions in a callback will skip that callback and continue with the next one in the list
-  /// - If any callback returns `null`, the event is dropped and subsequent callbacks are not called.
+  /// - Callbacks can be synchronous or asynchronous (via
+  ///   `FutureOr<PostHogEvent?>`)
+  /// - Exceptions in a callback will skip that callback and continue with the
+  ///   next one in the list.
+  /// - If any callback returns `null`, the event is dropped and subsequent
+  ///   callbacks are not called.
   List<BeforeSendCallback> beforeSend = [];
 
   // TODO: missing getAnonymousId, propertiesSanitizer, captureDeepLinks integrations
 
+  /// Creates a configuration for [projectToken].
+  ///
+  /// The [projectToken] is trimmed before it is stored.
+  ///
+  /// The optional [onFeatureFlags] callback is invoked when feature flags finish
+  /// loading.
+  ///
+  /// The optional [beforeSend] callbacks are copied into [beforeSend] and run in
+  /// order before Dart-captured events are sent.
   PostHogConfig(
     String projectToken, {
     this.onFeatureFlags,
@@ -158,6 +261,9 @@ class PostHogConfig {
     return trimmedHost.isEmpty ? _defaultHost : trimmedHost;
   }
 
+  /// Converts this configuration to a platform-channel map.
+  ///
+  /// Returns the values consumed by the Android, Apple, and web implementations.
   Map<String, dynamic> toMap() {
     return {
       'projectToken': projectToken,
@@ -182,7 +288,14 @@ class PostHogConfig {
   }
 }
 
+/// Configuration for mobile session replay capture and masking.
+///
+/// Assign an instance to [PostHogConfig.sessionReplayConfig] before calling
+/// `Posthog().setup(config)`.
 class PostHogSessionReplayConfig {
+  /// Creates a session replay configuration with default masking enabled.
+  PostHogSessionReplayConfig();
+
   /// Enable masking of all text and text input fields.
   /// Default: true.
   var maskAllTexts = true;
@@ -191,20 +304,22 @@ class PostHogSessionReplayConfig {
   /// Default: true.
   var maskAllImages = true;
 
-  /// The value assigned to this var will be forwarded to [throttleDelay]
+  /// Deprecated setter that forwards assigned values to [throttleDelay].
   ///
-  /// Debouncer delay used to reduce the number of snapshots captured and reduce performance impact.
-  /// This is used for capturing the view as a screenshot.
-  /// The lower the number, the more snapshots will be captured but higher the performance impact.
-  /// Defaults to 1s.
+  /// Debouncer delay used to reduce the number of snapshots captured and reduce
+  /// performance impact. This is used for capturing the view as a screenshot.
+  /// The lower the number, the more snapshots will be captured but higher the
+  /// performance impact. Defaults to 1s.
   @Deprecated('Deprecated in favor of [throttleDelay] from v4.8.0.')
   set debouncerDelay(Duration debouncerDelay) {
     throttleDelay = debouncerDelay;
   }
 
-  /// Throttling delay used to reduce the number of snapshots captured and reduce performance impact.
-  /// This is used for capturing the view as a screenshot.
-  /// The lower the number, the more snapshots will be captured but higher the performance impact.
+  /// Throttling delay used to reduce the number of snapshots captured and reduce
+  /// performance impact.
+  ///
+  /// This is used for capturing the view as a screenshot. The lower the number,
+  /// the more snapshots will be captured but higher the performance impact.
   /// Defaults to 1s.
   var throttleDelay = const Duration(seconds: 1);
 
@@ -213,6 +328,10 @@ class PostHogSessionReplayConfig {
   /// If null, sampling is controlled by remote config (when available).
   double? sampleRate;
 
+  /// Converts this session replay configuration to a platform-channel map.
+  ///
+  /// Returns values consumed by the Android and Apple session replay
+  /// implementations.
   Map<String, dynamic> toMap() {
     return {
       'maskAllImages': maskAllImages,
@@ -223,12 +342,23 @@ class PostHogSessionReplayConfig {
   }
 }
 
+/// Configuration for PostHog error tracking and exception capture.
 class PostHogErrorTrackingConfig {
-  /// List of package names to be considered inApp frames for exception tracking
+  /// Creates an error tracking configuration with all autocapture disabled.
+  PostHogErrorTrackingConfig();
+
+  /// List of package names to be considered in-app frames for exception tracking.
   ///
-  /// inApp Example:
-  /// inAppIncludes.addAll(["package:your_app", "package:your_company_utils"])
-  /// All exception stacktrace frames from these packages will be considered inApp
+  /// Example:
+  /// ```dart
+  /// config.errorTrackingConfig.inAppIncludes.addAll([
+  ///   'package:your_app',
+  ///   'package:your_company_utils',
+  /// ]);
+  /// ```
+  ///
+  /// All exception stack trace frames from these packages will be considered
+  /// in-app.
   ///
   /// This option takes precedence over inAppExcludes.
   /// For Flutter/Dart, this typically includes:
@@ -240,13 +370,20 @@ class PostHogErrorTrackingConfig {
   ///
   final inAppIncludes = <String>[];
 
-  /// List of package names to be excluded from inApp frames for exception tracking
+  /// List of package names to exclude from in-app frames for exception tracking.
   ///
-  /// inAppExcludes Example:
-  /// inAppExcludes.addAll(["package:third_party_lib", "package:analytics_package"])
-  /// All exception stacktrace frames from these packages will be considered external
+  /// Example:
+  /// ```dart
+  /// config.errorTrackingConfig.inAppExcludes.addAll([
+  ///   'package:third_party_lib',
+  ///   'package:analytics_package',
+  /// ]);
+  /// ```
   ///
-  /// Note: inAppIncludes takes precedence over this setting.
+  /// All exception stack trace frames from these packages will be considered
+  /// external.
+  ///
+  /// Note: [inAppIncludes] takes precedence over this setting.
   /// Common packages to exclude:
   /// - Third-party analytics packages
   /// - External utility libraries
@@ -258,8 +395,9 @@ class PostHogErrorTrackingConfig {
   ///
   final inAppExcludes = <String>[];
 
-  /// Configures whether stack trace frames are considered inApp by default
-  /// when the origin cannot be determined or no explicit includes/excludes match.
+  /// Configures whether stack trace frames are considered in-app by default
+  /// when the origin cannot be determined or no explicit includes/excludes
+  /// match.
   ///
   /// - If true: Frames are inApp unless explicitly excluded (allowlist approach)
   /// - If false: Frames are external unless explicitly included (denylist approach)
@@ -275,23 +413,24 @@ class PostHogErrorTrackingConfig {
   ///
   var inAppByDefault = true;
 
-  /// Enable automatic capture of Flutter framework errors
+  /// Enable automatic capture of Flutter framework errors.
   ///
   /// Controls whether `FlutterError.onError` errors are captured.
   ///
   /// Default: false
   var captureFlutterErrors = false;
 
-  /// Enable capturing of silent Flutter errors
+  /// Enable capturing of silent Flutter errors.
   ///
-  /// Controls whether Flutter errors marked as silent (FlutterErrorDetails.silent = true) are captured.
+  /// Controls whether Flutter errors marked as silent
+  /// (`FlutterErrorDetails.silent = true`) are captured.
   ///
   /// Default: false
   var captureSilentFlutterErrors = false;
 
-  /// Enable automatic capture of Dart runtime errors
+  /// Enable automatic capture of Dart runtime errors.
   ///
-  /// Controls whether `PlatformDispatcher.onError errors` are captured.
+  /// Controls whether `PlatformDispatcher.onError` errors are captured.
   ///
   /// **Note:**
   /// - Flutter web: Not supported
@@ -329,7 +468,7 @@ class PostHogErrorTrackingConfig {
   /// Default: false
   var captureNativeExceptions = false;
 
-  /// Enable automatic capture of isolate errors
+  /// Enable automatic capture of isolate errors.
   ///
   /// Controls whether errors from the current isolate are captured.
   /// This includes errors from the main isolate and any isolates spawned
@@ -341,6 +480,10 @@ class PostHogErrorTrackingConfig {
   /// Default: false
   var captureIsolateErrors = false;
 
+  /// Converts this error tracking configuration to a platform-channel map.
+  ///
+  /// Returns values consumed by the Android, Apple, and Dart exception capture
+  /// implementations.
   Map<String, dynamic> toMap() {
     return {
       'inAppIncludes': inAppIncludes,

--- a/posthog_flutter/lib/src/posthog_event.dart
+++ b/posthog_flutter/lib/src/posthog_event.dart
@@ -1,6 +1,7 @@
-/// Represents an event that can be modified or dropped by the [BeforeSendCallback].
+/// Represents an event that can be modified or dropped before it is sent.
 ///
-/// This class is used in the beforeSend callback to allow modification of events before they are sent to PostHog.
+/// This class is used in before-send callbacks to allow modification of events
+/// before they are sent to PostHog.
 class PostHogEvent {
   /// The name of the event (e.g., 'button_clicked', '$screen', '$exception')
   String event;
@@ -21,6 +22,17 @@ class PostHogEvent {
   /// These properties will only be set if they don't already exist on the user profile.
   Map<String, Object>? userPropertiesSetOnce;
 
+  /// Creates an event passed to a before-send callback.
+  ///
+  /// The [event] is the event name to capture.
+  ///
+  /// The optional [properties] are event properties that can be amended before
+  /// capture.
+  ///
+  /// The optional [userProperties] are person properties to set with `$set`.
+  ///
+  /// The optional [userPropertiesSetOnce] are person properties to set with
+  /// `$set_once`.
   PostHogEvent({
     required this.event,
     this.properties,

--- a/posthog_flutter/lib/src/posthog_observer.dart
+++ b/posthog_flutter/lib/src/posthog_observer.dart
@@ -4,19 +4,44 @@ import 'package:meta/meta.dart';
 
 import 'posthog.dart';
 
+/// Extracts a PostHog screen name from Flutter [RouteSettings].
+///
+/// Return `null` to skip tracking the route. The [settings] argument is the
+/// route settings from the route being pushed, popped to, or replaced.
 typedef ScreenNameExtractor = String? Function(RouteSettings settings);
 
-/// [PostHogRouteFilter] allows to filter out routes that should not be tracked.
+/// Filters routes before [PosthogObserver] captures screen views.
 ///
-/// By default, only [PageRoute]s are tracked.
+/// Return `true` to allow tracking for [route] and `false` to ignore it. By
+/// default, only [PageRoute]s are tracked.
 typedef PostHogRouteFilter = bool Function(Route<dynamic>? route);
 
+/// Returns [RouteSettings.name] as the screen name for [settings].
+///
+/// Returns `null` when the route settings do not define a name.
 String? defaultNameExtractor(RouteSettings settings) => settings.name;
 
+/// Returns whether [route] should be tracked by the default route filter.
+///
+/// The default implementation tracks only [PageRoute] instances.
 bool defaultPostHogRouteFilter(Route<dynamic>? route) => route is PageRoute;
 
+/// A Flutter [NavigatorObserver] that automatically captures `$screen` events.
+///
+/// Add this observer to `MaterialApp.navigatorObservers` or a router such as
+/// `go_router` to capture screen views when named routes are pushed, popped, or
+/// replaced.
 class PosthogObserver extends RouteObserver<ModalRoute<dynamic>>
     with WidgetsBindingObserver {
+  /// Creates a PostHog route observer.
+  ///
+  /// The [nameExtractor] reads a screen name from route settings. It defaults
+  /// to [defaultNameExtractor], which returns [RouteSettings.name].
+  ///
+  /// The [routeFilter] determines which routes are eligible for tracking. It
+  /// defaults to [defaultPostHogRouteFilter], which tracks [PageRoute]s.
+  ///
+  /// Screen events are only sent while the app is in the foreground.
   PosthogObserver({
     ScreenNameExtractor nameExtractor = defaultNameExtractor,
     PostHogRouteFilter routeFilter = defaultPostHogRouteFilter,

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -7,15 +7,23 @@ import 'replay/change_detector.dart';
 import 'replay/native_communicator.dart';
 import 'replay/screenshot/screenshot_capturer.dart';
 
+/// Wraps a Flutter app to enable mobile session replay screenshots.
+///
+/// Place [PostHogWidget] above your app content when `PostHogConfig.sessionReplay`
+/// is enabled. The widget captures snapshots from [child] and sends them to the
+/// native SDK while session recording is active.
 class PostHogWidget extends StatefulWidget {
+  /// The widget subtree to include in session replay snapshots.
   final Widget child;
 
+  /// Creates a session replay root widget around [child].
   const PostHogWidget({super.key, required this.child});
 
   @override
   PostHogWidgetState createState() => PostHogWidgetState();
 }
 
+/// State for [PostHogWidget].
 class PostHogWidgetState extends State<PostHogWidget> {
   ChangeDetector? _changeDetector;
   ScreenshotCapturer? _screenshotCapturer;

--- a/posthog_flutter/lib/src/replay/mask/posthog_mask_widget.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_mask_widget.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
 
+/// Masks a widget subtree in PostHog session replay snapshots.
+///
+/// Wrap sensitive UI with [PostHogMaskWidget] to hide that area in captured
+/// screenshots, regardless of the global session replay masking settings.
 class PostHogMaskWidget extends StatefulWidget {
+  /// The widget subtree to mask in session replay snapshots.
   final Widget child;
 
+  /// Creates a mask around [child] for session replay.
   const PostHogMaskWidget({super.key, required this.child});
 
   @override
   PostHogMaskWidgetState createState() => PostHogMaskWidgetState();
 }
 
+/// State for [PostHogMaskWidget].
 class PostHogMaskWidgetState extends State<PostHogMaskWidget> {
   final GlobalKey _widgetKey = GlobalKey();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -132,10 +132,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -201,10 +201,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -230,5 +230,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -132,10 +132,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -201,10 +201,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -230,5 +230,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"


### PR DESCRIPTION
## :bulb: Motivation and Context

The public Dart API had incomplete or stale Dartdoc coverage for several SDK entry points, constructor parameters, method parameters, return values, and configuration options. This makes generated API docs less useful for Flutter SDK consumers.

This PR adds and refreshes Dartdoc comments for the exported Dart API, including `Posthog`, `PostHogConfig`, feature flag results, before-send events, route observer helpers, and session replay widgets.

## :green_heart: How did you test it?

- `dart format posthog_flutter/lib/posthog_flutter.dart posthog_flutter/lib/src/feature_flag_result.dart posthog_flutter/lib/src/posthog.dart posthog_flutter/lib/src/posthog_config.dart posthog_flutter/lib/src/posthog_event.dart posthog_flutter/lib/src/posthog_observer.dart posthog_flutter/lib/src/posthog_widget.dart posthog_flutter/lib/src/replay/mask/posthog_mask_widget.dart`
- `cd posthog_flutter && flutter analyze`
- `cd posthog_flutter && flutter test`
- `cd posthog_flutter && dart doc --dry-run`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
