### PR TITLE
chore: use macOS 26 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   # Linting and formatting checks
   lint:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -65,7 +65,7 @@ jobs:
 
   # Apple builds (iOS and macOS) with CocoaPods and Swift Package Manager
   build-apple:
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       matrix:
         target: [ios, macos]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.4'
 
       - name: Enable Swift Package Manager
         if: matrix.package_manager == 'spm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '16.4'
+          xcode-version: latest-stable
 
       - name: Enable Swift Package Manager
         if: matrix.package_manager == 'spm'


### PR DESCRIPTION
## :bulb: Motivation and Context
GitHub Actions workflows should pin macOS jobs to the `macos-26` runner instead of using the moving `macos-latest` label.

This updates the Flutter SDK CI jobs that currently use `macos-latest`. The Apple build job now selects `latest-stable` Xcode because the `macos-26` image does not include Xcode 16.4.

in a month `macos-latest` will be migrated to what `macos-26` is today, so changing to `macos-26` already and we can monitor any hiccups CI may have before they do the final change, so we can fix things with more patience if any

## :green_heart: How did you test it?

- Ran `git diff --check`
- Confirmed no `macos-latest` references remain under `.github/workflows`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
