### PR TITLE
chore: add Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Some files in this codebase contain code from getsentry/sentry-dart by Sentry.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+
+MIT License
+
+Copyright (c) 2020 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
+++ b/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 import 'package:flutter/foundation.dart';
 import 'package:posthog_flutter/src/util/logging.dart';
 import 'package:stack_trace/stack_trace.dart';

--- a/posthog_flutter/lib/src/error_tracking/isolate_handler_io.dart
+++ b/posthog_flutter/lib/src/error_tracking/isolate_handler_io.dart
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 import 'dart:isolate';
 
 // ignore: unnecessary_import

--- a/posthog_flutter/lib/src/error_tracking/origin.dart
+++ b/posthog_flutter/lib/src/error_tracking/origin.dart
@@ -1,1 +1,4 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 export 'origin_io.dart' if (dart.library.js_interop) 'origin_web.dart';

--- a/posthog_flutter/lib/src/error_tracking/origin_io.dart
+++ b/posthog_flutter/lib/src/error_tracking/origin_io.dart
@@ -1,2 +1,5 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 /// request origin, empty out of browser context
 String eventOrigin = '';

--- a/posthog_flutter/lib/src/error_tracking/origin_web.dart
+++ b/posthog_flutter/lib/src/error_tracking/origin_web.dart
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 import 'package:web/web.dart';
 
 /// request origin, used for browser stacktrace

--- a/posthog_flutter/lib/src/error_tracking/posthog_error_tracking_autocapture_integration.dart
+++ b/posthog_flutter/lib/src/error_tracking/posthog_error_tracking_autocapture_integration.dart
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';

--- a/posthog_flutter/lib/src/error_tracking/utils/_io_isolate_utils.dart
+++ b/posthog_flutter/lib/src/error_tracking/utils/_io_isolate_utils.dart
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 import 'dart:isolate';
 import 'package:flutter/services.dart';
 

--- a/posthog_flutter/lib/src/error_tracking/utils/isolate_utils.dart
+++ b/posthog_flutter/lib/src/error_tracking/utils/isolate_utils.dart
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-dart by Sentry
+// Licensed under the MIT License
+
 import '_io_isolate_utils.dart'
     if (dart.library.js_interop) '_web_isolate_utils.dart' as platform;
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some error tracking files include code derived from getsentry/sentry-dart. This adds explicit attribution in those file headers and includes the relevant Sentry MIT license text in the repository license file.

## :green_heart: How did you test it?

Not run (license/header-only change).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
