### PR TITLE
chore: clarify Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,7 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-dart by Sentry.
+Some files in this codebase contain code from getsentry/sentry-dart.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License

--- a/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
+++ b/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 import 'package:flutter/foundation.dart';
 import 'package:posthog_flutter/src/util/logging.dart';

--- a/posthog_flutter/lib/src/error_tracking/isolate_handler_io.dart
+++ b/posthog_flutter/lib/src/error_tracking/isolate_handler_io.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 import 'dart:isolate';
 

--- a/posthog_flutter/lib/src/error_tracking/origin.dart
+++ b/posthog_flutter/lib/src/error_tracking/origin.dart
@@ -1,4 +1,5 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 export 'origin_io.dart' if (dart.library.js_interop) 'origin_web.dart';

--- a/posthog_flutter/lib/src/error_tracking/origin_io.dart
+++ b/posthog_flutter/lib/src/error_tracking/origin_io.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 /// request origin, empty out of browser context
 String eventOrigin = '';

--- a/posthog_flutter/lib/src/error_tracking/origin_web.dart
+++ b/posthog_flutter/lib/src/error_tracking/origin_web.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 import 'package:web/web.dart';
 

--- a/posthog_flutter/lib/src/error_tracking/posthog_error_tracking_autocapture_integration.dart
+++ b/posthog_flutter/lib/src/error_tracking/posthog_error_tracking_autocapture_integration.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 import 'dart:ui';
 

--- a/posthog_flutter/lib/src/error_tracking/utils/_io_isolate_utils.dart
+++ b/posthog_flutter/lib/src/error_tracking/utils/_io_isolate_utils.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 import 'dart:isolate';
 import 'package:flutter/services.dart';

--- a/posthog_flutter/lib/src/error_tracking/utils/isolate_utils.dart
+++ b/posthog_flutter/lib/src/error_tracking/utils/isolate_utils.dart
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-dart by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-dart
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
 import '_io_isolate_utils.dart'
     if (dart.library.js_interop) '_web_isolate_utils.dart' as platform;


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clarifies attribution for PostHog error tracking files that include code derived from getsentry/sentry-dart.

## :green_heart: How did you test it?

Not run; changes only update license attribution comments and the LICENSE notice.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
