### PR TITLE
chore: split CI lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Linting and formatting checks
-  lint:
-    runs-on: macos-26
+  dart-format:
+    name: Dart format
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+
+      - name: Check Dart formatting
+        run: make checkFormatDart
+
+  dart-analyze:
+    name: Dart analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
       # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
       # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
@@ -34,13 +44,32 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: SDK format check
-        run: |
-          make installLinters
-          make checkFormatDart
-          make analyzeDart
-          make formatKotlin
-          make formatSwift
+      - name: Analyze Dart
+        run: make analyzeDart
+
+  kotlin-format:
+    name: Kotlin format
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install ktlint
+        run: brew install ktlint
+
+      - name: Check Kotlin formatting
+        run: make checkFormatKotlin
+
+  swift-format:
+    name: Swift format
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install swiftformat
+        run: brew install swiftformat
+
+      - name: Check Swift formatting
+        run: make checkFormatSwift
 
   # Unit tests
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
 
       - name: Check Dart formatting
         run: make checkFormatDart

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format formatKotlin formatSwift formatDart checkDart installLinters test
+.PHONY: format formatKotlin formatSwift formatDart checkFormatDart checkFormatKotlin checkFormatSwift analyzeDart installLinters test
 
 format: formatSwift formatKotlin formatDart
 
@@ -9,9 +9,15 @@ installLinters:
 formatKotlin:
 	ktlint --format --baseline=posthog_flutter/ktlint-baseline.xml posthog_flutter/android/**/*.kt
 
+checkFormatKotlin:
+	ktlint --baseline=posthog_flutter/ktlint-baseline.xml posthog_flutter/android/**/*.kt
+
 # swiftlint darwin/posthog_flutter/Sources --fix conflicts with swiftformat
 formatSwift:
 	swiftformat posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter --swiftversion 5.3
+
+checkFormatSwift:
+	swiftformat posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter --swiftversion 5.3 --lint
 
 formatDart:
 	dart format .

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -60,14 +60,15 @@ class PosthogFlutterPlugin :
             }
 
             val projectToken =
-                (bundle.getString("com.posthog.posthog.PROJECT_TOKEN")
-                    ?: bundle.getString("com.posthog.posthog.API_KEY"))
-                    ?.trim()
+                (
+                    bundle.getString("com.posthog.posthog.PROJECT_TOKEN")
+                        ?: bundle.getString("com.posthog.posthog.API_KEY")
+                )?.trim()
 
             if (!bundle.containsKey("com.posthog.posthog.PROJECT_TOKEN") && bundle.containsKey("com.posthog.posthog.API_KEY")) {
                 Log.w(
                     "PostHog",
-                    "com.posthog.posthog.API_KEY is deprecated and will be removed in the next major version. Use com.posthog.posthog.PROJECT_TOKEN instead!"
+                    "com.posthog.posthog.API_KEY is deprecated and will be removed in the next major version. Use com.posthog.posthog.PROJECT_TOKEN instead!",
                 )
             }
 
@@ -76,16 +77,19 @@ class PosthogFlutterPlugin :
                 return
             }
 
-            val host = bundle.getString("com.posthog.posthog.POSTHOG_HOST", PostHogConfig.DEFAULT_HOST)
-                ?.trim()
-                ?.takeIf { it.isNotEmpty() }
-                ?: PostHogConfig.DEFAULT_HOST
+            val host =
+                bundle
+                    .getString("com.posthog.posthog.POSTHOG_HOST", PostHogConfig.DEFAULT_HOST)
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: PostHogConfig.DEFAULT_HOST
             // Check new key first, then legacy key, default to true
-            val captureApplicationLifecycleEvents = if (bundle.containsKey("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS")) {
-                bundle.getBoolean("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS", true)
-            } else {
-                bundle.getBoolean("com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS", true)
-            }
+            val captureApplicationLifecycleEvents =
+                if (bundle.containsKey("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS")) {
+                    bundle.getBoolean("com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS", true)
+                } else {
+                    bundle.getBoolean("com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS", true)
+                }
             val debug = bundle.getBoolean("com.posthog.posthog.DEBUG", false)
 
             val posthogConfig = mutableMapOf<String, Any>()
@@ -310,13 +314,14 @@ class PosthogFlutterPlugin :
 
     private fun setupPostHog(posthogConfig: Map<String, Any>) {
         val projectToken =
-            ((posthogConfig["projectToken"] as String?)
-                ?: (posthogConfig["apiKey"] as String?))
-                ?.trim()
+            (
+                (posthogConfig["projectToken"] as String?)
+                    ?: (posthogConfig["apiKey"] as String?)
+            )?.trim()
         if (!posthogConfig.containsKey("projectToken") && posthogConfig.containsKey("apiKey")) {
             Log.w(
                 "PostHog",
-                "apiKey is deprecated and will be removed in the next major version. Use projectToken instead!"
+                "apiKey is deprecated and will be removed in the next major version. Use projectToken instead!",
             )
         }
         if (projectToken.isNullOrEmpty()) {

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -61,7 +61,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         if Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.PROJECT_TOKEN") == nil,
-           Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") != nil {
+           Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.API_KEY") != nil
+        {
             print("[PostHog] com.posthog.posthog.API_KEY is deprecated and will be removed in the next major version. Use com.posthog.posthog.PROJECT_TOKEN instead!")
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

**Problem:** CI currently groups Dart formatting/analyze plus Kotlin and Swift formatting into one macOS lint job, making failures less targeted and requiring macOS runners for checks that can run on Ubuntu. Splitting these checks also exposed existing Kotlin/Swift formatter drift and the Dart format job needed Flutter dependencies installed to honor the repo analysis options.

**Changes:**
- Split CI linting into separate Dart format, Dart analyze, Kotlin format, and Swift format jobs.
- Run Dart format/analyze jobs on Ubuntu.
- Install Flutter dependencies before checking Dart formatting so package-based analysis options resolve correctly.
- Add dedicated Makefile targets for checking Kotlin and Swift formatting without applying changes.
- Apply ktlint and swiftformat to the existing platform plugin sources.

## :green_heart: How did you test it?

- `flutter pub get`
- `make checkFormatDart checkFormatKotlin checkFormatSwift`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
