### PR TITLE
test: Add public API baseline probe

### DIFF
--- a/posthog_flutter/lib/posthog_flutter.dart
+++ b/posthog_flutter/lib/posthog_flutter.dart
@@ -1,6 +1,9 @@
 /// Public Flutter API for the PostHog SDK.
 library posthog_flutter;
 
+/// Test-only public API marker used to verify baseline checks.
+const String publicApiBaselineProbe = 'public-api-baseline-probe';
+
 export 'src/feature_flag_result.dart';
 export 'src/logs/posthog_log_record.dart';
 export 'src/logs/posthog_log_severity.dart';


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds a tiny test-only public API surface so the Dart public API check added in #437 can be observed failing when the baseline is not updated.

## :green_heart: How did you test it?

- Ran `scripts/check-api-dart.sh` and confirmed it fails because `api/posthog_flutter.api.json` was intentionally not updated.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
