### PR TITLE
chore: Add pub publish dry-run CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,27 @@ jobs:
         working-directory: ./posthog_flutter
         run: flutter test --platform chrome test/posthog_flutter_web_handler_test.dart
 
+  publish-dry-run:
+    name: Pub publish dry run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
+      # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
+      # "Require actions to be pinned to a full-length commit SHA" policy. Tracks upstream.
+      - uses: axi92/flutter-action@36d2c2625bac6ea011cd7808d2a01bd8a7e5c766 # feature/pin-action-sha @ 2026-04-30
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Validate pub package
+        working-directory: ./posthog_flutter
+        run: flutter pub publish --dry-run
+
   # Apple builds (iOS and macOS) with CocoaPods and Swift Package Manager
   build-apple:
     runs-on: macos-26


### PR DESCRIPTION
## :bulb: Motivation and Context
Add a CI check that validates the Flutter package can be published to pub.dev before release by running `flutter pub publish --dry-run`.

## :green_heart: How did you test it?
Not run locally; this adds a GitHub Actions validation job.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
