### PR TITLE
fix: skip setup for blank project tokens

### DIFF
--- a/.changeset/blank-tokens-bail.md
+++ b/.changeset/blank-tokens-bail.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Skip Flutter SDK setup for blank project tokens before storing config or installing Dart integrations.

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -56,7 +56,7 @@ class Posthog {
   Future<void> setup(PostHogConfig config) {
     if (config.projectToken.isEmpty) {
       debugPrint(
-        '[PostHog] Either projectToken or apiKey must be provided! Setup skipped.',
+        '[PostHog] projectToken must not be blank. Setup skipped.',
       );
       return Future<void>.value();
     }

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -54,6 +54,13 @@ class Posthog {
   /// ensure `com.posthog.posthog.AUTO_INIT: false` is set in your native
   /// configuration.
   Future<void> setup(PostHogConfig config) {
+    if (config.projectToken.isEmpty) {
+      debugPrint(
+        '[PostHog] Either projectToken or apiKey must be provided! Setup skipped.',
+      );
+      return Future<void>.value();
+    }
+
     _config = config; // Store the config
 
     if (config.sessionReplay) {

--- a/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
+++ b/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
@@ -69,6 +69,9 @@ class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
   Future<void> enable() async {}
 
   @override
+  Future<void> close() async {}
+
+  @override
   Future<void> setPersonProperties({
     Map<String, Object>? userPropertiesToSet,
     Map<String, Object>? userPropertiesToSetOnce,

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -38,29 +38,38 @@ void main() {
       },
     );
 
-    test(
-      'setup with blank project token skips platform setup and integrations',
-      () async {
-        final originalFlutterErrorHandler = FlutterError.onError;
-        void sentinelHandler(FlutterErrorDetails _) {}
-        FlutterError.onError = sentinelHandler;
+    group('setup with blank project token', () {
+      const blankProjectTokens = <String, String>{
+        'empty string': '',
+        'space': ' ',
+        'tab': '\t',
+        'mixed whitespace': ' \n\t ',
+      };
 
-        try {
-          final config = PostHogConfig(' \n\t ');
-          config.sessionReplay = true;
-          config.errorTrackingConfig.captureFlutterErrors = true;
+      for (final entry in blankProjectTokens.entries) {
+        test('skips platform setup and integrations for ${entry.key}',
+            () async {
+          final originalFlutterErrorHandler = FlutterError.onError;
+          void sentinelHandler(FlutterErrorDetails _) {}
+          FlutterError.onError = sentinelHandler;
 
-          await Posthog().setup(config);
+          try {
+            final config = PostHogConfig(entry.value);
+            config.sessionReplay = true;
+            config.errorTrackingConfig.captureFlutterErrors = true;
 
-          expect(fakePlatformInterface.receivedConfig, isNull);
-          expect(Posthog().config, isNull);
-          expect(PostHogInternalEvents.sessionRecordingActive.value, isFalse);
-          expect(FlutterError.onError, same(sentinelHandler));
-        } finally {
-          FlutterError.onError = originalFlutterErrorHandler;
-        }
-      },
-    );
+            await Posthog().setup(config);
+
+            expect(fakePlatformInterface.receivedConfig, isNull);
+            expect(Posthog().config, isNull);
+            expect(PostHogInternalEvents.sessionRecordingActive.value, isFalse);
+            expect(FlutterError.onError, same(sentinelHandler));
+          } finally {
+            FlutterError.onError = originalFlutterErrorHandler;
+          }
+        });
+      }
+    });
 
     test(
       'enable reinstalls Flutter error autocapture after disable',

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+import 'package:posthog_flutter/src/posthog_internal_events.dart';
 
 import 'posthog_flutter_platform_interface_fake.dart';
 
@@ -11,9 +12,10 @@ void main() {
   group('Posthog', () {
     late PosthogFlutterPlatformFake fakePlatformInterface;
 
-    setUp(() {
+    setUp(() async {
       fakePlatformInterface = PosthogFlutterPlatformFake();
       PosthogFlutterPlatformInterface.instance = fakePlatformInterface;
+      await Posthog().close();
     });
 
     test(
@@ -33,6 +35,30 @@ void main() {
           fakePlatformInterface.registeredOnFeatureFlagsCallback,
           equals(testCallback),
         );
+      },
+    );
+
+    test(
+      'setup with blank project token skips platform setup and integrations',
+      () async {
+        final originalFlutterErrorHandler = FlutterError.onError;
+        void sentinelHandler(FlutterErrorDetails _) {}
+        FlutterError.onError = sentinelHandler;
+
+        try {
+          final config = PostHogConfig(' \n\t ');
+          config.sessionReplay = true;
+          config.errorTrackingConfig.captureFlutterErrors = true;
+
+          await Posthog().setup(config);
+
+          expect(fakePlatformInterface.receivedConfig, isNull);
+          expect(Posthog().config, isNull);
+          expect(PostHogInternalEvents.sessionRecordingActive.value, isFalse);
+          expect(FlutterError.onError, same(sentinelHandler));
+        } finally {
+          FlutterError.onError = originalFlutterErrorHandler;
+        }
       },
     );
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Blank or whitespace-only project tokens should not initialize the Flutter SDK. Without this guard, setup can store an invalid config and install Dart integrations even though the token is unusable.

This change skips setup early when the project token is blank and logs a clear message that the `projectToken` must not be blank.

## :green_heart: How did you test it?

- `cd posthog_flutter && flutter test test/posthog_test.dart`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
