### PR TITLE
chore: gate pub.dev publishing behind release environment

### DIFF
--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -15,6 +15,7 @@ jobs:
   publish:
     name: Publish to pub.dev
     runs-on: ubuntu-latest
+    environment: 'Release' # pub.dev trusted publishing is tag-triggered, so gate this publishing job too.
     permissions:
       contents: write
       id-token: write # Required for authentication using OIDC

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,14 +28,20 @@ No release label is required. When the PR is merged to `main`, the release workf
 
 1. Check for changesets
 2. Notify the client libraries team in Slack for approval
-3. Wait for approval from a maintainer (via GitHub environment protection)
+3. Wait for the first approval from a maintainer (via GitHub `Release` environment protection)
 4. Once approved:
    - Apply changesets and bump the version
    - Update the CHANGELOG.md
    - Sync the version to `pubspec.yaml`, iOS (`PostHogFlutterVersion.swift`), and Android (`PostHogVersion.kt`)
    - Commit the version bump to `main`
+   - Create and push the release tag
+5. The tag-triggered pub.dev publish workflow starts from that release tag
+6. Wait for the second approval from a maintainer (via GitHub `Release` environment protection)
+7. Once approved:
    - Publish the package to pub.dev
-   - Create a git tag and GitHub release
+   - Create the GitHub release
+
+Flutter releases require two `Release` environment approvals because pub.dev trusted publishing only allows publishing from GitHub tag workflows. The first approval gates the version bump and tag creation; the second approval gates the tag-triggered pub.dev publish job.
 
 ### Manual Trigger
 
@@ -67,6 +73,8 @@ pnpm changeset pre exit
 ## pub.dev Package
 
 The package is published as [`posthog_flutter`](https://pub.dev/packages/posthog_flutter) on pub.dev.
+
+Release tags are protected by a GitHub tag ruleset: https://github.com/PostHog/posthog-flutter/settings/rules/11273241. This ensures tag-triggered pub.dev publishing can only happen from protected release tags created by the approved release process.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## :bulb: Motivation and Context

pub.dev trusted publishing requires publishing from a GitHub tag workflow. To keep that compatible while preserving the release approval gate, the tag-triggered pub.dev publish job now also uses the `Release` environment.

## :green_heart: How did you test it?

- Parsed the changed workflow YAML with Python/PyYAML.
- Ran `git diff --check`.
- Confirmed the branch contains the latest `origin/main` before opening this draft PR.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
