### PR TITLE
fix: await feature flag load in reloadFeatureFlags

### DIFF
--- a/.changeset/reload-flags-await-completion.md
+++ b/.changeset/reload-flags-await-completion.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+`reloadFeatureFlags()` now resolves its `Future` only after feature flags have finished loading, instead of returning immediately. `await Posthog().reloadFeatureFlags()` is now reliable, so reading a flag (or starting session recording) right after a reload sees the up-to-date result.

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,8 +64,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.44.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.44.0,4.0.0]'
+        // + Version 3.47.2 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.47.2,4.0.0]'
     }
 
     testOptions {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -628,8 +628,14 @@ class PosthogFlutterPlugin :
 
     private fun reloadFeatureFlags(result: Result) {
         try {
-            PostHog.reloadFeatureFlags()
-            result.success(null)
+            // Resolve the Dart Future only once flags have actually finished
+            // loading. The native callback fires on a background thread, so the
+            // result must be posted back to the main thread for Flutter.
+            PostHog.reloadFeatureFlags {
+                Handler(Looper.getMainLooper()).post {
+                    result.success(null)
+                }
+            }
         } catch (e: Throwable) {
             result.error("PosthogFlutterException", e.localizedMessage, null)
         }

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.56.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.56.0', '< 4.0.0'
+  # ~> Version 3.59.3 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.59.3', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.56.0"..<"4.0.0")
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.59.3"..<"4.0.0")
     ],
     targets: [
         .target(

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -765,8 +765,13 @@ extension PosthogFlutterPlugin {
     }
 
     private func reloadFeatureFlags(_ result: @escaping FlutterResult) {
-        PostHogSDK.shared.reloadFeatureFlags()
-        result(nil)
+        // Resolve the Dart Future only once flags have actually finished loading.
+        // The native callback fires on a background thread, so hop to main for Flutter.
+        PostHogSDK.shared.reloadFeatureFlags {
+            DispatchQueue.main.async {
+                result(nil)
+            }
+        }
     }
 
     private func group(


### PR DESCRIPTION
## :bulb: Motivation and Context

https://posthoghelp.zendesk.com/agent/tickets/58925 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61593)

`reloadFeatureFlags()` resolved its `Future` immediately instead of waiting for the native reload to finish. On both platforms the plugin called the fire-and-forget native overload and then returned right away:

```kotlin
PostHog.reloadFeatureFlags()
result.success(null) // resolves before flags are loaded
```

So `await Posthog().reloadFeatureFlags()` returned before flags were ready. Reading a flag (or starting session recording) right after a reload saw stale/empty values — e.g. `getFeatureFlag(...)` returning `null` immediately after `await reloadFeatureFlags()`, and the documented `await reloadFeatureFlags(); await startSessionRecording();` pattern not behaving as written.

Found while investigating session-replay-not-restarting-after-an-in-session `identify()`/`reset()` (PostHog support ticket).

## What this PR does

1. **Awaits the native reload.** The plugin now calls the callback-based native overload and resolves the Dart `Future` from the completion callback (hopping back to the main thread) instead of returning immediately.

2. **Raises the native SDK minimums** so the callback this fix relies on is always invoked:
   - `posthog-android` (`build.gradle`): `[3.44.0,4.0.0]` → `[3.47.2,4.0.0]`
   - `posthog-ios` (`podspec`): `>= 3.56.0` → `>= 3.59.3`
   - `posthog-ios` (SwiftPM `Package.swift`): `3.56.0..<4.0.0` → `3.59.3..<4.0.0`

### Changes pulled in by the native bump

- **`reloadFeatureFlags` always invokes its callback** (posthog-android #546, posthog-ios #629). Previously the native reload skipped its completion callback on the guard early-returns — SDK disabled / opted-out, blank `distinctId` (Android) / nil `remoteConfig` (iOS). Since this PR's `await` resolves from that callback, those states would otherwise hang the `Future` forever. With the bump the callback always fires, so `await reloadFeatureFlags()` is safe to await unconditionally. **This resolves the "known follow-up" the earlier version of this PR flagged as out of scope.**
- **Session replay re-arms after an in-session identity change.** On the bumped versions the native SDKs restart session recording when the session id rotates mid-session (after `identify()` / `reset()`) without an app restart — the second half of the support ticket. The Dart `await` fix is the prerequisite; this bump carries the native half.

## :green_heart: How did you test it?

Built the example app against the bumped versions and ran the documented in-session flow on real targets with `config.debug = true`.

**Android — Pixel 4 (Android 13), posthog-android 3.47.2:**
- `await reloadFeatureFlags()` ordering is now `BEFORE await` → `[PostHog] Feature flags loaded!` → `AFTER await (117ms)` — the `Future` resolves *after* the native `onFeatureFlags` callback and a real network round-trip (previously ~0ms, before the callback).
- In-session `reset()` → `identify()` → `reloadFeatureFlags()` → `startSessionRecording()`: `isSessionReplayActive() == true`, log shows `[Session Replay] Session changed. Re-initializing recording for new session`, **7 `$snapshot`s sent under the new identity**, and **zero** `Could not start recording … disabled …` errors (the customer's Android symptom).

**iOS — iPhone 17 simulator (iOS 26.4), posthog-ios 3.59.3 (resolved via SwiftPM):**
- `await reloadFeatureFlags()` ordering: `BEFORE` → `Feature flags loaded!` → `AFTER (35ms)`.
- Same in-session identity flow: `isSessionReplayActive() == true` after `reset()` + `identify()` + reload + `startSessionRecording()`. (iOS native session-recording debug logs don't surface through the Flutter console, so this rests on the SDK's own `isSessionReplayActive()` state rather than observed snapshot traffic.)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
