### PR TITLE
chore: update PostHog/.github pins

### DIFF
--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Notify Slack - Failed
         continue-on-error: true
         if: ${{ failure() && steps.slack-thread-for-failure.outputs.thread_ts != '' }}
-        uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -172,7 +172,7 @@ jobs:
       - name: Notify Slack - Released
         if: needs.publish.result == 'success'
         continue-on-error: true
-        uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -183,7 +183,7 @@ jobs:
       - name: Notify Slack - Failed
         if: needs.publish.result == 'failure'
         continue-on-error: true
-        uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Some workflows referenced older pinned `PostHog/.github` revisions. One older revision of the shared release approval workflow still used tag-based nested actions (`actions/checkout@v6` and `PostHog/posthog-github-action@v1.1.1`), which violates the org policy requiring every action reference, including nested reusable workflow actions, to be pinned to a full-length commit SHA.

This updates all `PostHog/.github` reusable workflow/action references in this repository to the latest pinned `PostHog/.github` commit: `5fc4680761e8ac29a61b212756230eba0e276d8c`.

## :green_heart: How did you test it?

- Ran `git diff --check`
- Verified all `PostHog/.github` references in `.github` point to `5fc4680761e8ac29a61b212756230eba0e276d8c`
- Verified the latest `PostHog/.github` revision has no unpinned `uses:` references

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
