### PR TITLE
ci: restore publish workflow fetch depth

### DIFF
--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Validate tag matches version bump
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Check for changesets
         id: check
@@ -85,6 +86,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
+          fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
       - name: Configure Git


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Rollback the removal of `fetch-depth: 0` from the publish workflows in #437 so release-related checkout steps keep the full Git history available.

## :green_heart: How did you test it?

Verified the workflow diffs locally with `git diff` and confirmed the restored `fetch-depth: 0` entries with `rg`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
