### PR TITLE
feat: person & group properties for feature flag evaluation

### DIFF
--- a/.changeset/person-group-properties-for-flags.md
+++ b/.changeset/person-group-properties-for-flags.md
@@ -1,0 +1,15 @@
+---
+"posthog_flutter": minor
+---
+
+Add `setPersonPropertiesForFlags`, `resetPersonPropertiesForFlags`, `setGroupPropertiesForFlags`, and `resetGroupPropertiesForFlags`, bringing the Flutter SDK to parity with the native iOS/Android and JS SDKs.
+
+These set person/group properties that are sent inline with the next feature flag evaluation request, so flags targeting those properties can be evaluated immediately — without enqueuing a `$set` event or waiting for it to be ingested into the person store. By default they reload feature flags and the returned `Future` completes only after the reload finishes, so the next `getFeatureFlag`/`getFeatureFlagResult` reflects the updated properties. Pass `reloadFeatureFlags: false` to skip the reload.
+
+```dart
+await Posthog().setPersonPropertiesForFlags({
+  "storefront_country": "US",
+  "superwall_demand_score": 88,
+});
+final result = await Posthog().getFeatureFlagResult("my_flag");
+```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -272,9 +272,10 @@ class InitialScreenState extends State<InitialScreen> {
                 ),
                 ElevatedButton(
                   onPressed: () async {
-                    await _posthogFlutterPlugin.setPersonPropertiesForFlags(
-                      {"storefront_country": "US", "demand_score": 88},
-                    );
+                    await _posthogFlutterPlugin.setPersonPropertiesForFlags({
+                      "storefront_country": "US",
+                      "demand_score": 88,
+                    });
                   },
                   child: const Text("Set person properties for flags"),
                 ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -272,6 +272,35 @@ class InitialScreenState extends State<InitialScreen> {
                 ),
                 ElevatedButton(
                   onPressed: () async {
+                    await _posthogFlutterPlugin.setPersonPropertiesForFlags(
+                      {"storefront_country": "US", "demand_score": 88},
+                    );
+                  },
+                  child: const Text("Set person properties for flags"),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    await _posthogFlutterPlugin.resetPersonPropertiesForFlags();
+                  },
+                  child: const Text("Reset person properties for flags"),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    await _posthogFlutterPlugin.setGroupPropertiesForFlags(
+                      "theType",
+                      {"is_enterprise": true},
+                    );
+                  },
+                  child: const Text("Set group properties for flags"),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    await _posthogFlutterPlugin.resetGroupPropertiesForFlags();
+                  },
+                  child: const Text("Reset group properties for flags"),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
                     await _posthogFlutterPlugin.identify(
                       userId: "myId",
                       userProperties: {"foo": "bar"},

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -158,6 +158,22 @@ class PosthogFlutterPlugin :
                 reloadFeatureFlags(result)
             }
 
+            "setPersonPropertiesForFlags" -> {
+                setPersonPropertiesForFlags(call, result)
+            }
+
+            "resetPersonPropertiesForFlags" -> {
+                resetPersonPropertiesForFlags(result)
+            }
+
+            "setGroupPropertiesForFlags" -> {
+                setGroupPropertiesForFlags(call, result)
+            }
+
+            "resetGroupPropertiesForFlags" -> {
+                resetGroupPropertiesForFlags(call, result)
+            }
+
             "group" -> {
                 group(call, result)
             }
@@ -636,6 +652,57 @@ class PosthogFlutterPlugin :
                     result.success(null)
                 }
             }
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    // reloadFeatureFlags is handled on the Dart side (so the Future resolves only
+    // after the awaited reload completes), so we always disable the native reload.
+    private fun setPersonPropertiesForFlags(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val userProperties: Map<String, Any> = call.argument("userProperties")!!
+            PostHog.setPersonPropertiesForFlags(userProperties, reloadFeatureFlags = false)
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun resetPersonPropertiesForFlags(result: Result) {
+        try {
+            PostHog.resetPersonPropertiesForFlags(reloadFeatureFlags = false)
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun setGroupPropertiesForFlags(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val groupType: String = call.argument("groupType")!!
+            val groupProperties: Map<String, Any> = call.argument("groupProperties")!!
+            PostHog.setGroupPropertiesForFlags(groupType, groupProperties, reloadFeatureFlags = false)
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun resetGroupPropertiesForFlags(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val groupType: String? = call.argument("groupType")
+            PostHog.resetGroupPropertiesForFlags(groupType, reloadFeatureFlags = false)
+            result.success(null)
         } catch (e: Throwable) {
             result.error("PosthogFlutterException", e.localizedMessage, null)
         }

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -255,6 +255,14 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             debug(call, result: result)
         case "reloadFeatureFlags":
             reloadFeatureFlags(result)
+        case "setPersonPropertiesForFlags":
+            setPersonPropertiesForFlags(call, result: result)
+        case "resetPersonPropertiesForFlags":
+            resetPersonPropertiesForFlags(result)
+        case "setGroupPropertiesForFlags":
+            setGroupPropertiesForFlags(call, result: result)
+        case "resetGroupPropertiesForFlags":
+            resetGroupPropertiesForFlags(call, result: result)
         case "group":
             group(call, result: result)
         case "register":
@@ -772,6 +780,55 @@ extension PosthogFlutterPlugin {
                 result(nil)
             }
         }
+    }
+
+    // reloadFeatureFlags is handled on the Dart side (so the Future resolves only
+    // after the awaited reload completes), so we always disable the native reload.
+    private func setPersonPropertiesForFlags(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        if let args = call.arguments as? [String: Any],
+           let userProperties = args["userProperties"] as? [String: Any]
+        {
+            PostHogSDK.shared.setPersonPropertiesForFlags(userProperties, reloadFeatureFlags: false)
+            result(nil)
+        } else {
+            _badArgumentError(result)
+        }
+    }
+
+    private func resetPersonPropertiesForFlags(_ result: @escaping FlutterResult) {
+        PostHogSDK.shared.resetPersonPropertiesForFlags(reloadFeatureFlags: false)
+        result(nil)
+    }
+
+    private func setGroupPropertiesForFlags(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        if let args = call.arguments as? [String: Any],
+           let groupType = args["groupType"] as? String,
+           let groupProperties = args["groupProperties"] as? [String: Any]
+        {
+            PostHogSDK.shared.setGroupPropertiesForFlags(groupType, properties: groupProperties, reloadFeatureFlags: false)
+            result(nil)
+        } else {
+            _badArgumentError(result)
+        }
+    }
+
+    private func resetGroupPropertiesForFlags(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        let groupType = (call.arguments as? [String: Any])?["groupType"] as? String
+        if let groupType = groupType {
+            PostHogSDK.shared.resetGroupPropertiesForFlags(groupType, reloadFeatureFlags: false)
+        } else {
+            PostHogSDK.shared.resetGroupPropertiesForFlags(reloadFeatureFlags: false)
+        }
+        result(nil)
     }
 
     private func group(

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -235,6 +235,46 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
   }
 
   @override
+  Future<void> setPersonPropertiesForFlags(
+    Map<String, Object> userProperties,
+  ) async {
+    return handleWebMethodCall(
+      MethodCall('setPersonPropertiesForFlags', {
+        'userProperties': userProperties,
+      }),
+    );
+  }
+
+  @override
+  Future<void> resetPersonPropertiesForFlags() async {
+    return handleWebMethodCall(
+      const MethodCall('resetPersonPropertiesForFlags'),
+    );
+  }
+
+  @override
+  Future<void> setGroupPropertiesForFlags(
+    String groupType,
+    Map<String, Object> groupProperties,
+  ) async {
+    return handleWebMethodCall(
+      MethodCall('setGroupPropertiesForFlags', {
+        'groupType': groupType,
+        'groupProperties': groupProperties,
+      }),
+    );
+  }
+
+  @override
+  Future<void> resetGroupPropertiesForFlags({String? groupType}) async {
+    return handleWebMethodCall(
+      MethodCall('resetGroupPropertiesForFlags', {
+        if (groupType != null) 'groupType': groupType,
+      }),
+    );
+  }
+
+  @override
   Future<void> group({
     required String groupType,
     required String groupKey,

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -312,6 +312,118 @@ class Posthog {
   /// Returns a [Future] that completes when the reload request has been queued.
   Future<void> reloadFeatureFlags() => _posthog.reloadFeatureFlags();
 
+  /// Sets person properties that are used only for feature flag evaluation.
+  ///
+  /// Docs: https://posthog.com/docs/feature-flags
+  ///
+  /// Unlike [setPersonProperties], this does **not** enqueue a `$set` event. The
+  /// properties are sent inline with the next feature flag evaluation request,
+  /// so flags that target these properties can be evaluated immediately without
+  /// waiting for the `$set` event to be ingested into the person store.
+  ///
+  /// The [userProperties] are merged with any previously set values; matching
+  /// keys are overwritten. If [userProperties] is empty, this is a no-op.
+  ///
+  /// Set [reloadFeatureFlags] to `false` to skip reloading flags after updating
+  /// the properties (defaults to `true`). When `true`, the returned [Future]
+  /// awaits the reload before completing; on iOS and Android this means flags
+  /// have finished loading, so the next [getFeatureFlag] / [getFeatureFlagResult]
+  /// reflects the updated properties. On web the reload is best-effort.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// await Posthog().setPersonPropertiesForFlags({
+  ///   "storefront_country": "US",
+  ///   "superwall_demand_score": 88,
+  /// });
+  /// final result = await Posthog().getFeatureFlagResult("my_flag");
+  /// ```
+  Future<void> setPersonPropertiesForFlags(
+    Map<String, Object> userProperties, {
+    bool reloadFeatureFlags = true,
+  }) async {
+    if (userProperties.isEmpty) {
+      return;
+    }
+    await _posthog.setPersonPropertiesForFlags(userProperties);
+    if (reloadFeatureFlags) {
+      await this.reloadFeatureFlags();
+    }
+  }
+
+  /// Clears all person properties that were set for feature flag evaluation via
+  /// [setPersonPropertiesForFlags].
+  ///
+  /// Set [reloadFeatureFlags] to `false` to skip reloading flags after clearing
+  /// the properties (defaults to `true`). When `true`, the returned [Future]
+  /// awaits the reload before completing (on iOS/Android, after flags finish
+  /// loading; on web, best-effort).
+  Future<void> resetPersonPropertiesForFlags({
+    bool reloadFeatureFlags = true,
+  }) async {
+    await _posthog.resetPersonPropertiesForFlags();
+    if (reloadFeatureFlags) {
+      await this.reloadFeatureFlags();
+    }
+  }
+
+  /// Sets properties for a specific [groupType] that are used only for feature
+  /// flag evaluation.
+  ///
+  /// The properties are sent inline with the next feature flag evaluation
+  /// request, so flags that target group properties can be evaluated without
+  /// waiting for ingestion.
+  ///
+  /// The [groupProperties] are merged with any previously set values for the
+  /// same [groupType]; matching keys are overwritten. If [groupProperties] is
+  /// empty, this is a no-op.
+  ///
+  /// Set [reloadFeatureFlags] to `false` to skip reloading flags after updating
+  /// the properties (defaults to `true`). When `true`, the returned [Future]
+  /// awaits the reload before completing (on iOS/Android, after flags finish
+  /// loading; on web, best-effort).
+  ///
+  /// **Example:**
+  /// ```dart
+  /// await Posthog().setGroupPropertiesForFlags(
+  ///   "organization",
+  ///   {"name": "ACME Corp", "is_enterprise": true},
+  /// );
+  /// ```
+  Future<void> setGroupPropertiesForFlags(
+    String groupType,
+    Map<String, Object> groupProperties, {
+    bool reloadFeatureFlags = true,
+  }) async {
+    if (groupProperties.isEmpty) {
+      return;
+    }
+    await _posthog.setGroupPropertiesForFlags(groupType, groupProperties);
+    if (reloadFeatureFlags) {
+      await this.reloadFeatureFlags();
+    }
+  }
+
+  /// Clears group properties that were set for feature flag evaluation via
+  /// [setGroupPropertiesForFlags].
+  ///
+  /// If [groupType] is provided, only properties for that group type are
+  /// cleared; otherwise all group properties are cleared.
+  ///
+  /// Set [reloadFeatureFlags] to `false` to skip reloading flags after clearing
+  /// the properties (defaults to `true`). When `true`, the returned [Future]
+  /// awaits the reload before completing (on iOS/Android, after flags finish
+  /// loading; on web, best-effort).
+  Future<void> resetGroupPropertiesForFlags({
+    String? groupType,
+    bool reloadFeatureFlags = true,
+  }) async {
+    await _posthog.resetGroupPropertiesForFlags(groupType: groupType);
+    if (reloadFeatureFlags) {
+      await this.reloadFeatureFlags();
+    }
+  }
+
   /// Associates the current user with a group.
   ///
   /// Docs: https://posthog.com/docs/product-analytics/group-analytics

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -494,6 +494,76 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   }
 
   @override
+  Future<void> setPersonPropertiesForFlags(
+    Map<String, Object> userProperties,
+  ) async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      final normalizedUserProperties =
+          PropertyNormalizer.normalize(userProperties);
+
+      await _methodChannel.invokeMethod('setPersonPropertiesForFlags', {
+        'userProperties': normalizedUserProperties,
+      });
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on setPersonPropertiesForFlags: $exception');
+    }
+  }
+
+  @override
+  Future<void> resetPersonPropertiesForFlags() async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      await _methodChannel.invokeMethod('resetPersonPropertiesForFlags');
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on resetPersonPropertiesForFlags: $exception');
+    }
+  }
+
+  @override
+  Future<void> setGroupPropertiesForFlags(
+    String groupType,
+    Map<String, Object> groupProperties,
+  ) async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      final normalizedGroupProperties =
+          PropertyNormalizer.normalize(groupProperties);
+
+      await _methodChannel.invokeMethod('setGroupPropertiesForFlags', {
+        'groupType': groupType,
+        'groupProperties': normalizedGroupProperties,
+      });
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on setGroupPropertiesForFlags: $exception');
+    }
+  }
+
+  @override
+  Future<void> resetGroupPropertiesForFlags({String? groupType}) async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      await _methodChannel.invokeMethod('resetGroupPropertiesForFlags', {
+        if (groupType != null) 'groupType': groupType,
+      });
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on resetGroupPropertiesForFlags: $exception');
+    }
+  }
+
+  @override
   Future<void> group({
     required String groupType,
     required String groupKey,

--- a/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
@@ -115,6 +115,33 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
     throw UnimplementedError('reloadFeatureFlags() has not been implemented.');
   }
 
+  Future<void> setPersonPropertiesForFlags(Map<String, Object> userProperties) {
+    throw UnimplementedError(
+      'setPersonPropertiesForFlags() has not been implemented.',
+    );
+  }
+
+  Future<void> resetPersonPropertiesForFlags() {
+    throw UnimplementedError(
+      'resetPersonPropertiesForFlags() has not been implemented.',
+    );
+  }
+
+  Future<void> setGroupPropertiesForFlags(
+    String groupType,
+    Map<String, Object> groupProperties,
+  ) {
+    throw UnimplementedError(
+      'setGroupPropertiesForFlags() has not been implemented.',
+    );
+  }
+
+  Future<void> resetGroupPropertiesForFlags({String? groupType}) {
+    throw UnimplementedError(
+      'resetGroupPropertiesForFlags() has not been implemented.',
+    );
+  }
+
   Future<void> showSurvey(Map<String, dynamic> survey) {
     throw UnimplementedError('showSurvey() has not been implemented.');
   }

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -32,6 +32,16 @@ extension PostHogExtension on PostHog {
     JSAny? userPropertiesToSet,
     JSAny? userPropertiesToSetOnce,
   );
+  external void setPersonPropertiesForFlags(
+    JSAny properties,
+    JSAny reloadFeatureFlags,
+  );
+  external void resetPersonPropertiesForFlags();
+  external void setGroupPropertiesForFlags(
+    JSAny properties,
+    JSAny reloadFeatureFlags,
+  );
+  external void resetGroupPropertiesForFlags(JSAny? groupType);
   // ignore: non_constant_identifier_names
   external void opt_in_capturing();
   // ignore: non_constant_identifier_names
@@ -229,6 +239,33 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       break;
     case 'reloadFeatureFlags':
       posthog?.reloadFeatureFlags();
+      break;
+    case 'setPersonPropertiesForFlags':
+      final userProperties = safeMapConversion(args['userProperties']);
+      // reload is orchestrated by the Dart layer, so disable it here.
+      posthog?.setPersonPropertiesForFlags(
+        mapToJSAny(userProperties),
+        boolToJSAny(false),
+      );
+      break;
+    case 'resetPersonPropertiesForFlags':
+      posthog?.resetPersonPropertiesForFlags();
+      break;
+    case 'setGroupPropertiesForFlags':
+      final groupType = args['groupType'] as String;
+      final groupProperties = safeMapConversion(args['groupProperties']);
+      // posthog-js expects an object keyed by group type.
+      // reload is orchestrated by the Dart layer, so disable it here.
+      posthog?.setGroupPropertiesForFlags(
+        mapToJSAny({groupType: groupProperties}),
+        boolToJSAny(false),
+      );
+      break;
+    case 'resetGroupPropertiesForFlags':
+      final groupType = args['groupType'] as String?;
+      posthog?.resetGroupPropertiesForFlags(
+        groupType != null ? stringToJSAny(groupType) : null,
+      );
       break;
     case 'enable':
       posthog?.opt_in_capturing();

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -239,6 +239,84 @@ void main() {
     });
   });
 
+  group('PosthogFlutterIO properties for flags', () {
+    test('setPersonPropertiesForFlags sends userProperties', () async {
+      testConfig = PostHogConfig('test_project_token');
+      await posthogFlutterIO.setup(testConfig);
+
+      await posthogFlutterIO.setPersonPropertiesForFlags({
+        'storefront_country': 'US',
+        'superwall_demand_score': 88,
+      });
+
+      final call =
+          log.firstWhere((c) => c.method == 'setPersonPropertiesForFlags');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['userProperties'], {
+        'storefront_country': 'US',
+        'superwall_demand_score': 88,
+      });
+    });
+
+    test('resetPersonPropertiesForFlags sends method channel call', () async {
+      testConfig = PostHogConfig('test_project_token');
+      await posthogFlutterIO.setup(testConfig);
+
+      await posthogFlutterIO.resetPersonPropertiesForFlags();
+
+      expect(
+        log.any((c) => c.method == 'resetPersonPropertiesForFlags'),
+        isTrue,
+      );
+    });
+
+    test('setGroupPropertiesForFlags sends groupType and properties', () async {
+      testConfig = PostHogConfig('test_project_token');
+      await posthogFlutterIO.setup(testConfig);
+
+      await posthogFlutterIO.setGroupPropertiesForFlags(
+        'organization',
+        {'name': 'ACME Corp', 'is_enterprise': true},
+      );
+
+      final call =
+          log.firstWhere((c) => c.method == 'setGroupPropertiesForFlags');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['groupType'], 'organization');
+      expect(args['groupProperties'], {
+        'name': 'ACME Corp',
+        'is_enterprise': true,
+      });
+    });
+
+    test('resetGroupPropertiesForFlags includes groupType when provided',
+        () async {
+      testConfig = PostHogConfig('test_project_token');
+      await posthogFlutterIO.setup(testConfig);
+
+      await posthogFlutterIO.resetGroupPropertiesForFlags(
+        groupType: 'organization',
+      );
+
+      final call =
+          log.firstWhere((c) => c.method == 'resetGroupPropertiesForFlags');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['groupType'], 'organization');
+    });
+
+    test('resetGroupPropertiesForFlags omits groupType when null', () async {
+      testConfig = PostHogConfig('test_project_token');
+      await posthogFlutterIO.setup(testConfig);
+
+      await posthogFlutterIO.resetGroupPropertiesForFlags();
+
+      final call =
+          log.firstWhere((c) => c.method == 'resetGroupPropertiesForFlags');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args.containsKey('groupType'), isFalse);
+    });
+  });
+
   group('PosthogFlutterIO beforeSend callback', () {
     test(
       'capture sends event unchanged when no beforeSend registered',

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -240,10 +240,12 @@ void main() {
   });
 
   group('PosthogFlutterIO properties for flags', () {
-    test('setPersonPropertiesForFlags sends userProperties', () async {
+    setUp(() async {
       testConfig = PostHogConfig('test_project_token');
       await posthogFlutterIO.setup(testConfig);
+    });
 
+    test('setPersonPropertiesForFlags sends userProperties', () async {
       await posthogFlutterIO.setPersonPropertiesForFlags({
         'storefront_country': 'US',
         'superwall_demand_score': 88,
@@ -259,9 +261,6 @@ void main() {
     });
 
     test('resetPersonPropertiesForFlags sends method channel call', () async {
-      testConfig = PostHogConfig('test_project_token');
-      await posthogFlutterIO.setup(testConfig);
-
       await posthogFlutterIO.resetPersonPropertiesForFlags();
 
       expect(
@@ -271,9 +270,6 @@ void main() {
     });
 
     test('setGroupPropertiesForFlags sends groupType and properties', () async {
-      testConfig = PostHogConfig('test_project_token');
-      await posthogFlutterIO.setup(testConfig);
-
       await posthogFlutterIO.setGroupPropertiesForFlags(
         'organization',
         {'name': 'ACME Corp', 'is_enterprise': true},
@@ -291,9 +287,6 @@ void main() {
 
     test('resetGroupPropertiesForFlags includes groupType when provided',
         () async {
-      testConfig = PostHogConfig('test_project_token');
-      await posthogFlutterIO.setup(testConfig);
-
       await posthogFlutterIO.resetGroupPropertiesForFlags(
         groupType: 'organization',
       );
@@ -305,9 +298,6 @@ void main() {
     });
 
     test('resetGroupPropertiesForFlags omits groupType when null', () async {
-      testConfig = PostHogConfig('test_project_token');
-      await posthogFlutterIO.setup(testConfig);
-
       await posthogFlutterIO.resetGroupPropertiesForFlags();
 
       final call =

--- a/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
+++ b/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
@@ -31,6 +31,46 @@ class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
   // Call tracking for getFeatureFlagResult
   final List<Map<String, dynamic>> getFeatureFlagResultCalls = [];
 
+  // Call tracking for properties-for-flags + reload
+  int reloadFeatureFlagsCount = 0;
+  final List<Map<String, Object>> setPersonPropertiesForFlagsCalls = [];
+  int resetPersonPropertiesForFlagsCount = 0;
+  final List<Map<String, dynamic>> setGroupPropertiesForFlagsCalls = [];
+  final List<String?> resetGroupPropertiesForFlagsCalls = [];
+
+  @override
+  Future<void> reloadFeatureFlags() async {
+    reloadFeatureFlagsCount++;
+  }
+
+  @override
+  Future<void> setPersonPropertiesForFlags(
+    Map<String, Object> userProperties,
+  ) async {
+    setPersonPropertiesForFlagsCalls.add(userProperties);
+  }
+
+  @override
+  Future<void> resetPersonPropertiesForFlags() async {
+    resetPersonPropertiesForFlagsCount++;
+  }
+
+  @override
+  Future<void> setGroupPropertiesForFlags(
+    String groupType,
+    Map<String, Object> groupProperties,
+  ) async {
+    setGroupPropertiesForFlagsCalls.add({
+      'groupType': groupType,
+      'groupProperties': groupProperties,
+    });
+  }
+
+  @override
+  Future<void> resetGroupPropertiesForFlags({String? groupType}) async {
+    resetGroupPropertiesForFlagsCalls.add(groupType);
+  }
+
   @override
   Future<void> screen({
     required String screenName,

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -416,7 +416,8 @@ void main() {
       expect(fake.reloadFeatureFlagsCount, 1);
     });
 
-    test('setPersonPropertiesForFlags skips reload when reloadFeatureFlags=false',
+    test(
+        'setPersonPropertiesForFlags skips reload when reloadFeatureFlags=false',
         () async {
       await Posthog().setPersonPropertiesForFlags(
         {'country': 'US'},

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -396,4 +396,88 @@ void main() {
       expect(result!.enabled, isFalse);
     });
   });
+
+  group('Posthog properties for flags', () {
+    late PosthogFlutterPlatformFake fake;
+
+    setUp(() async {
+      fake = PosthogFlutterPlatformFake();
+      PosthogFlutterPlatformInterface.instance = fake;
+      await Posthog().close();
+    });
+
+    test('setPersonPropertiesForFlags sets props and reloads by default',
+        () async {
+      await Posthog().setPersonPropertiesForFlags({'country': 'US'});
+
+      expect(fake.setPersonPropertiesForFlagsCalls, [
+        {'country': 'US'},
+      ]);
+      expect(fake.reloadFeatureFlagsCount, 1);
+    });
+
+    test('setPersonPropertiesForFlags skips reload when reloadFeatureFlags=false',
+        () async {
+      await Posthog().setPersonPropertiesForFlags(
+        {'country': 'US'},
+        reloadFeatureFlags: false,
+      );
+
+      expect(fake.setPersonPropertiesForFlagsCalls.length, 1);
+      expect(fake.reloadFeatureFlagsCount, 0);
+    });
+
+    test('setPersonPropertiesForFlags is a no-op for empty map', () async {
+      await Posthog().setPersonPropertiesForFlags({});
+
+      expect(fake.setPersonPropertiesForFlagsCalls, isEmpty);
+      expect(fake.reloadFeatureFlagsCount, 0);
+    });
+
+    test('resetPersonPropertiesForFlags resets and reloads by default',
+        () async {
+      await Posthog().resetPersonPropertiesForFlags();
+
+      expect(fake.resetPersonPropertiesForFlagsCount, 1);
+      expect(fake.reloadFeatureFlagsCount, 1);
+    });
+
+    test('setGroupPropertiesForFlags passes groupType and reloads', () async {
+      await Posthog().setGroupPropertiesForFlags(
+        'organization',
+        {'name': 'ACME'},
+      );
+
+      expect(fake.setGroupPropertiesForFlagsCalls, [
+        {
+          'groupType': 'organization',
+          'groupProperties': {'name': 'ACME'},
+        },
+      ]);
+      expect(fake.reloadFeatureFlagsCount, 1);
+    });
+
+    test('setGroupPropertiesForFlags is a no-op for empty map', () async {
+      await Posthog().setGroupPropertiesForFlags('organization', {});
+
+      expect(fake.setGroupPropertiesForFlagsCalls, isEmpty);
+      expect(fake.reloadFeatureFlagsCount, 0);
+    });
+
+    test('resetGroupPropertiesForFlags forwards groupType and reloads',
+        () async {
+      await Posthog().resetGroupPropertiesForFlags(groupType: 'organization');
+
+      expect(fake.resetGroupPropertiesForFlagsCalls, ['organization']);
+      expect(fake.reloadFeatureFlagsCount, 1);
+    });
+
+    test('resetGroupPropertiesForFlags forwards null when groupType omitted',
+        () async {
+      await Posthog().resetGroupPropertiesForFlags(reloadFeatureFlags: false);
+
+      expect(fake.resetGroupPropertiesForFlagsCalls, [null]);
+      expect(fake.reloadFeatureFlagsCount, 0);
+    });
+  });
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

https://posthog.slack.com/archives/C0ACMS2BNTU/p1780680135233249

Brings the Flutter SDK to parity with the native iOS/Android and JS SDKs by exposing the "properties for flags" APIs that were already in the underlying native SDKs but not bridged.

These let you set person/group properties that ride **inline** with the next feature-flag evaluation request. Flags that target those properties evaluate immediately, without waiting for a `$set` event to be ingested into the person store. This fixes the common "set a property, reload flags, still get the stale variant" race on mobile.

Adds four methods:
- `setPersonPropertiesForFlags(props, {reloadFeatureFlags})`
- `resetPersonPropertiesForFlags({reloadFeatureFlags})`
- `setGroupPropertiesForFlags(groupType, props, {reloadFeatureFlags})`
- `resetGroupPropertiesForFlags({groupType, reloadFeatureFlags})`

All default `reloadFeatureFlags` to `true`.

## :green_heart: How did you test it?

- New unit tests for the Dart facade (`posthog_test.dart`): reload-on-by-default, `reloadFeatureFlags: false` skip, empty-map no-op, group passthrough, and `groupType` null/value.
- New method-channel tests (`posthog_flutter_io_test.dart`) asserting the args sent to native for all four methods.
- `flutter analyze` clean; example app updated with buttons to exercise each method.

Implementation note: `reloadFeatureFlags` is orchestrated in the Dart layer — the native/JS bridges are always called with reload disabled, then `reloadFeatureFlags()` is awaited from Dart. This means `await setPersonPropertiesForFlags(...)` resolves only after flags finish reloading on iOS/Android (#409). Web stays best-effort, since posthog-js `reloadFeatureFlags()` is fire-and-forget. Native minimums on `main` (android 3.47.2 / iOS 3.59.3) already include these methods, so no pin bump is needed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
