### PR TITLE
feat: add logs API (captureLog + logger facade)

### DIFF
--- a/.changeset/logs-api.md
+++ b/.changeset/logs-api.md
@@ -12,6 +12,8 @@ Posthog().logger.error('payment failed', {'error_code': 'E001'});
 await Posthog().captureLog(body: 'request finished', level: PostHogLogSeverity.warn);
 ```
 
-Levels: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. Configure service identity, redaction (`beforeSend`), and batching/rate-cap tuning on `config.logs` — all optional, with sensible native defaults. Works on iOS, Android, and web.
+Levels: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. Configure service identity, redaction (`beforeSend`), and batching/rate-cap tuning on `config.logsConfig` — all optional, with sensible native defaults. Works on iOS, Android, and web.
+
+Requires `posthog-android` `3.48.0` or newer.
 
 See https://posthog.com/docs/logs for details.

--- a/.changeset/logs-api.md
+++ b/.changeset/logs-api.md
@@ -2,47 +2,16 @@
 "posthog_flutter": minor
 ---
 
-Add structured logging. You can now send logs to PostHog from your Flutter app and see them next to your events and session replays — great for debugging what actually happened in production.
-
-Use `logger` for everyday logging:
+Add structured logging. Send logs to PostHog from your Flutter app and see them next to your events and session replays.
 
 ```dart
 Posthog().logger.info('checkout completed', {'order_id': 'ord_789'});
-Posthog().logger.warn('retrying payment', {'attempt': 2});
 Posthog().logger.error('payment failed', {'error_code': 'E001'});
+
+// Or pick the level at runtime:
+await Posthog().captureLog(body: 'request finished', level: PostHogLogSeverity.warn);
 ```
 
-Levels are `trace`, `debug`, `info`, `warn`, `error`, and `fatal`, and you can attach any JSON-friendly attributes. When you need to pick the level at runtime, use `captureLog` instead:
+Levels: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. Configure service identity, redaction (`beforeSend`), and batching/rate-cap tuning on `config.logs` — all optional, with sensible native defaults. Works on iOS, Android, and web.
 
-```dart
-await Posthog().captureLog(
-  body: 'request finished',
-  level: ok ? PostHogLogSeverity.info : PostHogLogSeverity.error,
-  attributes: {'duration_ms': 142},
-);
-```
-
-Every log is automatically tagged with the current distinct ID, session, screen, app state, and active feature flags, so you get that context for free.
-
-Configure it (everything optional — anything you skip keeps a sensible default) on `config.logs`:
-
-```dart
-config.logs
-  ..serviceName = 'checkout-app'
-  ..environment = 'production'
-  // Redact or drop logs before they leave the device:
-  ..beforeSend = [
-    (record) {
-      record.attributes?.remove('password');
-      return record;
-    },
-  ];
-```
-
-You can also tune batching and rate limiting (`flushInterval`, `flushAt`, `maxBatchSize`, `maxBufferSize`, `rateCapMaxLogs`, `rateCapWindow`) if the defaults don't suit you. Works on iOS, Android, and web.
-
-**Good to know:**
-
-- Distributed tracing: `captureLog` also accepts optional `traceId`, `spanId`, and `traceFlags` to correlate a log with a trace.
-- On Flutter web, set your log options in your own `posthog.init({...})` call (Flutter attaches to your existing posthog-js instance) — your Dart `beforeSend` still runs.
-- Android: needs `posthog-android` `3.48.0` or newer, which this package now requires for you.
+See https://posthog.com/docs/logs for details.

--- a/.changeset/logs-api.md
+++ b/.changeset/logs-api.md
@@ -1,0 +1,48 @@
+---
+"posthog_flutter": minor
+---
+
+Add structured logging. You can now send logs to PostHog from your Flutter app and see them next to your events and session replays — great for debugging what actually happened in production.
+
+Use `logger` for everyday logging:
+
+```dart
+Posthog().logger.info('checkout completed', {'order_id': 'ord_789'});
+Posthog().logger.warn('retrying payment', {'attempt': 2});
+Posthog().logger.error('payment failed', {'error_code': 'E001'});
+```
+
+Levels are `trace`, `debug`, `info`, `warn`, `error`, and `fatal`, and you can attach any JSON-friendly attributes. When you need to pick the level at runtime, use `captureLog` instead:
+
+```dart
+await Posthog().captureLog(
+  body: 'request finished',
+  level: ok ? PostHogLogSeverity.info : PostHogLogSeverity.error,
+  attributes: {'duration_ms': 142},
+);
+```
+
+Every log is automatically tagged with the current distinct ID, session, screen, app state, and active feature flags, so you get that context for free.
+
+Configure it (everything optional — anything you skip keeps a sensible default) on `config.logs`:
+
+```dart
+config.logs
+  ..serviceName = 'checkout-app'
+  ..environment = 'production'
+  // Redact or drop logs before they leave the device:
+  ..beforeSend = [
+    (record) {
+      record.attributes?.remove('password');
+      return record;
+    },
+  ];
+```
+
+You can also tune batching and rate limiting (`flushInterval`, `flushAt`, `maxBatchSize`, `maxBufferSize`, `rateCapMaxLogs`, `rateCapWindow`) if the defaults don't suit you. Works on iOS, Android, and web.
+
+**Good to know:**
+
+- Distributed tracing: `captureLog` also accepts optional `traceId`, `spanId`, and `traceFlags` to correlate a log with a trace.
+- On Flutter web, set your log options in your own `posthog.init({...})` call (Flutter attaches to your existing posthog-js instance) — your Dart `beforeSend` still runs.
+- Android: needs `posthog-android` `3.48.0` or newer, which this package now requires for you.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
         working-directory: ./posthog_flutter
         run: flutter test
 
+      # Browser-only tests (`@TestOn('browser')`) are skipped by the VM run above.
+      - name: Test (web)
+        working-directory: ./posthog_flutter
+        run: flutter test --platform chrome test/posthog_flutter_web_handler_test.dart
+
   # Apple builds (iOS and macOS) with CocoaPods and Swift Package Manager
   build-apple:
     runs-on: macos-26

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -4,10 +4,54 @@ import XCTest
 
 @testable import posthog_flutter
 
-// This demonstrates a simple unit test of the Swift portion of this plugin's implementation.
+// Unit tests of the Swift portion of this plugin's implementation.
 //
-// See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+// Mirrors the Android `PosthogFlutterPluginTest`. Run from the example app's
+// iOS test target.
+//
+// See https://developer.apple.com/documentation/xctest for more information
+// about using XCTest.
 
 class RunnerTests: XCTestCase {
+    func testCaptureLogRoutesToCaptureLogAndSucceeds() {
+        let plugin = PosthogFlutterPlugin()
 
+        let arguments: [String: Any] = [
+            "body": "checkout completed",
+            "level": "warn",
+            "attributes": ["order_id": "ord_789"],
+            "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+            "spanId": "00f067aa0ba902b7",
+            "traceFlags": 1,
+        ]
+        let call = FlutterMethodCall(methodName: "captureLog", arguments: arguments)
+
+        var resultCalled = false
+        var resultValue: Any?
+        plugin.handle(call) { value in
+            resultCalled = true
+            resultValue = value
+        }
+
+        // Routed through the public PostHogSDK.shared.captureLog (with W3C trace
+        // fields); the SDK is not set up in the test, so it no-ops and we still
+        // succeed with a nil result.
+        XCTAssertTrue(resultCalled)
+        XCTAssertNil(resultValue)
+    }
+
+    func testCaptureLogMissingBodyReturnsError() {
+        let plugin = PosthogFlutterPlugin()
+
+        let call = FlutterMethodCall(methodName: "captureLog", arguments: [String: Any]())
+
+        var resultValue: Any?
+        plugin.handle(call) { value in
+            resultValue = value
+        }
+
+        let error = resultValue as? FlutterError
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error?.code, "PosthogFlutterException")
+    }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -201,6 +201,39 @@ class InitialScreenState extends State<InitialScreen> {
                 const Padding(
                   padding: EdgeInsets.all(8.0),
                   child: Text(
+                    "Logs",
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Wrap(
+                  alignment: WrapAlignment.spaceEvenly,
+                  spacing: 8.0,
+                  runSpacing: 8.0,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        _posthogFlutterPlugin.captureLog(
+                          body: "checkout completed",
+                          level: PostHogLogSeverity.info,
+                          attributes: {"order_id": "ord_789"},
+                        );
+                      },
+                      child: const Text("Capture Log (info)"),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        _posthogFlutterPlugin.logger.error("payment failed", {
+                          "error_code": "E001",
+                        });
+                      },
+                      child: const Text("logger.error"),
+                    ),
+                  ],
+                ),
+                const Divider(),
+                const Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: Text(
                     "Activity",
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,8 +64,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.47.2 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.47.2,4.0.0]'
+        // + Version 3.48.0 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.48.0,4.0.0]'
     }
 
     testOptions {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -15,6 +15,7 @@ import com.posthog.PostHogOnFeatureFlags
 import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.internal.getApplicationInfo
+import com.posthog.logs.PostHogLogSeverity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -124,6 +125,10 @@ class PosthogFlutterPlugin :
 
             "screen" -> {
                 screen(call, result)
+            }
+
+            "captureLog" -> {
+                captureLog(call, result)
             }
 
             "alias" -> {
@@ -401,6 +406,41 @@ class PosthogFlutterPlugin :
                     }
                 }
 
+                // Configure logs (beforeSend runs Dart-side). Each field is only
+                // present when the user set it; unset fields keep native defaults.
+                posthogConfig.getIfNotNull<Map<String, Any>>("logs") { logsConfig ->
+                    logsConfig.getIfNotNull<String>("serviceName") {
+                        logs.serviceName = it
+                    }
+                    logsConfig.getIfNotNull<String>("serviceVersion") {
+                        logs.serviceVersion = it
+                    }
+                    logsConfig.getIfNotNull<String>("environment") {
+                        logs.environment = it
+                    }
+                    logsConfig.getIfNotNull<Map<String, Any>>("resourceAttributes") {
+                        logs.resourceAttributes = it
+                    }
+                    logsConfig.getIfNotNull<Int>("flushIntervalSeconds") {
+                        logs.flushIntervalSeconds = it
+                    }
+                    logsConfig.getIfNotNull<Int>("flushAt") {
+                        logs.flushAt = it
+                    }
+                    logsConfig.getIfNotNull<Int>("maxBatchSize") {
+                        logs.maxBatchSize = it
+                    }
+                    logsConfig.getIfNotNull<Int>("maxBufferSize") {
+                        logs.maxBufferSize = it
+                    }
+                    logsConfig.getIfNotNull<Int>("rateCapMaxLogs") {
+                        logs.rateCapMaxLogs = it
+                    }
+                    logsConfig.getIfNotNull<Int>("rateCapWindowSeconds") {
+                        logs.rateCapWindowSeconds = it
+                    }
+                }
+
                 sdkName = "posthog-flutter"
                 sdkVersion = postHogVersion
 
@@ -555,6 +595,34 @@ class PosthogFlutterPlugin :
             result.success(null)
         } catch (e: Throwable) {
             result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun captureLog(
+        call: MethodCall,
+        result: Result,
+    ) {
+        val body: String? = call.argument("body")
+        if (body == null) {
+            result.error("PosthogFlutterException", "Missing argument: body", null)
+            return
+        }
+        try {
+            val level: String = call.argument("level") ?: "info"
+            val attributes: Map<String, Any>? = call.argument("attributes")
+            val traceId: String? = call.argument("traceId")
+            val spanId: String? = call.argument("spanId")
+            // traceFlags 0 is meaningful (W3C sampled-false); null omits it.
+            val traceFlags: Int? = call.argument("traceFlags")
+            // Unknown levels fall back to INFO.
+            val severity = PostHogLogSeverity.from(level) ?: PostHogLogSeverity.INFO
+            PostHog.captureLog(body, severity, attributes, traceId, spanId, traceFlags)
+            result.success(null)
+        } catch (e: Throwable) {
+            // Unlike the other handlers, avoid returning e.localizedMessage: a
+            // captureLog failure can carry the log body or attribute values, and
+            // the message is forwarded back over the channel.
+            result.error("PosthogFlutterException", "Failed to capture log", null)
         }
     }
 

--- a/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
+++ b/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
@@ -41,6 +41,44 @@ internal class PosthogFlutterPluginTest {
     }
 
     @Test
+    fun onMethodCall_captureLog_routesToCaptureLogAndSucceeds() {
+        val plugin = PosthogFlutterPlugin()
+
+        val arguments =
+            mapOf(
+                "body" to "checkout completed",
+                "level" to "warn",
+                "attributes" to mapOf("order_id" to "ord_789"),
+                "traceId" to "4bf92f3577b34da6a3ce929d0e0e4736",
+                "spanId" to "00f067aa0ba902b7",
+                "traceFlags" to 1,
+            )
+
+        val call = MethodCall("captureLog", arguments)
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        // Routed through the public PostHog.captureLog (with W3C trace fields);
+        // the SDK is not set up in the test, so it no-ops and we still succeed.
+        Mockito.verify(mockResult).success(null)
+    }
+
+    @Test
+    fun onMethodCall_captureLog_missingBody_returnsError() {
+        val plugin = PosthogFlutterPlugin()
+
+        val call = MethodCall("captureLog", mapOf<String, Any>())
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("PosthogFlutterException"),
+            Mockito.any(),
+            Mockito.isNull(),
+        )
+    }
+
+    @Test
     fun onMethodCall_getFeatureFlagResult_missingKey_returnsError() {
         val plugin = PosthogFlutterPlugin()
 

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -769,8 +769,9 @@ extension PosthogFlutterPlugin {
             let spanId = args["spanId"] as? String
             // traceFlags 0 is meaningful (W3C sampled-false); nil omits it.
             let traceFlags = args["traceFlags"] as? Int
-            // Unknown levels fall back to .info.
-            let severity = PostHogLogSeverity.from(name: level) ?? .info
+            // PostHogLogSeverity.from(name:) is internal in the SDK, so map the
+            // wire string here. Unknown levels fall back to .info.
+            let severity = severityFromString(level)
             PostHogSDK.shared.captureLog(
                 body,
                 level: severity,
@@ -782,6 +783,20 @@ extension PosthogFlutterPlugin {
             result(nil)
         } else {
             _badArgumentError(result)
+        }
+    }
+
+    // Maps the lowercase wire level to PostHogLogSeverity using only public enum
+    // cases (the SDK's `from(name:)` is internal). Unknown levels fall back to .info.
+    private func severityFromString(_ level: String) -> PostHogLogSeverity {
+        switch level {
+        case "trace": return .trace
+        case "debug": return .debug
+        case "info": return .info
+        case "warn": return .warn
+        case "error": return .error
+        case "fatal": return .fatal
+        default: return .info
         }
     }
 

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -207,6 +207,41 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             }
         }
 
+        // Configure logs (beforeSend runs Dart-side). Each field is only present
+        // when the user set it; unset fields keep native defaults.
+        if let logsConfig = posthogConfig["logs"] as? [String: Any] {
+            if let serviceName = logsConfig["serviceName"] as? String {
+                config.logs.serviceName = serviceName
+            }
+            if let serviceVersion = logsConfig["serviceVersion"] as? String {
+                config.logs.serviceVersion = serviceVersion
+            }
+            if let environment = logsConfig["environment"] as? String {
+                config.logs.environment = environment
+            }
+            if let resourceAttributes = logsConfig["resourceAttributes"] as? [String: Any] {
+                config.logs.resourceAttributes = resourceAttributes
+            }
+            if let flushIntervalSeconds = logsConfig["flushIntervalSeconds"] as? Int {
+                config.logs.flushIntervalSeconds = TimeInterval(flushIntervalSeconds)
+            }
+            if let flushAt = logsConfig["flushAt"] as? Int {
+                config.logs.flushAt = flushAt
+            }
+            if let maxBatchSize = logsConfig["maxBatchSize"] as? Int {
+                config.logs.maxBatchSize = maxBatchSize
+            }
+            if let maxBufferSize = logsConfig["maxBufferSize"] as? Int {
+                config.logs.maxBufferSize = maxBufferSize
+            }
+            if let rateCapMaxLogs = logsConfig["rateCapMaxLogs"] as? Int {
+                config.logs.rateCapMaxLogs = rateCapMaxLogs
+            }
+            if let rateCapWindowSeconds = logsConfig["rateCapWindowSeconds"] as? Int {
+                config.logs.rateCapWindowSeconds = TimeInterval(rateCapWindowSeconds)
+            }
+        }
+
         // Update SDK name and version
         postHogSdkName = "posthog-flutter"
         postHogVersion = postHogFlutterVersion
@@ -239,6 +274,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             capture(call, result: result)
         case "screen":
             screen(call, result: result)
+        case "captureLog":
+            captureLog(call, result: result)
         case "alias":
             alias(call, result: result)
         case "distinctId":
@@ -712,6 +749,35 @@ extension PosthogFlutterPlugin {
             PostHogSDK.shared.screen(
                 screenName,
                 properties: properties
+            )
+            result(nil)
+        } else {
+            _badArgumentError(result)
+        }
+    }
+
+    private func captureLog(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        if let args = call.arguments as? [String: Any],
+           let body = args["body"] as? String
+        {
+            let level = args["level"] as? String ?? "info"
+            let attributes = args["attributes"] as? [String: Any]
+            let traceId = args["traceId"] as? String
+            let spanId = args["spanId"] as? String
+            // traceFlags 0 is meaningful (W3C sampled-false); nil omits it.
+            let traceFlags = args["traceFlags"] as? Int
+            // Unknown levels fall back to .info.
+            let severity = PostHogLogSeverity.from(name: level) ?? .info
+            PostHogSDK.shared.captureLog(
+                body,
+                level: severity,
+                attributes: attributes,
+                traceId: traceId,
+                spanId: spanId,
+                traceFlags: traceFlags
             )
             result(nil)
         } else {

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -786,10 +786,10 @@ extension PosthogFlutterPlugin {
         }
     }
 
-    // Maps the lowercase wire level to PostHogLogSeverity using only public enum
-    // cases (the SDK's `from(name:)` is internal). Unknown levels fall back to .info.
+    // Maps the wire level to PostHogLogSeverity using only public enum cases
+    // (the SDK's `from(name:)` is internal). Unknown levels fall back to .info.
     private func severityFromString(_ level: String) -> PostHogLogSeverity {
-        switch level {
+        switch level.lowercased() {
         case "trace": return .trace
         case "debug": return .debug
         case "info": return .info

--- a/posthog_flutter/lib/posthog_flutter.dart
+++ b/posthog_flutter/lib/posthog_flutter.dart
@@ -2,6 +2,9 @@
 library posthog_flutter;
 
 export 'src/feature_flag_result.dart';
+export 'src/logs/posthog_log_record.dart';
+export 'src/logs/posthog_log_severity.dart';
+export 'src/logs/posthog_logger.dart' hide CaptureLog;
 export 'src/posthog.dart';
 export 'src/posthog_config.dart';
 export 'src/posthog_event.dart';

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -10,6 +10,7 @@ import 'package:posthog_flutter/src/util/logging.dart';
 import 'package:posthog_flutter/src/utils/property_normalizer.dart';
 
 import 'src/feature_flag_result.dart';
+import 'src/logs/posthog_log_severity.dart';
 import 'src/posthog_config.dart';
 import 'src/posthog_flutter_platform_interface.dart';
 import 'src/posthog_flutter_web_handler.dart';
@@ -155,6 +156,31 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
           'userProperties': normalizedUserProperties,
         if (normalizedUserPropertiesSetOnce != null)
           'userPropertiesSetOnce': normalizedUserPropertiesSetOnce,
+      }),
+    );
+  }
+
+  @override
+  Future<void> captureLog({
+    required String body,
+    PostHogLogSeverity level = PostHogLogSeverity.info,
+    Map<String, Object>? attributes,
+    String? traceId,
+    String? spanId,
+    int? traceFlags,
+  }) async {
+    final normalizedAttributes =
+        attributes != null ? PropertyNormalizer.normalize(attributes) : null;
+
+    return handleWebMethodCall(
+      MethodCall('captureLog', {
+        'body': body,
+        'level': level.name,
+        if (normalizedAttributes != null) 'attributes': normalizedAttributes,
+        if (traceId != null) 'traceId': traceId,
+        if (spanId != null) 'spanId': spanId,
+        // traceFlags 0 is meaningful (W3C sampled-false); only omit when null.
+        if (traceFlags != null) 'traceFlags': traceFlags,
       }),
     );
   }

--- a/posthog_flutter/lib/src/logs/posthog_log_record.dart
+++ b/posthog_flutter/lib/src/logs/posthog_log_record.dart
@@ -1,0 +1,40 @@
+import 'posthog_log_severity.dart';
+
+/// Represents a log record that can be modified or dropped before it is sent.
+///
+/// This class is passed to the before-send callbacks registered via
+/// [PostHogLogsConfig.beforeSend] to allow modification of log records before
+/// they are forwarded to the native SDK.
+class PostHogLogRecord {
+  /// The log message body.
+  String body;
+
+  /// The severity level of the record.
+  PostHogLogSeverity level;
+
+  /// User-provided attributes for this record.
+  ///
+  /// Note: Auto-captured context (distinct id, session id, screen name, app
+  /// state, active feature flags) is added by the native SDK at a later stage
+  /// and is not available in this map.
+  Map<String, Object>? attributes;
+
+  /// Creates a log record passed to a before-send callback.
+  ///
+  /// The [body] is the log message.
+  ///
+  /// The [level] is the severity, defaulting to [PostHogLogSeverity.info].
+  ///
+  /// The optional [attributes] are per-record attributes that can be amended
+  /// before capture.
+  PostHogLogRecord({
+    required this.body,
+    this.level = PostHogLogSeverity.info,
+    this.attributes,
+  });
+
+  @override
+  String toString() {
+    return 'PostHogLogRecord(body: $body, level: ${level.name}, attributes: $attributes)';
+  }
+}

--- a/posthog_flutter/lib/src/logs/posthog_log_severity.dart
+++ b/posthog_flutter/lib/src/logs/posthog_log_severity.dart
@@ -1,0 +1,27 @@
+/// Severity level for a structured log record captured via
+/// `Posthog().captureLog()` or the `Posthog().logger` facade.
+///
+/// The levels map to OpenTelemetry severity numbers (`trace`=1, `debug`=5,
+/// `info`=9, `warn`=13, `error`=17, `fatal`=21). The mapping is performed by
+/// the native SDKs; the Flutter layer forwards the level by [name] (lowercase),
+/// which both the Android and Apple SDKs parse case-insensitively.
+enum PostHogLogSeverity {
+  /// Finest-grained diagnostic detail. High-volume; usually only enabled while
+  /// diagnosing a problem.
+  trace,
+
+  /// Diagnostic detail useful during development.
+  debug,
+
+  /// Default level for regular runtime events.
+  info,
+
+  /// Something unexpected that is not yet an error.
+  warn,
+
+  /// A failure that should be looked at.
+  error,
+
+  /// A critical failure.
+  fatal,
+}

--- a/posthog_flutter/lib/src/logs/posthog_logger.dart
+++ b/posthog_flutter/lib/src/logs/posthog_logger.dart
@@ -1,0 +1,57 @@
+import 'package:meta/meta.dart';
+
+import 'posthog_log_severity.dart';
+
+/// Signature used internally by [PostHogLogger] to forward a record to the
+/// capture path. Not part of the public API.
+@internal
+typedef CaptureLog = Future<void> Function(
+  String body,
+  PostHogLogSeverity level,
+  Map<String, Object>? attributes,
+);
+
+/// Per-level convenience facade for capturing structured logs.
+///
+/// Obtain it via `Posthog().logger`. Each helper captures a record at its
+/// severity and is equivalent to calling `Posthog().captureLog(...)` with the
+/// matching `level`.
+///
+/// **Example:**
+/// ```dart
+/// Posthog().logger.info('checkout completed', {'order_id': 'ord_789'});
+/// Posthog().logger.error('payment failed', {'error_code': 'E001'});
+/// ```
+class PostHogLogger {
+  final CaptureLog _capture;
+
+  /// Creates a logger that forwards records through [capture].
+  ///
+  /// For internal use — obtain the logger via `Posthog().logger`.
+  @internal
+  PostHogLogger(CaptureLog capture) : _capture = capture;
+
+  /// Captures a [PostHogLogSeverity.trace] record.
+  Future<void> trace(String body, [Map<String, Object>? attributes]) =>
+      _capture(body, PostHogLogSeverity.trace, attributes);
+
+  /// Captures a [PostHogLogSeverity.debug] record.
+  Future<void> debug(String body, [Map<String, Object>? attributes]) =>
+      _capture(body, PostHogLogSeverity.debug, attributes);
+
+  /// Captures a [PostHogLogSeverity.info] record.
+  Future<void> info(String body, [Map<String, Object>? attributes]) =>
+      _capture(body, PostHogLogSeverity.info, attributes);
+
+  /// Captures a [PostHogLogSeverity.warn] record.
+  Future<void> warn(String body, [Map<String, Object>? attributes]) =>
+      _capture(body, PostHogLogSeverity.warn, attributes);
+
+  /// Captures a [PostHogLogSeverity.error] record.
+  Future<void> error(String body, [Map<String, Object>? attributes]) =>
+      _capture(body, PostHogLogSeverity.error, attributes);
+
+  /// Captures a [PostHogLogSeverity.fatal] record.
+  Future<void> fatal(String body, [Map<String, Object>? attributes]) =>
+      _capture(body, PostHogLogSeverity.fatal, attributes);
+}

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -284,11 +284,11 @@ class Posthog {
     var record = PostHogLogRecord(
       body: body,
       level: level,
-      attributes: attributes,
+      attributes: attributes == null ? null : {...attributes},
     );
 
     final callbacks =
-        _config?.logs.beforeSend ?? const <BeforeSendLogCallback>[];
+        _config?.logsConfig.beforeSend ?? const <BeforeSendLogCallback>[];
     for (final callback in callbacks) {
       try {
         final result = await runBeforeSend<PostHogLogRecord>(callback, record);

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -5,10 +5,14 @@ import 'package:meta/meta.dart';
 import 'package:posthog_flutter/src/error_tracking/posthog_error_tracking_autocapture_integration.dart';
 import 'package:posthog_flutter/src/error_tracking/posthog_exception.dart';
 import 'feature_flag_result.dart';
+import 'logs/posthog_log_record.dart';
+import 'logs/posthog_log_severity.dart';
+import 'logs/posthog_logger.dart';
 import 'posthog_config.dart';
 import 'posthog_flutter_platform_interface.dart';
 import 'posthog_internal_events.dart';
 import 'posthog_observer.dart';
+import 'utils/before_send.dart';
 
 /// Entry point for the PostHog Flutter SDK.
 ///
@@ -226,6 +230,100 @@ class Posthog {
     _currentScreen = screenName;
     return _posthog.screen(screenName: screenName, properties: properties);
   }
+
+  /// Captures a structured log record.
+  ///
+  /// Docs: https://posthog.com/docs/logs
+  ///
+  /// The [body] is the log message. A blank body is dropped before
+  /// [PostHogLogsConfig.beforeSend] runs.
+  ///
+  /// The optional [level] is the severity, defaulting to
+  /// [PostHogLogSeverity.info].
+  ///
+  /// The optional [attributes] are per-record attributes (e.g. request id,
+  /// duration). Values must be supported by the platform channel serializer.
+  ///
+  /// The optional [traceId], [spanId], and [traceFlags] are W3C distributed
+  /// tracing fields used to correlate a log with a trace. [traceId] is a
+  /// 32-character lowercase hex string, [spanId] is 16 characters, and
+  /// [traceFlags] is a bitfield whose bit 0 is the `sampled` flag (an explicit
+  /// `0` is emitted; `null` omits the field). They pass through unchanged and
+  /// are not visible to [PostHogLogsConfig.beforeSend].
+  ///
+  /// Auto-captured context (distinct id, session id, screen name, app state,
+  /// active feature flags) is added by the native SDK.
+  ///
+  /// Records are passed through [PostHogLogsConfig.beforeSend] before being
+  /// forwarded to the native SDK; a callback may modify or drop them.
+  ///
+  /// Returns a [Future] that completes when the record has been forwarded.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// await Posthog().captureLog(
+  ///   body: 'checkout completed',
+  ///   level: PostHogLogSeverity.info,
+  ///   attributes: {'order_id': 'ord_789'},
+  /// );
+  /// ```
+  Future<void> captureLog({
+    required String body,
+    PostHogLogSeverity level = PostHogLogSeverity.info,
+    Map<String, Object>? attributes,
+    String? traceId,
+    String? spanId,
+    int? traceFlags,
+  }) async {
+    if (body.trim().isEmpty) {
+      return;
+    }
+
+    var record = PostHogLogRecord(
+      body: body,
+      level: level,
+      attributes: attributes,
+    );
+
+    final callbacks =
+        _config?.logs.beforeSend ?? const <BeforeSendLogCallback>[];
+    for (final callback in callbacks) {
+      final result = await applyBeforeSend<PostHogLogRecord>(callback, record);
+      if (result == null) {
+        debugPrint('[PostHog] Log dropped by beforeSend');
+        return;
+      }
+      record = result;
+    }
+
+    // A beforeSend callback may have blanked the body, which drops the record.
+    if (record.body.trim().isEmpty) {
+      return;
+    }
+
+    return _posthog.captureLog(
+      body: record.body,
+      level: record.level,
+      attributes: record.attributes,
+      traceId: traceId,
+      spanId: spanId,
+      traceFlags: traceFlags,
+    );
+  }
+
+  /// Per-level logger facade for capturing structured logs.
+  ///
+  /// Each helper delegates to [captureLog] with the matching severity.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// Posthog().logger.info('user signed in', {'method': 'google'});
+  /// Posthog().logger.error('payment failed', {'error_code': 'E001'});
+  /// ```
+  late final PostHogLogger logger = PostHogLogger(
+    (body, level, attributes) =>
+        captureLog(body: body, level: level, attributes: attributes),
+  );
 
   /// Creates an alias for the current user.
   ///

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -298,7 +298,6 @@ class Posthog {
         }
         record = result;
       } catch (e) {
-        // Fail closed: a throwing hook drops the log so it can't leak unredacted.
         debugPrint('[PostHog] beforeSend threw, dropping log: $e');
         return;
       }

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -235,6 +235,8 @@ class Posthog {
   ///
   /// Docs: https://posthog.com/docs/logs
   ///
+  /// `captureLog` is not gated by remote config.
+  ///
   /// The [body] is the log message. A blank body is dropped before
   /// [PostHogLogsConfig.beforeSend] runs.
   ///
@@ -288,12 +290,18 @@ class Posthog {
     final callbacks =
         _config?.logs.beforeSend ?? const <BeforeSendLogCallback>[];
     for (final callback in callbacks) {
-      final result = await applyBeforeSend<PostHogLogRecord>(callback, record);
-      if (result == null) {
-        debugPrint('[PostHog] Log dropped by beforeSend');
+      try {
+        final result = await runBeforeSend<PostHogLogRecord>(callback, record);
+        if (result == null) {
+          debugPrint('[PostHog] Log dropped by beforeSend');
+          return;
+        }
+        record = result;
+      } catch (e) {
+        // Fail closed: a throwing hook drops the log so it can't leak unredacted.
+        debugPrint('[PostHog] beforeSend threw, dropping log: $e');
         return;
       }
-      record = result;
     }
 
     // A beforeSend callback may have blanked the body, which drops the record.
@@ -311,19 +319,22 @@ class Posthog {
     );
   }
 
+  PostHogLogger? _logger;
+
   /// Per-level logger facade for capturing structured logs.
   ///
-  /// Each helper delegates to [captureLog] with the matching severity.
+  /// Each helper delegates to [captureLog] with the matching severity. Built
+  /// once on first access and cached.
   ///
   /// **Example:**
   /// ```dart
   /// Posthog().logger.info('user signed in', {'method': 'google'});
   /// Posthog().logger.error('payment failed', {'error_code': 'E001'});
   /// ```
-  late final PostHogLogger logger = PostHogLogger(
-    (body, level, attributes) =>
-        captureLog(body: body, level: level, attributes: attributes),
-  );
+  PostHogLogger get logger => _logger ??= PostHogLogger(
+        (body, level, attributes) =>
+            captureLog(body: body, level: level, attributes: attributes),
+      );
 
   /// Creates an alias for the current user.
   ///

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -420,15 +420,22 @@ class PostHogLogsConfig {
       if (resourceAttributes.isNotEmpty)
         'resourceAttributes': resourceAttributes,
       if (flushInterval != null)
-        'flushIntervalSeconds': flushInterval!.inSeconds,
+        'flushIntervalSeconds': _wholeSeconds(flushInterval!),
       if (flushAt != null) 'flushAt': flushAt,
       if (maxBatchSize != null) 'maxBatchSize': maxBatchSize,
       if (maxBufferSize != null) 'maxBufferSize': maxBufferSize,
       if (rateCapMaxLogs != null) 'rateCapMaxLogs': rateCapMaxLogs,
       if (rateCapWindow != null)
-        'rateCapWindowSeconds': rateCapWindow!.inSeconds,
+        'rateCapWindowSeconds': _wholeSeconds(rateCapWindow!),
     };
   }
+
+  /// The native flush interval and rate-cap window are whole seconds. A
+  /// sub-second [Duration] truncates to `0`, which the native SDK treats as
+  /// "disabled" (rate cap) or continuous flushing — surprising for a caller who
+  /// set, say, 500ms. Floor at 1s, the smallest value the native API can honor.
+  static int _wholeSeconds(Duration duration) =>
+      duration.inSeconds < 1 ? 1 : duration.inSeconds;
 }
 
 /// Configuration for mobile session replay capture and masking.

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -173,7 +173,7 @@ class PostHogConfig {
 
   /// Configuration for the logs subsystem (`Posthog().captureLog()` and the
   /// `Posthog().logger` facade).
-  final logs = PostHogLogsConfig();
+  final logsConfig = PostHogLogsConfig();
 
   /// Callback to be invoked when feature flags are loaded.
   ///
@@ -302,7 +302,7 @@ class PostHogConfig {
       'dataMode': dataMode.name,
       'sessionReplayConfig': sessionReplayConfig.toMap(),
       'errorTrackingConfig': errorTrackingConfig.toMap(),
-      'logs': logs.toMap(),
+      'logs': logsConfig.toMap(),
     };
   }
 }
@@ -383,7 +383,7 @@ class PostHogLogsConfig {
   ///
   /// **Example:**
   /// ```dart
-  /// config.logs.beforeSend = [
+  /// config.logsConfig.beforeSend = [
   ///   (record) {
   ///     record.attributes?.remove('password');
   ///     return record;
@@ -399,7 +399,7 @@ class PostHogLogsConfig {
   ///   (including web). This mirrors the event [PostHogConfig.beforeSend].
   /// - Callbacks can be synchronous or asynchronous (via
   ///   `FutureOr<PostHogLogRecord?>`).
-  /// - Exceptions in a callback skip that callback and continue with the next.
+  /// - A callback that throws is logged, and the record is dropped.
   /// - The W3C trace fields (`traceId`, `spanId`, `traceFlags`) are **not**
   ///   part of [PostHogLogRecord] and are not visible here. They pass straight
   ///   through to the native SDK, so they cannot be redacted or used to drop a

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'logs/posthog_log_record.dart';
 import 'posthog_event.dart';
 import 'posthog_flutter_platform_interface.dart';
 
@@ -13,6 +14,19 @@ import 'posthog_flutter_platform_interface.dart';
 /// `FutureOr<PostHogEvent?>`).
 typedef BeforeSendCallback = FutureOr<PostHogEvent?> Function(
   PostHogEvent event,
+);
+
+/// Callback to intercept and modify log records before they are sent to
+/// PostHog.
+///
+/// The [record] argument contains the body, level, and user-provided
+/// attributes that are about to be captured. Return a possibly modified record
+/// to send it, or return `null` to drop it.
+///
+/// Callbacks can be synchronous or asynchronous (returning
+/// `FutureOr<PostHogLogRecord?>`).
+typedef BeforeSendLogCallback = FutureOr<PostHogLogRecord?> Function(
+  PostHogLogRecord record,
 );
 
 /// Controls whether events create or update PostHog person profiles.
@@ -157,6 +171,10 @@ class PostHogConfig {
   /// Configuration for error tracking and exception capture.
   final errorTrackingConfig = PostHogErrorTrackingConfig();
 
+  /// Configuration for the logs subsystem (`Posthog().captureLog()` and the
+  /// `Posthog().logger` facade).
+  final logs = PostHogLogsConfig();
+
   /// Callback to be invoked when feature flags are loaded.
   ///
   /// Use [Posthog.getFeatureFlag] or [Posthog.isFeatureEnabled] within this
@@ -284,6 +302,131 @@ class PostHogConfig {
       'dataMode': dataMode.name,
       'sessionReplayConfig': sessionReplayConfig.toMap(),
       'errorTrackingConfig': errorTrackingConfig.toMap(),
+      'logs': logs.toMap(),
+    };
+  }
+}
+
+/// Configuration for the logs subsystem.
+///
+/// Assign values before calling `Posthog().setup(config)`. The identity and
+/// tuning fields are forwarded to the native iOS/Android logs configuration;
+/// [beforeSend] runs in Dart before a record is forwarded to the native SDK.
+///
+/// Every field that is `null` (or, for [resourceAttributes], empty) is left at
+/// the native SDK's default — it is not sent over the channel.
+///
+/// **Flutter web:** this configuration is **not** applied on web. The web SDK
+/// hooks onto an already-initialized posthog-js instance, so configure logs in
+/// your `posthog.init({...})` call instead. Only [beforeSend] runs on web (in
+/// Dart).
+class PostHogLogsConfig {
+  /// Creates a logs configuration with native defaults.
+  PostHogLogsConfig();
+
+  /// Sets the OTLP `service.name` resource attribute.
+  ///
+  /// When `null`, the native SDK's default is used (the app bundle id on Apple
+  /// platforms, the app namespace on Android).
+  String? serviceName;
+
+  /// Sets the OTLP `service.version` resource attribute.
+  ///
+  /// When `null`, the native SDK's default is used (the app version where the
+  /// platform provides one).
+  String? serviceVersion;
+
+  /// Sets the OTLP `deployment.environment` resource attribute (e.g.
+  /// `production`, `staging`). When `null`, the native SDK's default is used
+  /// (no environment).
+  String? environment;
+
+  /// Extra OTLP resource attributes merged into every payload.
+  ///
+  /// SDK-managed identity keys (`service.*`, `telemetry.sdk.*`) take precedence
+  /// and cannot be overridden.
+  Map<String, Object> resourceAttributes = {};
+
+  /// Periodic auto-flush interval. When `null`, the native default is used
+  /// (30s on iOS/Android).
+  Duration? flushInterval;
+
+  /// Queue depth that triggers an immediate flush. When `null`, the native
+  /// default is used (20 on iOS/Android).
+  int? flushAt;
+
+  /// Maximum number of records sent per POST. When `null`, the native default
+  /// is used (50 on iOS/Android).
+  int? maxBatchSize;
+
+  /// Maximum number of buffered records before the oldest are dropped (FIFO).
+  /// When `null`, the native default is used (1000 on iOS/Android).
+  int? maxBufferSize;
+
+  /// Maximum number of logs accepted per rate-cap window before excess logs are
+  /// dropped. When `null`, the native default is used (500 on iOS/Android). A
+  /// non-positive value disables the cap natively.
+  int? rateCapMaxLogs;
+
+  /// Length of the rate-cap window. When `null`, the native default is used
+  /// (10s on iOS/Android).
+  Duration? rateCapWindow;
+
+  /// Callbacks to intercept and modify log records before they are forwarded to
+  /// the native SDK.
+  ///
+  /// Callbacks are invoked in order for records captured via
+  /// `Posthog().captureLog()` and the `Posthog().logger` facade. Each callback
+  /// receives the record (possibly modified by previous callbacks). Return a
+  /// possibly modified record to continue, or return `null` to drop it.
+  /// Blanking the body also drops the record.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// config.logs.beforeSend = [
+  ///   (record) {
+  ///     record.attributes?.remove('password');
+  ///     return record;
+  ///   },
+  ///   (record) => record.body.contains('secret') ? null : record,
+  /// ];
+  /// ```
+  ///
+  /// **Note:**
+  /// - Runs in Dart on all platforms — it is intentionally not forwarded to the
+  ///   native SDKs' own `beforeSend`. Dart callbacks cannot cross the platform
+  ///   channel, and running it here gives identical behavior everywhere
+  ///   (including web). This mirrors the event [PostHogConfig.beforeSend].
+  /// - Callbacks can be synchronous or asynchronous (via
+  ///   `FutureOr<PostHogLogRecord?>`).
+  /// - Exceptions in a callback skip that callback and continue with the next.
+  /// - The W3C trace fields (`traceId`, `spanId`, `traceFlags`) are **not**
+  ///   part of [PostHogLogRecord] and are not visible here. They pass straight
+  ///   through to the native SDK, so they cannot be redacted or used to drop a
+  ///   record. Keep anything sensitive out of those fields; put it in [body] or
+  ///   [PostHogLogRecord.attributes], which a callback can scrub or drop.
+  List<BeforeSendLogCallback> beforeSend = [];
+
+  /// Converts the identity and tuning options to a platform-channel map.
+  ///
+  /// Only fields the user set are included, so unset fields keep the native
+  /// default. [beforeSend] is intentionally omitted: it runs in Dart and never
+  /// crosses the platform channel.
+  Map<String, dynamic> toMap() {
+    return {
+      if (serviceName != null) 'serviceName': serviceName,
+      if (serviceVersion != null) 'serviceVersion': serviceVersion,
+      if (environment != null) 'environment': environment,
+      if (resourceAttributes.isNotEmpty)
+        'resourceAttributes': resourceAttributes,
+      if (flushInterval != null)
+        'flushIntervalSeconds': flushInterval!.inSeconds,
+      if (flushAt != null) 'flushAt': flushAt,
+      if (maxBatchSize != null) 'maxBatchSize': maxBatchSize,
+      if (maxBufferSize != null) 'maxBufferSize': maxBufferSize,
+      if (rateCapMaxLogs != null) 'rateCapMaxLogs': rateCapMaxLogs,
+      if (rateCapWindow != null)
+        'rateCapWindowSeconds': rateCapWindow!.inSeconds,
     };
   }
 }

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -56,9 +56,14 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     if (_beforeSendCallbacks.isEmpty) return event;
 
     for (final callback in _beforeSendCallbacks) {
-      final result = await applyBeforeSend<PostHogEvent>(callback, event);
-      if (result == null) return null;
-      event = result;
+      try {
+        final result = await runBeforeSend<PostHogEvent>(callback, event);
+        if (result == null) return null;
+        event = result;
+      } catch (e) {
+        // Skip a throwing callback; continue with the pre-callback event.
+        printIfDebug('[PostHog] beforeSend callback threw exception: $e');
+      }
     }
     return event;
   }
@@ -370,10 +375,8 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
       final normalizedAttributes =
           attributes != null ? PropertyNormalizer.normalize(attributes) : null;
 
-      // These keys are camelCase on the native (iOS/Android) channel. The web
-      // path remaps the trace fields to snake_case (`trace_id`/`span_id`/
-      // `trace_flags`) for posthog-js; if you add or rename a field here, update
-      // the `captureLog` case in posthog_flutter_web_handler.dart too.
+      // Trace fields are camelCase here; the web handler remaps them to
+      // snake_case for posthog-js.
       await _methodChannel.invokeMethod('captureLog', {
         'body': body,
         'level': level.name,

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -10,10 +10,12 @@ import 'package:posthog_flutter/src/util/logging.dart';
 import 'surveys/models/posthog_display_survey.dart' as models;
 import 'surveys/models/survey_callbacks.dart';
 import 'error_tracking/dart_exception_processor.dart';
+import 'utils/before_send.dart';
 import 'utils/capture_utils.dart';
 import 'utils/property_normalizer.dart';
 
 import 'feature_flag_result.dart';
+import 'logs/posthog_log_severity.dart';
 import 'posthog_config.dart';
 import 'posthog_constants.dart';
 import 'posthog_event.dart';
@@ -54,30 +56,11 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
     if (_beforeSendCallbacks.isEmpty) return event;
 
     for (final callback in _beforeSendCallbacks) {
-      final result = await _applyBeforeSendCallback(callback, event);
+      final result = await applyBeforeSend<PostHogEvent>(callback, event);
       if (result == null) return null;
       event = result;
     }
     return event;
-  }
-
-  /// Applies a single beforeSend callback safely.
-  /// Returns null if event should be dropped, otherwise returns the (possibly modified) event.
-  /// Handles both synchronous and asynchronous callbacks via FutureOr.
-  Future<PostHogEvent?> _applyBeforeSendCallback(
-    BeforeSendCallback callback,
-    PostHogEvent event,
-  ) async {
-    try {
-      final callbackResult = callback(event);
-      if (callbackResult is Future<PostHogEvent?>) {
-        return await callbackResult;
-      }
-      return callbackResult;
-    } catch (e) {
-      printIfDebug('[PostHog] beforeSend callback threw exception: $e');
-      return event;
-    }
   }
 
   /// Native plugin calls to Flutter
@@ -367,6 +350,41 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
       });
     } on PlatformException catch (exception) {
       printIfDebug('Exeption on screen: $exception');
+    }
+  }
+
+  @override
+  Future<void> captureLog({
+    required String body,
+    PostHogLogSeverity level = PostHogLogSeverity.info,
+    Map<String, Object>? attributes,
+    String? traceId,
+    String? spanId,
+    int? traceFlags,
+  }) async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      final normalizedAttributes =
+          attributes != null ? PropertyNormalizer.normalize(attributes) : null;
+
+      // These keys are camelCase on the native (iOS/Android) channel. The web
+      // path remaps the trace fields to snake_case (`trace_id`/`span_id`/
+      // `trace_flags`) for posthog-js; if you add or rename a field here, update
+      // the `captureLog` case in posthog_flutter_web_handler.dart too.
+      await _methodChannel.invokeMethod('captureLog', {
+        'body': body,
+        'level': level.name,
+        if (normalizedAttributes != null) 'attributes': normalizedAttributes,
+        if (traceId != null) 'traceId': traceId,
+        if (spanId != null) 'spanId': spanId,
+        // traceFlags 0 is meaningful (W3C sampled-false); only omit when null.
+        if (traceFlags != null) 'traceFlags': traceFlags,
+      });
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on captureLog: $exception');
     }
   }
 

--- a/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
@@ -1,6 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'feature_flag_result.dart';
+import 'logs/posthog_log_severity.dart';
 import 'posthog_config.dart';
 import 'posthog_flutter_io.dart';
 
@@ -64,6 +65,17 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
     Map<String, Object>? properties,
   }) {
     throw UnimplementedError('screen() has not been implemented.');
+  }
+
+  Future<void> captureLog({
+    required String body,
+    PostHogLogSeverity level = PostHogLogSeverity.info,
+    Map<String, Object>? attributes,
+    String? traceId,
+    String? spanId,
+    int? traceFlags,
+  }) {
+    throw UnimplementedError('captureLog() has not been implemented.');
   }
 
   /// Opens a URL using the platform's default browser

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -215,8 +215,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final spanId = args['spanId'] as String?;
       final traceFlags = args['traceFlags'] as int?;
 
-      // posthog-js captureLog options. See:
-      // https://github.com/PostHog/posthog-js/blob/main/packages/types/src/capture-log.ts
+      // posthog-js captureLog options. See https://posthog.com/docs/logs
       final options = <String, Object>{
         'body': body,
         'level': level,
@@ -230,8 +229,7 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       try {
         posthog?.captureLog(mapToJSAny(options));
       } catch (error) {
-        // captureLog was added to posthog-js after the minimum supported
-        // version, so calling it on an older build throws.
+        // Older posthog-js builds lack captureLog and throw.
         printIfDebug(
           '[PostHog] captureLog is not supported by the loaded posthog-js version: $error',
         );

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -20,6 +20,8 @@ extension PostHogExtension on PostHog {
     JSAny propertiesSetOnce,
   );
   external JSAny? capture(JSAny eventName, JSAny? properties, JSAny? options);
+  // May be absent on older posthog-js builds; the call site guards with try/catch.
+  external void captureLog(JSAny options);
   external JSAny? alias(JSAny alias);
   // ignore: non_constant_identifier_names
   external JSAny? get_distinct_id();
@@ -204,6 +206,36 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       properties.addAll(_getLocationProperties());
 
       posthog?.capture(stringToJSAny('\$screen'), mapToJSAny(properties), null);
+      break;
+    case 'captureLog':
+      final body = args['body'] as String;
+      final level = args['level'] as String? ?? 'info';
+      final attributes = safeMapConversion(args['attributes']);
+      final traceId = args['traceId'] as String?;
+      final spanId = args['spanId'] as String?;
+      final traceFlags = args['traceFlags'] as int?;
+
+      // posthog-js captureLog options. See:
+      // https://github.com/PostHog/posthog-js/blob/main/packages/types/src/capture-log.ts
+      final options = <String, Object>{
+        'body': body,
+        'level': level,
+        if (attributes.isNotEmpty) 'attributes': attributes,
+        if (traceId != null) 'trace_id': traceId,
+        if (spanId != null) 'span_id': spanId,
+        // trace_flags 0 is meaningful (W3C sampled-false); only omit when null.
+        if (traceFlags != null) 'trace_flags': traceFlags,
+      };
+
+      try {
+        posthog?.captureLog(mapToJSAny(options));
+      } catch (error) {
+        // captureLog was added to posthog-js after the minimum supported
+        // version, so calling it on an older build throws.
+        printIfDebug(
+          '[PostHog] captureLog is not supported by the loaded posthog-js version: $error',
+        );
+      }
       break;
     case 'alias':
       final alias = args['alias'] as String;

--- a/posthog_flutter/lib/src/utils/before_send.dart
+++ b/posthog_flutter/lib/src/utils/before_send.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:posthog_flutter/src/util/logging.dart';
+
+/// Applies a single beforeSend [callback] to [record] safely.
+///
+/// Returns `null` if the callback drops the record, otherwise returns the
+/// (possibly modified) record. Handles both synchronous and asynchronous
+/// callbacks via `FutureOr`. A callback that throws is contained: the exception
+/// is logged and the pre-callback [record] is returned so the chain continues
+/// with the remaining callbacks.
+///
+/// Shared by the event path (`PosthogFlutterIO.capture`) and the logs path
+/// (`Posthog.captureLog`) so both keep identical exception-handling semantics.
+Future<T?> applyBeforeSend<T>(
+  FutureOr<T?> Function(T) callback,
+  T record,
+) async {
+  try {
+    final result = callback(record);
+    if (result is Future<T?>) {
+      return await result;
+    }
+    return result;
+  } catch (e) {
+    printIfDebug('[PostHog] beforeSend callback threw exception: $e');
+    return record;
+  }
+}

--- a/posthog_flutter/lib/src/utils/before_send.dart
+++ b/posthog_flutter/lib/src/utils/before_send.dart
@@ -1,29 +1,17 @@
 import 'dart:async';
 
-import 'package:posthog_flutter/src/util/logging.dart';
-
-/// Applies a single beforeSend [callback] to [record] safely.
+/// Runs a single beforeSend [callback] against [record], awaiting an async
+/// result. Returns the (possibly modified) record, or `null` to drop it.
 ///
-/// Returns `null` if the callback drops the record, otherwise returns the
-/// (possibly modified) record. Handles both synchronous and asynchronous
-/// callbacks via `FutureOr`. A callback that throws is contained: the exception
-/// is logged and the pre-callback [record] is returned so the chain continues
-/// with the remaining callbacks.
-///
-/// Shared by the event path (`PosthogFlutterIO.capture`) and the logs path
-/// (`Posthog.captureLog`) so both keep identical exception-handling semantics.
-Future<T?> applyBeforeSend<T>(
+/// Exceptions propagate so each caller applies its own policy (events continue,
+/// logs drop). Shared so both handle sync and async callbacks identically.
+Future<T?> runBeforeSend<T>(
   FutureOr<T?> Function(T) callback,
   T record,
 ) async {
-  try {
-    final result = callback(record);
-    if (result is Future<T?>) {
-      return await result;
-    }
-    return result;
-  } catch (e) {
-    printIfDebug('[PostHog] beforeSend callback threw exception: $e');
-    return record;
+  final result = callback(record);
+  if (result is Future<T?>) {
+    return await result;
   }
+  return result;
 }

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -887,23 +887,22 @@ void main() {
       expect(args.containsKey('attributes'), isFalse);
     });
 
-    test('serializes every severity as its lowercase wire name', () async {
-      const expected = {
-        PostHogLogSeverity.trace: 'trace',
-        PostHogLogSeverity.debug: 'debug',
-        PostHogLogSeverity.info: 'info',
-        PostHogLogSeverity.warn: 'warn',
-        PostHogLogSeverity.error: 'error',
-        PostHogLogSeverity.fatal: 'fatal',
-      };
+    const severityWireNames = {
+      PostHogLogSeverity.trace: 'trace',
+      PostHogLogSeverity.debug: 'debug',
+      PostHogLogSeverity.info: 'info',
+      PostHogLogSeverity.warn: 'warn',
+      PostHogLogSeverity.error: 'error',
+      PostHogLogSeverity.fatal: 'fatal',
+    };
+    severityWireNames.forEach((severity, wireName) {
+      test('serializes ${severity.name} as "$wireName" on the wire', () async {
+        await posthogFlutterIO.captureLog(body: 'x', level: severity);
 
-      for (final entry in expected.entries) {
-        log.clear();
-        await posthogFlutterIO.captureLog(body: 'x', level: entry.key);
         final call = log.firstWhere((c) => c.method == 'captureLog');
         final args = Map<String, dynamic>.from(call.arguments as Map);
-        expect(args['level'], entry.value, reason: 'for ${entry.key}');
-      }
+        expect(args['level'], wireName);
+      });
     });
 
     test('normalizes unsupported attribute values for the channel', () async {

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/logs/posthog_log_severity.dart';
 import 'package:posthog_flutter/src/posthog_config.dart';
 import 'package:posthog_flutter/src/posthog_event.dart';
 import 'package:posthog_flutter/src/posthog_flutter_io.dart';
@@ -860,5 +861,88 @@ void main() {
         expect(eventOrder, isNot(['event_1', 'event_2', 'event_3']));
       },
     );
+  });
+
+  group('PosthogFlutterIO captureLog', () {
+    test('sends body, lowercase level name, and attributes', () async {
+      await posthogFlutterIO.captureLog(
+        body: 'checkout completed',
+        level: PostHogLogSeverity.warn,
+        attributes: {'order_id': 'ord_789'},
+      );
+
+      final call = log.firstWhere((c) => c.method == 'captureLog');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['body'], 'checkout completed');
+      expect(args['level'], 'warn');
+      expect(args['attributes'], {'order_id': 'ord_789'});
+    });
+
+    test('omits attributes when none provided', () async {
+      await posthogFlutterIO.captureLog(body: 'hello');
+
+      final call = log.firstWhere((c) => c.method == 'captureLog');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['level'], 'info');
+      expect(args.containsKey('attributes'), isFalse);
+    });
+
+    test('serializes every severity as its lowercase wire name', () async {
+      const expected = {
+        PostHogLogSeverity.trace: 'trace',
+        PostHogLogSeverity.debug: 'debug',
+        PostHogLogSeverity.info: 'info',
+        PostHogLogSeverity.warn: 'warn',
+        PostHogLogSeverity.error: 'error',
+        PostHogLogSeverity.fatal: 'fatal',
+      };
+
+      for (final entry in expected.entries) {
+        log.clear();
+        await posthogFlutterIO.captureLog(body: 'x', level: entry.key);
+        final call = log.firstWhere((c) => c.method == 'captureLog');
+        final args = Map<String, dynamic>.from(call.arguments as Map);
+        expect(args['level'], entry.value, reason: 'for ${entry.key}');
+      }
+    });
+
+    test('normalizes unsupported attribute values for the channel', () async {
+      await posthogFlutterIO.captureLog(
+        body: 'event',
+        attributes: {'at': DateTime(2024, 3, 1)},
+      );
+
+      final call = log.firstWhere((c) => c.method == 'captureLog');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      final attributes = Map<String, dynamic>.from(args['attributes'] as Map);
+      // DateTime is not a StandardMessageCodec type; it is stringified.
+      expect(attributes['at'], isA<String>());
+    });
+
+    test('sends trace fields when provided', () async {
+      await posthogFlutterIO.captureLog(
+        body: 'event',
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+        spanId: '00f067aa0ba902b7',
+        traceFlags: 1,
+      );
+
+      final call = log.firstWhere((c) => c.method == 'captureLog');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['traceId'], '4bf92f3577b34da6a3ce929d0e0e4736');
+      expect(args['spanId'], '00f067aa0ba902b7');
+      expect(args['traceFlags'], 1);
+    });
+
+    test('emits an explicit traceFlags of 0 but omits trace fields when null',
+        () async {
+      await posthogFlutterIO.captureLog(body: 'event', traceFlags: 0);
+
+      final call = log.firstWhere((c) => c.method == 'captureLog');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['traceFlags'], 0);
+      expect(args.containsKey('traceId'), isFalse);
+      expect(args.containsKey('spanId'), isFalse);
+    });
   });
 }

--- a/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
+++ b/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
@@ -1,4 +1,5 @@
 import 'package:posthog_flutter/src/feature_flag_result.dart';
+import 'package:posthog_flutter/src/logs/posthog_log_severity.dart';
 import 'package:posthog_flutter/src/posthog_config.dart';
 import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
 
@@ -12,6 +13,25 @@ class CapturedExceptionCall {
     required this.error,
     this.stackTrace,
     this.properties,
+  });
+}
+
+/// Captured log call data
+class CapturedLogCall {
+  final String body;
+  final PostHogLogSeverity level;
+  final Map<String, Object>? attributes;
+  final String? traceId;
+  final String? spanId;
+  final int? traceFlags;
+
+  CapturedLogCall({
+    required this.body,
+    required this.level,
+    this.attributes,
+    this.traceId,
+    this.spanId,
+    this.traceFlags,
   });
 }
 
@@ -71,12 +91,36 @@ class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
     resetGroupPropertiesForFlagsCalls.add(groupType);
   }
 
+  // Tracking for captureLog calls (after Dart-side beforeSend has run)
+  final List<CapturedLogCall> capturedLogs = [];
+
   @override
   Future<void> screen({
     required String screenName,
     Map<String, Object>? properties,
   }) async {
     this.screenName = screenName;
+  }
+
+  @override
+  Future<void> captureLog({
+    required String body,
+    PostHogLogSeverity level = PostHogLogSeverity.info,
+    Map<String, Object>? attributes,
+    String? traceId,
+    String? spanId,
+    int? traceFlags,
+  }) async {
+    capturedLogs.add(
+      CapturedLogCall(
+        body: body,
+        level: level,
+        attributes: attributes,
+        traceId: traceId,
+        spanId: spanId,
+        traceFlags: traceFlags,
+      ),
+    );
   }
 
   @override

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -1,0 +1,80 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/posthog_flutter_web_handler.dart';
+
+// Browser-only: handleWebMethodCall talks to the posthog-js instance on
+// `window.posthog`, so these run under `flutter test --platform chrome`.
+void main() {
+  // The most recent options object passed to the fake posthog-js captureLog.
+  JSObject? capturedOptions;
+
+  setUp(() {
+    capturedOptions = null;
+
+    // Install a fake `window.posthog` whose captureLog records its argument.
+    final fake = JSObject();
+    fake.setProperty(
+      'captureLog'.toJS,
+      ((JSObject options) {
+        capturedOptions = options;
+      }).toJS,
+    );
+    globalContext.setProperty('posthog'.toJS, fake);
+  });
+
+  Map<Object?, Object?> readOptions() =>
+      capturedOptions!.dartify()! as Map<Object?, Object?>;
+
+  group('handleWebMethodCall captureLog', () {
+    test('remaps trace fields to snake_case for posthog-js', () async {
+      await handleWebMethodCall(const MethodCall('captureLog', {
+        'body': 'checkout completed',
+        'level': 'warn',
+        'attributes': {'order_id': 'ord_789'},
+        'traceId': '4bf92f3577b34da6a3ce929d0e0e4736',
+        'spanId': '00f067aa0ba902b7',
+        'traceFlags': 1,
+      }));
+
+      final options = readOptions();
+      expect(options['body'], 'checkout completed');
+      expect(options['level'], 'warn');
+      expect(options['attributes'], {'order_id': 'ord_789'});
+      // posthog-js expects snake_case, unlike the camelCase native channel.
+      expect(options['trace_id'], '4bf92f3577b34da6a3ce929d0e0e4736');
+      expect(options['span_id'], '00f067aa0ba902b7');
+      expect(options['trace_flags'], 1);
+      expect(options.containsKey('traceId'), isFalse);
+      expect(options.containsKey('spanId'), isFalse);
+      expect(options.containsKey('traceFlags'), isFalse);
+    });
+
+    test('defaults a missing level to info', () async {
+      await handleWebMethodCall(const MethodCall('captureLog', {
+        'body': 'hello',
+      }));
+
+      expect(readOptions()['level'], 'info');
+    });
+
+    test('emits an explicit traceFlags of 0 but omits trace fields when null',
+        () async {
+      await handleWebMethodCall(const MethodCall('captureLog', {
+        'body': 'x',
+        'traceFlags': 0,
+      }));
+
+      final options = readOptions();
+      // trace_flags 0 is meaningful (W3C sampled-false), so it must survive.
+      expect(options['trace_flags'], 0);
+      expect(options.containsKey('trace_id'), isFalse);
+      expect(options.containsKey('span_id'), isFalse);
+    });
+  });
+}

--- a/posthog_flutter/test/posthog_logs_test.dart
+++ b/posthog_flutter/test/posthog_logs_test.dart
@@ -143,7 +143,7 @@ void main() {
     group('beforeSend hook', () {
       test('hook returning null drops the record', () async {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [(record) => null];
+        config.logsConfig.beforeSend = [(record) => null];
         await setupWith(config);
 
         await Posthog().captureLog(body: 'secret');
@@ -153,7 +153,7 @@ void main() {
 
       test('hook can mutate body and attributes', () async {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [
+        config.logsConfig.beforeSend = [
           (record) {
             record.body = 'redacted';
             record.attributes = {'safe': true};
@@ -173,7 +173,7 @@ void main() {
 
       test('hook blanking the body drops the record', () async {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [
+        config.logsConfig.beforeSend = [
           (record) {
             record.body = '   ';
             return record;
@@ -188,7 +188,7 @@ void main() {
 
       test('throwing hook is contained and drops the log', () async {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [
+        config.logsConfig.beforeSend = [
           (record) => throw Exception('boom'),
         ];
         await setupWith(config);
@@ -201,7 +201,7 @@ void main() {
       test('callbacks run left-to-right, feeding each output to the next',
           () async {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [
+        config.logsConfig.beforeSend = [
           (record) {
             record.body = '${record.body}-1';
             return record;
@@ -220,7 +220,7 @@ void main() {
 
       test('async hook is awaited', () async {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [
+        config.logsConfig.beforeSend = [
           (record) async {
             await Future<void>.delayed(Duration.zero);
             record.body = 'async';
@@ -244,7 +244,7 @@ void main() {
 
       test('serializes set identity fields and attributes', () {
         final config = PostHogConfig('test_token');
-        config.logs
+        config.logsConfig
           ..serviceName = 'checkout'
           ..serviceVersion = '1.2.3'
           ..environment = 'production'
@@ -260,7 +260,7 @@ void main() {
 
       test('serializes tuning knobs, sending durations as seconds', () {
         final config = PostHogConfig('test_token');
-        config.logs
+        config.logsConfig
           ..flushInterval = const Duration(seconds: 15)
           ..flushAt = 5
           ..maxBatchSize = 25
@@ -280,7 +280,7 @@ void main() {
 
       test('floors sub-second flush/rate-cap durations at 1s (not 0)', () {
         final config = PostHogConfig('test_token');
-        config.logs
+        config.logsConfig
           ..flushInterval = const Duration(milliseconds: 500)
           ..rateCapWindow = const Duration(milliseconds: 1);
 
@@ -293,7 +293,7 @@ void main() {
 
       test('omits the tuning knobs that were left unset', () {
         final config = PostHogConfig('test_token');
-        config.logs
+        config.logsConfig
           ..flushAt = 5
           ..rateCapWindow = const Duration(seconds: 20);
 
@@ -307,7 +307,7 @@ void main() {
 
       test('beforeSend is never serialized', () {
         final config = PostHogConfig('test_token');
-        config.logs.beforeSend = [(record) => record];
+        config.logsConfig.beforeSend = [(record) => record];
 
         expect(
           (config.toMap()['logs'] as Map).containsKey('beforeSend'),

--- a/posthog_flutter/test/posthog_logs_test.dart
+++ b/posthog_flutter/test/posthog_logs_test.dart
@@ -187,8 +187,6 @@ void main() {
       });
 
       test('throwing hook is contained and drops the log', () async {
-        // Fail closed: a throwing redaction hook must not let the unredacted
-        // record through. The exception is logged so the bug stays visible.
         final config = PostHogConfig('test_token');
         config.logs.beforeSend = [
           (record) => throw Exception('boom'),

--- a/posthog_flutter/test/posthog_logs_test.dart
+++ b/posthog_flutter/test/posthog_logs_test.dart
@@ -54,27 +54,23 @@ void main() {
         expect(fake.capturedLogs.single.level, PostHogLogSeverity.info);
       });
 
-      test('each logger level maps to its severity', () async {
-        await setupWith(PostHogConfig('test_token'));
+      final loggerByLevel =
+          <PostHogLogSeverity, Future<void> Function(PostHogLogger)>{
+        PostHogLogSeverity.trace: (l) => l.trace('m'),
+        PostHogLogSeverity.debug: (l) => l.debug('m'),
+        PostHogLogSeverity.info: (l) => l.info('m'),
+        PostHogLogSeverity.warn: (l) => l.warn('m'),
+        PostHogLogSeverity.error: (l) => l.error('m'),
+        PostHogLogSeverity.fatal: (l) => l.fatal('m'),
+      };
+      loggerByLevel.forEach((level, call) {
+        test('logger.${level.name} captures at ${level.name}', () async {
+          await setupWith(PostHogConfig('test_token'));
 
-        await Posthog().logger.trace('a');
-        await Posthog().logger.debug('b');
-        await Posthog().logger.info('c');
-        await Posthog().logger.warn('d');
-        await Posthog().logger.error('e');
-        await Posthog().logger.fatal('f');
+          await call(Posthog().logger);
 
-        expect(
-          fake.capturedLogs.map((c) => c.level).toList(),
-          const [
-            PostHogLogSeverity.trace,
-            PostHogLogSeverity.debug,
-            PostHogLogSeverity.info,
-            PostHogLogSeverity.warn,
-            PostHogLogSeverity.error,
-            PostHogLogSeverity.fatal,
-          ],
-        );
+          expect(fake.capturedLogs.single.level, level);
+        });
       });
     });
 
@@ -190,16 +186,18 @@ void main() {
         expect(fake.capturedLogs, isEmpty);
       });
 
-      test('throwing hook is contained and record continues', () async {
+      test('throwing hook is contained and drops the log', () async {
+        // Fail closed: a throwing redaction hook must not let the unredacted
+        // record through. The exception is logged so the bug stays visible.
         final config = PostHogConfig('test_token');
         config.logs.beforeSend = [
           (record) => throw Exception('boom'),
         ];
         await setupWith(config);
 
-        await Posthog().captureLog(body: 'still sent');
+        await Posthog().captureLog(body: 'dropped on throw');
 
-        expect(fake.capturedLogs.single.body, 'still sent');
+        expect(fake.capturedLogs, isEmpty);
       });
 
       test('callbacks run left-to-right, feeding each output to the next',

--- a/posthog_flutter/test/posthog_logs_test.dart
+++ b/posthog_flutter/test/posthog_logs_test.dart
@@ -282,6 +282,19 @@ void main() {
         });
       });
 
+      test('floors sub-second flush/rate-cap durations at 1s (not 0)', () {
+        final config = PostHogConfig('test_token');
+        config.logs
+          ..flushInterval = const Duration(milliseconds: 500)
+          ..rateCapWindow = const Duration(milliseconds: 1);
+
+        // Native windows are whole seconds; truncating to 0 would disable the
+        // rate cap / trigger continuous flushing, so we floor at 1s.
+        final logs = config.toMap()['logs'] as Map;
+        expect(logs['flushIntervalSeconds'], 1);
+        expect(logs['rateCapWindowSeconds'], 1);
+      });
+
       test('omits the tuning knobs that were left unset', () {
         final config = PostHogConfig('test_token');
         config.logs

--- a/posthog_flutter/test/posthog_logs_test.dart
+++ b/posthog_flutter/test/posthog_logs_test.dart
@@ -1,0 +1,310 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+
+import 'posthog_flutter_platform_interface_fake.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Posthog logs', () {
+    late PosthogFlutterPlatformFake fake;
+
+    setUp(() async {
+      fake = PosthogFlutterPlatformFake();
+      PosthogFlutterPlatformInterface.instance = fake;
+      await Posthog().close();
+    });
+
+    Future<void> setupWith(PostHogConfig config) async {
+      await Posthog().setup(config);
+    }
+
+    group('Public capture API', () {
+      test('captureLog with explicit level forwards body and level', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(
+          body: 'checkout failed',
+          level: PostHogLogSeverity.error,
+        );
+
+        expect(fake.capturedLogs, hasLength(1));
+        expect(fake.capturedLogs.single.body, 'checkout failed');
+        expect(fake.capturedLogs.single.level, PostHogLogSeverity.error);
+      });
+
+      test('logger helper delegates to captureLog', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().logger.info('ready', {'region': 'us'});
+
+        expect(fake.capturedLogs, hasLength(1));
+        final call = fake.capturedLogs.single;
+        expect(call.body, 'ready');
+        expect(call.level, PostHogLogSeverity.info);
+        expect(call.attributes, {'region': 'us'});
+      });
+
+      test('missing level defaults to info', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(body: 'hello');
+
+        expect(fake.capturedLogs.single.level, PostHogLogSeverity.info);
+      });
+
+      test('each logger level maps to its severity', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().logger.trace('a');
+        await Posthog().logger.debug('b');
+        await Posthog().logger.info('c');
+        await Posthog().logger.warn('d');
+        await Posthog().logger.error('e');
+        await Posthog().logger.fatal('f');
+
+        expect(
+          fake.capturedLogs.map((c) => c.level).toList(),
+          const [
+            PostHogLogSeverity.trace,
+            PostHogLogSeverity.debug,
+            PostHogLogSeverity.info,
+            PostHogLogSeverity.warn,
+            PostHogLogSeverity.error,
+            PostHogLogSeverity.fatal,
+          ],
+        );
+      });
+    });
+
+    group('Trace correlation fields', () {
+      test('forwards traceId, spanId, and traceFlags', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(
+          body: 'request finished',
+          traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+          spanId: '00f067aa0ba902b7',
+          traceFlags: 1,
+        );
+
+        final call = fake.capturedLogs.single;
+        expect(call.traceId, '4bf92f3577b34da6a3ce929d0e0e4736');
+        expect(call.spanId, '00f067aa0ba902b7');
+        expect(call.traceFlags, 1);
+      });
+
+      test('forwards an explicit traceFlags of 0 (sampled-false)', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(body: 'x', traceFlags: 0);
+
+        expect(fake.capturedLogs.single.traceFlags, 0);
+      });
+
+      test('trace fields are null when not provided', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(body: 'x');
+
+        final call = fake.capturedLogs.single;
+        expect(call.traceId, isNull);
+        expect(call.spanId, isNull);
+        expect(call.traceFlags, isNull);
+      });
+
+      test('logger facade does not carry trace fields', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().logger.info('x');
+
+        final call = fake.capturedLogs.single;
+        expect(call.traceId, isNull);
+        expect(call.spanId, isNull);
+        expect(call.traceFlags, isNull);
+      });
+    });
+
+    group('Capture-time gating', () {
+      test('whitespace-only body is dropped', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(body: '   ');
+
+        expect(fake.capturedLogs, isEmpty);
+      });
+
+      test('empty body is dropped', () async {
+        await setupWith(PostHogConfig('test_token'));
+
+        await Posthog().captureLog(body: '');
+
+        expect(fake.capturedLogs, isEmpty);
+      });
+    });
+
+    group('beforeSend hook', () {
+      test('hook returning null drops the record', () async {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [(record) => null];
+        await setupWith(config);
+
+        await Posthog().captureLog(body: 'secret');
+
+        expect(fake.capturedLogs, isEmpty);
+      });
+
+      test('hook can mutate body and attributes', () async {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [
+          (record) {
+            record.body = 'redacted';
+            record.attributes = {'safe': true};
+            return record;
+          },
+        ];
+        await setupWith(config);
+
+        await Posthog().captureLog(
+          body: 'original',
+          attributes: {'password': 'hunter2'},
+        );
+
+        expect(fake.capturedLogs.single.body, 'redacted');
+        expect(fake.capturedLogs.single.attributes, {'safe': true});
+      });
+
+      test('hook blanking the body drops the record', () async {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [
+          (record) {
+            record.body = '   ';
+            return record;
+          },
+        ];
+        await setupWith(config);
+
+        await Posthog().captureLog(body: 'original');
+
+        expect(fake.capturedLogs, isEmpty);
+      });
+
+      test('throwing hook is contained and record continues', () async {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [
+          (record) => throw Exception('boom'),
+        ];
+        await setupWith(config);
+
+        await Posthog().captureLog(body: 'still sent');
+
+        expect(fake.capturedLogs.single.body, 'still sent');
+      });
+
+      test('callbacks run left-to-right, feeding each output to the next',
+          () async {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [
+          (record) {
+            record.body = '${record.body}-1';
+            return record;
+          },
+          (record) {
+            record.body = '${record.body}-2';
+            return record;
+          },
+        ];
+        await setupWith(config);
+
+        await Posthog().captureLog(body: 'x');
+
+        expect(fake.capturedLogs.single.body, 'x-1-2');
+      });
+
+      test('async hook is awaited', () async {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [
+          (record) async {
+            await Future<void>.delayed(Duration.zero);
+            record.body = 'async';
+            return record;
+          },
+        ];
+        await setupWith(config);
+
+        await Posthog().captureLog(body: 'x');
+
+        expect(fake.capturedLogs.single.body, 'async');
+      });
+    });
+
+    group('PostHogLogsConfig.toMap', () {
+      test('omits unset identity fields and empty attributes', () {
+        final config = PostHogConfig('test_token');
+
+        expect(config.toMap()['logs'], isEmpty);
+      });
+
+      test('serializes set identity fields and attributes', () {
+        final config = PostHogConfig('test_token');
+        config.logs
+          ..serviceName = 'checkout'
+          ..serviceVersion = '1.2.3'
+          ..environment = 'production'
+          ..resourceAttributes = {'region': 'us'};
+
+        expect(config.toMap()['logs'], {
+          'serviceName': 'checkout',
+          'serviceVersion': '1.2.3',
+          'environment': 'production',
+          'resourceAttributes': {'region': 'us'},
+        });
+      });
+
+      test('serializes tuning knobs, sending durations as seconds', () {
+        final config = PostHogConfig('test_token');
+        config.logs
+          ..flushInterval = const Duration(seconds: 15)
+          ..flushAt = 5
+          ..maxBatchSize = 25
+          ..maxBufferSize = 200
+          ..rateCapMaxLogs = 1000
+          ..rateCapWindow = const Duration(seconds: 20);
+
+        expect(config.toMap()['logs'], {
+          'flushIntervalSeconds': 15,
+          'flushAt': 5,
+          'maxBatchSize': 25,
+          'maxBufferSize': 200,
+          'rateCapMaxLogs': 1000,
+          'rateCapWindowSeconds': 20,
+        });
+      });
+
+      test('omits the tuning knobs that were left unset', () {
+        final config = PostHogConfig('test_token');
+        config.logs
+          ..flushAt = 5
+          ..rateCapWindow = const Duration(seconds: 20);
+
+        // Each field is guarded independently, so a partial config is the
+        // realistic shape: only the two set keys should appear.
+        expect(config.toMap()['logs'], {
+          'flushAt': 5,
+          'rateCapWindowSeconds': 20,
+        });
+      });
+
+      test('beforeSend is never serialized', () {
+        final config = PostHogConfig('test_token');
+        config.logs.beforeSend = [(record) => record];
+
+        expect(
+          (config.toMap()['logs'] as Map).containsKey('beforeSend'),
+          isFalse,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Brings PostHog's structured logging to Flutter, matching the iOS, Android, web, and React Native SDKs. App developers can now ship logs from their Flutter app and see them next to their events and session replays.

It's a thin wrapper: Dart `Posthog().captureLog(...)` / `Posthog().logger.{trace…fatal}` forward over the method channel to the native SDKs (iOS `PostHogSDK.captureLog`, Android `PostHog.captureLog`, posthog-js on web), which handle batching, persistence, rate-capping, OTLP transport, and auto-context. Identity/tuning config + a Dart-side `beforeSend` live on `config.logsConfig`. W3C trace fields are optional and pass-through.

Raises the `posthog-android` floor to `3.48.0` (the release with the public `captureLog` trace API).

Closes PostHog/posthog#40528.

## :green_heart: How did you test it?

- **Unit tests (161):** capture-time gating, `beforeSend` (incl. throwing-hook drops the log), severity→wire mapping per level, trace fields incl. the explicit `traceFlags: 0` case, config serialization, and the web handler (run in CI via `flutter test --platform chrome`).
- **On-device, end-to-end, all three platforms** — captured `captureLog` + `logger.error`, confirmed the OTLP `POST /i/v1/logs → 200` and the records are queryable in PostHog with correct severities, attributes, and native auto-context:
  - **Android** — physical Pixel 4 (Android 13).
  - **iOS** — iPhone 17 simulator (scope `posthog-ios`).
  - **Web** — Chrome via a production `flutter build web` + browser load (`url.full` auto-context; posthog-js path). Note: `flutter run -d chrome` hits an unrelated flutter-tooling DWDS crash in my env, so web was verified via the built app.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
