### PR TITLE
feat: add addExceptionStep API for error tracking

### DIFF
--- a/.changeset/witty-pandas-dance.md
+++ b/.changeset/witty-pandas-dance.md
@@ -10,4 +10,4 @@ Steps accumulate in a rolling, byte-bounded buffer owned by the embedded native 
 Posthog().addExceptionStep('User tapped Checkout', properties: {'screen': 'cart'});
 ```
 
-Requires `posthog-android` and `posthog-ios` versions that support exception steps. On web, steps are forwarded to posthog-js.
+Requires `posthog-android` and `posthog-ios` versions that support exception steps. On web, steps are forwarded to posthog-js, and exceptions captured via `captureException` now route through posthog-js's `captureException` (instead of a generic `$exception` capture) so steps and other required metadata attach.

--- a/.changeset/witty-pandas-dance.md
+++ b/.changeset/witty-pandas-dance.md
@@ -1,0 +1,13 @@
+---
+"posthog_flutter": minor
+---
+
+Add `addExceptionStep`, recording breadcrumb-style context records that attach to every captured `$exception` as `$exception_steps`, giving the error-tracking UI a timeline of recent activity leading up to each error.
+
+Steps accumulate in a rolling, byte-bounded buffer owned by the embedded native SDK, so they also survive native fatal crashes and attach to the crash `$exception` reported on the next launch. The buffer rotates only by byte-budget eviction and is not cleared by a capture or an identity change. Configure it on `config.errorTrackingConfig.exceptionSteps` (`enabled`, `maxBytes`).
+
+```dart
+Posthog().addExceptionStep('User tapped Checkout', properties: {'screen': 'cart'});
+```
+
+Requires `posthog-android` and `posthog-ios` versions that support exception steps. On web, steps are forwarded to posthog-js.

--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -863,6 +863,37 @@
                         "isDeprecated": false,
                         "isExperimental": false,
                         "isStatic": false,
+                        "name": "addExceptionStep",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": false,
+                                "isRequired": true,
+                                "name": "message",
+                                "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                                "typeName": "String"
+                            },
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": true,
+                                "isRequired": false,
+                                "name": "properties",
+                                "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                                "typeName": "Map<String, Object>?"
+                            }
+                        ],
+                        "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                        "returnTypeName": "Future<void>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
                         "name": "close",
                         "parameters": [],
                         "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
@@ -1692,6 +1723,37 @@
                         "isDeprecated": false,
                         "isExperimental": false,
                         "isStatic": false,
+                        "name": "addExceptionStep",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": false,
+                                "isRequired": true,
+                                "name": "message",
+                                "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                                "typeName": "String"
+                            },
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": true,
+                                "isRequired": false,
+                                "name": "properties",
+                                "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                                "typeName": "Map<String, Object>?"
+                            }
+                        ],
+                        "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                        "returnTypeName": "Future<void>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
                         "name": "close",
                         "parameters": [],
                         "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
@@ -2439,6 +2501,17 @@
                         "name": "captureIsolateErrors",
                         "relativePath": "lib/src/posthog_config.dart",
                         "typeName": "bool"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": false,
+                        "name": "exceptionSteps",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "PostHogExceptionStepsConfig"
                     }
                 ],
                 "isDeprecated": false,
@@ -2446,6 +2519,71 @@
                 "isRequired": false,
                 "isSealed": false,
                 "name": "PostHogErrorTrackingConfig",
+                "relativePath": "lib/src/posthog_config.dart",
+                "superTypeNames": [
+                    "Object"
+                ],
+                "typeParameterNames": []
+            },
+            {
+                "entryPoints": [
+                    "posthog_flutter.dart"
+                ],
+                "executableDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "toMap",
+                        "parameters": [],
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "returnTypeName": "Map<String, dynamic>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "new",
+                        "parameters": [],
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "returnTypeName": "PostHogExceptionStepsConfig",
+                        "type": "constructor",
+                        "typeParameterNames": []
+                    }
+                ],
+                "fieldDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "enabled",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "bool"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "maxBytes",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "int"
+                    }
+                ],
+                "isDeprecated": false,
+                "isExperimental": false,
+                "isRequired": false,
+                "isSealed": false,
+                "name": "PostHogExceptionStepsConfig",
                 "relativePath": "lib/src/posthog_config.dart",
                 "superTypeNames": [
                     "Object"
@@ -3913,6 +4051,37 @@
                                 "name": "stackTrace",
                                 "relativePath": "lib/src/posthog.dart",
                                 "typeName": "StackTrace?"
+                            },
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": true,
+                                "isRequired": false,
+                                "name": "properties",
+                                "relativePath": "lib/src/posthog.dart",
+                                "typeName": "Map<String, Object>?"
+                            }
+                        ],
+                        "relativePath": "lib/src/posthog.dart",
+                        "returnTypeName": "Future<void>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "addExceptionStep",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": false,
+                                "isRequired": true,
+                                "name": "message",
+                                "relativePath": "lib/src/posthog.dart",
+                                "typeName": "String"
                             },
                             {
                                 "isDeprecated": false,

--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -2538,7 +2538,7 @@
                         "name": "toMap",
                         "parameters": [],
                         "relativePath": "lib/src/posthog_config.dart",
-                        "returnTypeName": "Map<String, dynamic>",
+                        "returnTypeName": "Map<String, Object>",
                         "type": "method",
                         "typeParameterNames": []
                     },

--- a/example/lib/exception_steps_screen.dart
+++ b/example/lib/exception_steps_screen.dart
@@ -135,7 +135,10 @@ class _ExceptionStepsScreenState extends State<ExceptionStepsScreen> {
                 child: const Text('Steps → native crash (will crash app!)'),
               ),
               const Divider(),
-              const Text('Activity', style: TextStyle(fontWeight: FontWeight.bold)),
+              const Text(
+                'Activity',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
               for (final entry in _log)
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 2),
@@ -149,9 +152,9 @@ class _ExceptionStepsScreenState extends State<ExceptionStepsScreen> {
   }
 
   Widget _section(String title) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
-      );
+    padding: const EdgeInsets.symmetric(vertical: 8),
+    child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+  );
 }
 
 /// Thrown by the "unhandled Flutter error" test so it groups as its own issue in

--- a/example/lib/exception_steps_screen.dart
+++ b/example/lib/exception_steps_screen.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+import 'error_example.dart';
+
+/// Manual testing for [Posthog.addExceptionStep].
+///
+/// Exception steps are buffered breadcrumbs that the embedded native SDK
+/// attaches to the next `$exception` event as `$exception_steps`. Use the
+/// buttons to seed steps, then trigger an exception and confirm the steps ride
+/// along on the captured event in PostHog.
+class ExceptionStepsScreen extends StatefulWidget {
+  const ExceptionStepsScreen({super.key});
+
+  @override
+  State<ExceptionStepsScreen> createState() => _ExceptionStepsScreenState();
+}
+
+class _ExceptionStepsScreenState extends State<ExceptionStepsScreen> {
+  static const _exampleChannel = MethodChannel('posthog_flutter_example');
+  final _posthog = Posthog();
+  final List<String> _log = [];
+
+  void _note(String message) {
+    setState(() => _log.insert(0, message));
+  }
+
+  Future<void> _addSingleStep() async {
+    final at = DateTime.now().toIso8601String();
+    await _posthog.addExceptionStep('Manual breadcrumb at $at');
+    _note('Added 1 step');
+  }
+
+  Future<void> _addBatchWithMixedProperties() async {
+    await _posthog.addExceptionStep('App launched test flow');
+    await _posthog.addExceptionStep(
+      'User tapped Checkout',
+      properties: {
+        'screen': 'cart',
+        'item_count': 3,
+        'total': 42.5,
+        'is_member': true,
+        'at': DateTime.now(),
+        'tags': ['promo', 'first_order'],
+        'meta': {'experiment': 'b'},
+      },
+    );
+    await _posthog.addExceptionStep(
+      'Network request started',
+      properties: {'url': 'https://example.com/pay', 'method': 'POST'},
+    );
+    _note('Added 3 steps (mixed properties)');
+  }
+
+  /// High-frequency flood meant to exceed the default 32 KB byte budget so the
+  /// native FIFO buffer evicts the oldest steps; only the most recent survive.
+  Future<void> _floodSteps() async {
+    const total = 300;
+    final payload = 'x' * 128;
+    for (var i = 0; i < total; i++) {
+      await _posthog.addExceptionStep(
+        'Flood step $i',
+        properties: {'iteration': i, 'payload': payload},
+      );
+    }
+    _note('Flooded $total steps (oldest should be evicted)');
+  }
+
+  Future<void> _stepsThenHandledException() async {
+    await _addBatchWithMixedProperties();
+    await ErrorExample().causeHandledDivisionError();
+    _note('Captured handled exception — check \$exception_steps');
+  }
+
+  Future<void> _stepsThenUnhandledError() async {
+    await _addBatchWithMixedProperties();
+    _note('Throwing unhandled error — check \$exception_steps');
+    // Distinct type from the handled path's IntegerDivisionByZeroException so
+    // this surfaces as its own issue in PostHog.
+    throw const UnhandledExceptionStepsError(
+      'Unhandled error from the Exception Steps screen',
+    );
+  }
+
+  Future<void> _stepsThenNativeCrash() async {
+    await _addBatchWithMixedProperties();
+    _note('Crashing — steps should survive and attach on next launch');
+    await Future.delayed(const Duration(seconds: 1));
+    await _exampleChannel.invokeMethod('triggerNativeCrash');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Exception Steps')),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _section('Add steps'),
+              ElevatedButton(
+                onPressed: _addSingleStep,
+                child: const Text('Add single step'),
+              ),
+              ElevatedButton(
+                onPressed: _addBatchWithMixedProperties,
+                child: const Text('Add 3 steps (mixed properties)'),
+              ),
+              ElevatedButton(
+                onPressed: _floodSteps,
+                child: const Text('Flood 300 steps (high-frequency)'),
+              ),
+              _section('Trigger exception — steps should attach'),
+              ElevatedButton(
+                onPressed: _stepsThenHandledException,
+                child: const Text('Steps → handled exception'),
+              ),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red,
+                  foregroundColor: Colors.white,
+                ),
+                onPressed: _stepsThenUnhandledError,
+                child: const Text('Steps → unhandled Flutter error'),
+              ),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.deepOrange,
+                  foregroundColor: Colors.white,
+                ),
+                onPressed: _stepsThenNativeCrash,
+                child: const Text('Steps → native crash (will crash app!)'),
+              ),
+              const Divider(),
+              const Text('Activity', style: TextStyle(fontWeight: FontWeight.bold)),
+              for (final entry in _log)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Text(entry),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+      );
+}
+
+/// Thrown by the "unhandled Flutter error" test so it groups as its own issue in
+/// PostHog, separate from the handled path's IntegerDivisionByZeroException.
+class UnhandledExceptionStepsError implements Exception {
+  const UnhandledExceptionStepsError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'UnhandledExceptionStepsError: $message';
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:posthog_flutter_example/error_example.dart';
 
+import 'exception_steps_screen.dart';
 import 'masking_tests_screen.dart';
 
 Future<void> main() async {
@@ -160,6 +161,23 @@ class InitialScreenState extends State<InitialScreen> {
                     );
                   },
                   child: const Text('Masking Tests'),
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.indigo,
+                    foregroundColor: Colors.white,
+                  ),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const ExceptionStepsScreen(),
+                        settings: const RouteSettings(name: 'exception_steps'),
+                      ),
+                    );
+                  },
+                  child: const Text('Exception Steps'),
                 ),
                 const Padding(
                   padding: EdgeInsets.all(8.0),

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,8 +64,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.48.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.48.0,4.0.0]'
+        // + Version 3.51.0 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.51.0,4.0.0]'
     }
 
     testOptions {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -219,6 +219,10 @@ class PosthogFlutterPlugin :
                 captureException(call, result)
             }
 
+            "addExceptionStep" -> {
+                addExceptionStep(call, result)
+            }
+
             "close" -> {
                 close(result)
             }
@@ -408,6 +412,14 @@ class PosthogFlutterPlugin :
                     }
                     errorConfig.getIfNotNull<List<String>>("inAppIncludes") { includes ->
                         errorTrackingConfig.inAppIncludes.addAll(includes)
+                    }
+                    errorConfig.getIfNotNull<Map<String, Any>>("exceptionSteps") { stepsConfig ->
+                        stepsConfig.getIfNotNull<Boolean>("enabled") {
+                            errorTrackingConfig.exceptionSteps.enabled = it
+                        }
+                        stepsConfig.getIfNotNull<Int>("maxBytes") {
+                            errorTrackingConfig.exceptionSteps.maxBytes = it
+                        }
                     }
                 }
 
@@ -857,6 +869,24 @@ class PosthogFlutterPlugin :
             result.success(null)
         } catch (e: Throwable) {
             result.error("CAPTURE_EXCEPTION_ERROR", "Failed to capture exception: ${e.message}", null)
+        }
+    }
+
+    private fun addExceptionStep(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val message: String =
+                call.argument("message") ?: run {
+                    result.error("PosthogFlutterException", "Missing argument: message", null)
+                    return
+                }
+            val properties: Map<String, Any>? = call.argument("properties")
+            PostHog.addExceptionStep(message, properties)
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
         }
     }
 

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.59.3 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.59.3', '< 4.0.0'
+  # ~> Version 3.61.0 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.61.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.59.3"..<"4.0.0")
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.61.0"..<"4.0.0")
     ],
     targets: [
         .target(

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -206,6 +206,15 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             if let inAppByDefault = errorConfig["inAppByDefault"] as? Bool {
                 config.errorTrackingConfig.inAppByDefault = inAppByDefault
             }
+
+            if let exceptionSteps = errorConfig["exceptionSteps"] as? [String: Any] {
+                if let enabled = exceptionSteps["enabled"] as? Bool {
+                    config.errorTrackingConfig.exceptionSteps.enabled = enabled
+                }
+                if let maxBytes = exceptionSteps["maxBytes"] as? Int {
+                    config.errorTrackingConfig.exceptionSteps.maxBytes = maxBytes
+                }
+            }
         }
 
         // Configure logs (beforeSend runs Dart-side). Each field is only present
@@ -311,6 +320,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             flush(result)
         case "captureException":
             captureException(call, result: result)
+        case "addExceptionStep":
+            addExceptionStep(call, result: result)
         case "close":
             close(result)
         case "sendMetaEvent":
@@ -979,6 +990,19 @@ extension PosthogFlutterPlugin {
 
         // Use capture method with timestamp to ensure Flutter timestamp is used
         PostHogSDK.shared.capture("$exception", properties: properties, timestamp: timestamp)
+        result(nil)
+    }
+
+    private func addExceptionStep(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let arguments = call.arguments as? [String: Any],
+              let message = arguments["message"] as? String
+        else {
+            _badArgumentError(result)
+            return
+        }
+
+        let properties = arguments["properties"] as? [String: Any]
+        PostHogSDK.shared.addExceptionStep(message, properties: properties)
         result(nil)
     }
 

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -413,4 +413,20 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
     );
     return result as bool? ?? false;
   }
+
+  @override
+  Future<void> addExceptionStep(
+    String message, {
+    Map<String, Object>? properties,
+  }) async {
+    final normalizedProperties =
+        properties != null ? PropertyNormalizer.normalize(properties) : null;
+
+    return handleWebMethodCall(
+      MethodCall('addExceptionStep', {
+        'message': message,
+        if (normalizedProperties != null) 'properties': normalizedProperties,
+      }),
+    );
+  }
 }

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -675,9 +675,10 @@ class Posthog {
   /// next launch.
   ///
   /// The [message] is a short, non-empty description of what happened; an empty
-  /// message is ignored. The optional [properties] are additional context. The
-  /// reserved keys `$message` and `$timestamp` are stripped — the SDK sets the
-  /// canonical values, including a timestamp captured when the step is recorded.
+  /// or whitespace-only message is ignored. The optional [properties] are
+  /// additional context. The reserved keys `$message` and `$timestamp` are
+  /// stripped — the SDK sets the canonical values, including a timestamp
+  /// captured when the step is recorded.
   ///
   /// Recording never throws into your app and does not block the caller.
   ///
@@ -697,7 +698,7 @@ class Posthog {
     String message, {
     Map<String, Object>? properties,
   }) {
-    if (message.isEmpty) {
+    if (message.trim().isEmpty) {
       debugPrint('[PostHog] addExceptionStep called with an empty message.');
       return Future<void>.value();
     }

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -701,6 +701,12 @@ class Posthog {
       debugPrint('[PostHog] addExceptionStep called with an empty message.');
       return Future<void>.value();
     }
+    // Honor the documented no-op contract on every platform: native enforces
+    // `enabled` via the config forwarded at setup, but on web `setup` doesn't
+    // push it to posthog-js, so guard here too.
+    if (_config?.errorTrackingConfig.exceptionSteps.enabled == false) {
+      return Future<void>.value();
+    }
     return _posthog.addExceptionStep(message, properties: properties);
   }
 

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -661,6 +661,49 @@ class Posthog {
     );
   }
 
+  /// Records an exception step (breadcrumb-style context record).
+  ///
+  /// Steps accumulate in a rolling, byte-bounded buffer and are attached to
+  /// every captured `$exception` event as `$exception_steps`, giving the
+  /// PostHog error-tracking UI a timeline of recent activity leading up to each
+  /// error. The buffer rotates only by byte-budget eviction (see
+  /// [PostHogExceptionStepsConfig.maxBytes]) and is not cleared by a capture or
+  /// an identity change.
+  ///
+  /// The buffer is owned by the embedded native SDK, so steps also survive
+  /// native fatal crashes and attach to the crash `$exception` reported on the
+  /// next launch.
+  ///
+  /// The [message] is a short, non-empty description of what happened; an empty
+  /// message is ignored. The optional [properties] are additional context. The
+  /// reserved keys `$message` and `$timestamp` are stripped — the SDK sets the
+  /// canonical values, including a timestamp captured when the step is recorded.
+  ///
+  /// Recording never throws into your app and does not block the caller.
+  ///
+  /// **Note:**
+  /// - Flutter web: forwarded to posthog-js. Steps attach to exceptions
+  ///   captured by posthog-js, but not to exceptions captured via
+  ///   [captureException] on web.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// Posthog().addExceptionStep(
+  ///   'User tapped Checkout',
+  ///   properties: {'screen': 'cart'},
+  /// );
+  /// ```
+  Future<void> addExceptionStep(
+    String message, {
+    Map<String, Object>? properties,
+  }) {
+    if (message.isEmpty) {
+      debugPrint('[PostHog] addExceptionStep called with an empty message.');
+      return Future<void>.value();
+    }
+    return _posthog.addExceptionStep(message, properties: properties);
+  }
+
   /// Closes the PostHog SDK and cleans up resources.
   ///
   /// Returns a [Future] that completes when platform resources have been closed.

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -688,7 +688,7 @@ class PostHogExceptionStepsConfig {
   var maxBytes = 32768;
 
   /// Converts this configuration to a platform-channel map.
-  Map<String, dynamic> toMap() {
+  Map<String, Object> toMap() {
     return {
       'enabled': enabled,
       'maxBytes': maxBytes,

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -630,6 +630,12 @@ class PostHogErrorTrackingConfig {
   /// Default: false
   var captureIsolateErrors = false;
 
+  /// Configuration for exception steps (breadcrumb-style context records
+  /// attached to every captured `$exception` as `$exception_steps`).
+  ///
+  /// Record steps with `Posthog().addExceptionStep()`.
+  final exceptionSteps = PostHogExceptionStepsConfig();
+
   /// Converts this error tracking configuration to a platform-channel map.
   ///
   /// Returns values consumed by the Android, Apple, and Dart exception capture
@@ -644,6 +650,48 @@ class PostHogErrorTrackingConfig {
       'capturePlatformDispatcherErrors': capturePlatformDispatcherErrors,
       'captureNativeExceptions': captureNativeExceptions,
       'captureIsolateErrors': captureIsolateErrors,
+      'exceptionSteps': exceptionSteps.toMap(),
+    };
+  }
+}
+
+/// Configuration for exception steps.
+///
+/// Exception steps are breadcrumb-style context records recorded over time via
+/// `Posthog().addExceptionStep()`. The SDK keeps a rolling, byte-bounded buffer
+/// of these steps and attaches a snapshot to every captured `$exception` event
+/// as `$exception_steps`, giving the error tracking UI a timeline of recent
+/// activity leading up to each error.
+///
+/// The buffer is owned by the embedded native SDK (iOS/Android), so steps also
+/// survive native fatal crashes and attach to the crash `$exception` reported
+/// on the next launch.
+///
+/// **Flutter web:** the buffer lives in posthog-js. Steps are forwarded to it,
+/// but they only attach to exceptions captured by posthog-js itself, not to
+/// exceptions captured via `Posthog().captureException()` on web.
+class PostHogExceptionStepsConfig {
+  /// Creates an exception-steps configuration with native defaults.
+  PostHogExceptionStepsConfig();
+
+  /// Whether recording and attaching exception steps is enabled.
+  ///
+  /// When disabled, `Posthog().addExceptionStep()` is a no-op and nothing is
+  /// attached. Defaults to `true`.
+  var enabled = true;
+
+  /// Total UTF-8 byte budget for the rolling step buffer.
+  ///
+  /// When adding a step would exceed the budget, the oldest steps are evicted
+  /// until the total fits. A single step larger than the budget is rejected
+  /// outright. Defaults to `32768` (32 KiB).
+  var maxBytes = 32768;
+
+  /// Converts this configuration to a platform-channel map.
+  Map<String, dynamic> toMap() {
+    return {
+      'enabled': enabled,
+      'maxBytes': maxBytes,
     };
   }
 }

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -764,6 +764,28 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   }
 
   @override
+  Future<void> addExceptionStep(
+    String message, {
+    Map<String, Object>? properties,
+  }) async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      final normalizedProperties =
+          properties != null ? PropertyNormalizer.normalize(properties) : null;
+
+      await _methodChannel.invokeMethod('addExceptionStep', {
+        'message': message,
+        if (normalizedProperties != null) 'properties': normalizedProperties,
+      });
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on addExceptionStep: $exception');
+    }
+  }
+
+  @override
   Future<void> close() async {
     if (!isSupportedPlatform()) {
       return;

--- a/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
@@ -197,6 +197,13 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
     throw UnimplementedError('captureException() has not been implemented.');
   }
 
+  Future<void> addExceptionStep(
+    String message, {
+    Map<String, Object>? properties,
+  }) {
+    throw UnimplementedError('addExceptionStep() has not been implemented.');
+  }
+
   Future<void> close() {
     throw UnimplementedError('close() has not been implemented.');
   }

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -20,6 +20,9 @@ extension PostHogExtension on PostHog {
     JSAny propertiesSetOnce,
   );
   external JSAny? capture(JSAny eventName, JSAny? properties, JSAny? options);
+  // Routes through posthog-js's error pipeline so required metadata and
+  // $exception_steps attach. The call site guards with try/catch.
+  external JSAny? captureException(JSAny? error, JSAny? additionalProperties);
   // May be absent on older posthog-js builds; the call site guards with try/catch.
   external void captureLog(JSAny options);
   // May be absent on older posthog-js builds; the call site guards with try/catch.
@@ -137,6 +140,23 @@ Map<String, String> _getLocationProperties() {
   } catch (_) {
     return {};
   }
+}
+
+// The human-readable message used only as the posthog-js captureException
+// trigger; its parse is overridden by the Dart-built properties we pass as
+// additionalProperties. Read from the exception list the Dart side builds.
+String _exceptionMessage(Map<String, dynamic> properties) {
+  final exceptionList = properties[r'$exception_list'];
+  if (exceptionList is List && exceptionList.isNotEmpty) {
+    final first = exceptionList.first;
+    if (first is Map) {
+      final value = first['value'];
+      if (value is String && value.isNotEmpty) {
+        return value;
+      }
+    }
+  }
+  return 'Exception';
 }
 
 Future<dynamic> handleWebMethodCall(MethodCall call) async {
@@ -404,11 +424,26 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       final properties = safeMapConversion(args['properties']);
       properties.addAll(_getLocationProperties());
 
-      posthog?.capture(
-        stringToJSAny('\$exception'),
-        mapToJSAny(properties),
-        null,
-      );
+      // Route through posthog-js's captureException so it attaches required
+      // metadata and any buffered $exception_steps. posthog-js spreads the
+      // additionalProperties last, so our Dart-built $exception_list (frames,
+      // mechanism.handled, level) overrides its synthetic parse of `message`.
+      try {
+        posthog?.captureException(
+          stringToJSAny(_exceptionMessage(properties)),
+          mapToJSAny(properties),
+        );
+      } catch (error) {
+        // Very old posthog-js lacks captureException; still record the event.
+        printIfDebug(
+          '[PostHog] captureException via posthog-js failed; falling back to capture: $error',
+        );
+        posthog?.capture(
+          stringToJSAny('\$exception'),
+          mapToJSAny(properties),
+          null,
+        );
+      }
       break;
     default:
       throw PlatformException(

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -22,6 +22,8 @@ extension PostHogExtension on PostHog {
   external JSAny? capture(JSAny eventName, JSAny? properties, JSAny? options);
   // May be absent on older posthog-js builds; the call site guards with try/catch.
   external void captureLog(JSAny options);
+  // May be absent on older posthog-js builds; the call site guards with try/catch.
+  external void addExceptionStep(JSAny message, JSAny? properties);
   external JSAny? alias(JSAny alias);
   // ignore: non_constant_identifier_names
   external JSAny? get_distinct_id();
@@ -347,6 +349,22 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
     case 'close':
       // not supported on Web
       // analytics.callMethod('close');
+      break;
+    case 'addExceptionStep':
+      final message = args['message'] as String;
+      final properties = safeMapConversion(args['properties']);
+
+      try {
+        posthog?.addExceptionStep(
+          stringToJSAny(message),
+          properties.isNotEmpty ? mapToJSAny(properties) : null,
+        );
+      } catch (error) {
+        // Older posthog-js builds lack addExceptionStep and throw.
+        printIfDebug(
+          '[PostHog] addExceptionStep is not supported by the loaded posthog-js version: $error',
+        );
+      }
       break;
     case 'sendMetaEvent':
       // not supported on Web

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -145,7 +145,7 @@ Map<String, String> _getLocationProperties() {
 // The human-readable message used only as the posthog-js captureException
 // trigger; its parse is overridden by the Dart-built properties we pass as
 // additionalProperties. Read from the exception list the Dart side builds.
-String _exceptionMessage(Map<String, dynamic> properties) {
+String _exceptionMessage(Map<String, Object?> properties) {
   final exceptionList = properties[r'$exception_list'];
   if (exceptionList is List && exceptionList.isNotEmpty) {
     final first = exceptionList.first;

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -944,4 +944,30 @@ void main() {
       expect(args.containsKey('spanId'), isFalse);
     });
   });
+
+  group('PosthogFlutterIO addExceptionStep', () {
+    test('sends message and normalized properties', () async {
+      await posthogFlutterIO.addExceptionStep(
+        'User tapped Checkout',
+        properties: {'screen': 'cart', 'at': DateTime(2024, 3, 1)},
+      );
+
+      final call = log.firstWhere((c) => c.method == 'addExceptionStep');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['message'], 'User tapped Checkout');
+      final properties = Map<String, dynamic>.from(args['properties'] as Map);
+      expect(properties['screen'], 'cart');
+      // DateTime is not a StandardMessageCodec type; it is stringified.
+      expect(properties['at'], isA<String>());
+    });
+
+    test('omits properties when none provided', () async {
+      await posthogFlutterIO.addExceptionStep('Opened modal');
+
+      final call = log.firstWhere((c) => c.method == 'addExceptionStep');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args['message'], 'Opened modal');
+      expect(args.containsKey('properties'), isFalse);
+    });
+  });
 }

--- a/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
+++ b/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
@@ -146,6 +146,20 @@ class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
     );
   }
 
+  // Tracking for addExceptionStep calls
+  final List<Map<String, Object?>> addExceptionStepCalls = [];
+
+  @override
+  Future<void> addExceptionStep(
+    String message, {
+    Map<String, Object>? properties,
+  }) async {
+    addExceptionStepCalls.add({
+      'message': message,
+      'properties': properties,
+    });
+  }
+
   @override
   Future<void> disable() async {}
 

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -155,4 +155,65 @@ void main() {
       expect(capturedProperties.dartify(), {'screen': 'cart', 'count': 3});
     });
   });
+
+  // captureException must route through posthog-js's captureException (not the
+  // generic capture) so it attaches required metadata and any buffered
+  // $exception_steps. The Dart-built payload is passed as additionalProperties,
+  // which posthog-js spreads last — so our $exception_list must survive.
+  group('handleWebMethodCall captureException', () {
+    String? capturedMessage;
+    JSAny? capturedProperties;
+    var captured = false;
+
+    setUp(() {
+      capturedMessage = null;
+      capturedProperties = null;
+      captured = false;
+
+      final fake = JSObject();
+      fake.setProperty(
+        'captureException'.toJS,
+        ((JSString message, JSAny? properties) {
+          captured = true;
+          capturedMessage = message.toDart;
+          capturedProperties = properties;
+        }).toJS,
+      );
+      globalContext.setProperty('posthog'.toJS, fake);
+    });
+
+    test('forwards to captureException, preserving the Dart \$exception_list',
+        () async {
+      await handleWebMethodCall(const MethodCall('captureException', {
+        'properties': {
+          r'$exception_level': 'error',
+          r'$exception_list': [
+            {'type': 'StateError', 'value': 'boom'},
+          ],
+        },
+      }));
+
+      expect(captured, isTrue);
+      // The trigger message is the exception value; its parse is discarded.
+      expect(capturedMessage, 'boom');
+
+      final props = capturedProperties!.dartify()! as Map<Object?, Object?>;
+      // Our Dart-built payload wins over posthog-js's synthetic parse.
+      expect(props[r'$exception_level'], 'error');
+      final list = props[r'$exception_list'] as List;
+      final first = list.first as Map;
+      expect(first['type'], 'StateError');
+      expect(first['value'], 'boom');
+    });
+
+    test('uses a fallback trigger message when no exception value is present',
+        () async {
+      await handleWebMethodCall(const MethodCall('captureException', {
+        'properties': {r'$exception_level': 'error'},
+      }));
+
+      expect(captured, isTrue);
+      expect(capturedMessage, 'Exception');
+    });
+  });
 }

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -77,4 +77,47 @@ void main() {
       expect(options.containsKey('span_id'), isFalse);
     });
   });
+
+  group('handleWebMethodCall addExceptionStep', () {
+    String? capturedMessage;
+    JSAny? capturedProperties;
+    var captured = false;
+
+    setUp(() {
+      capturedMessage = null;
+      capturedProperties = null;
+      captured = false;
+
+      final fake = JSObject();
+      fake.setProperty(
+        'addExceptionStep'.toJS,
+        ((JSString message, JSAny? properties) {
+          captured = true;
+          capturedMessage = message.toDart;
+          capturedProperties = properties;
+        }).toJS,
+      );
+      globalContext.setProperty('posthog'.toJS, fake);
+    });
+
+    test('forwards message and properties to posthog-js', () async {
+      await handleWebMethodCall(const MethodCall('addExceptionStep', {
+        'message': 'User tapped Checkout',
+        'properties': {'screen': 'cart'},
+      }));
+
+      expect(capturedMessage, 'User tapped Checkout');
+      expect(capturedProperties.dartify(), {'screen': 'cart'});
+    });
+
+    test('forwards null properties when none provided', () async {
+      await handleWebMethodCall(const MethodCall('addExceptionStep', {
+        'message': 'Opened modal',
+      }));
+
+      expect(captured, isTrue);
+      expect(capturedMessage, 'Opened modal');
+      expect(capturedProperties, isNull);
+    });
+  });
 }

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -6,6 +6,7 @@ import 'dart:js_interop_unsafe';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter_web.dart';
 import 'package:posthog_flutter/src/posthog_flutter_web_handler.dart';
 
 // Browser-only: handleWebMethodCall talks to the posthog-js instance on
@@ -118,6 +119,40 @@ void main() {
       expect(captured, isTrue);
       expect(capturedMessage, 'Opened modal');
       expect(capturedProperties, isNull);
+    });
+  });
+
+  // Guards the web wiring: PosthogFlutterWeb must override addExceptionStep so
+  // the call actually reaches posthog-js. Without the override it falls through
+  // to the platform interface and throws UnimplementedError on web.
+  group('PosthogFlutterWeb addExceptionStep', () {
+    String? capturedMessage;
+    JSAny? capturedProperties;
+
+    setUp(() {
+      capturedMessage = null;
+      capturedProperties = null;
+
+      final fake = JSObject();
+      fake.setProperty(
+        'addExceptionStep'.toJS,
+        ((JSString message, JSAny? properties) {
+          capturedMessage = message.toDart;
+          capturedProperties = properties;
+        }).toJS,
+      );
+      globalContext.setProperty('posthog'.toJS, fake);
+    });
+
+    test('override forwards message and normalized properties to posthog-js',
+        () async {
+      await PosthogFlutterWeb().addExceptionStep(
+        'User tapped Checkout',
+        properties: {'screen': 'cart', 'count': 3},
+      );
+
+      expect(capturedMessage, 'User tapped Checkout');
+      expect(capturedProperties.dartify(), {'screen': 'cart', 'count': 3});
     });
   });
 }

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -519,6 +519,12 @@ void main() {
       expect(fake.addExceptionStepCalls, isEmpty);
     });
 
+    test('is a no-op for a whitespace-only message', () async {
+      await Posthog().addExceptionStep('   \t\n');
+
+      expect(fake.addExceptionStepCalls, isEmpty);
+    });
+
     test('is a no-op when exception steps are disabled', () async {
       final config = PostHogConfig('test_project_token')
         ..errorTrackingConfig.exceptionSteps.enabled = false;
@@ -527,6 +533,28 @@ void main() {
       await Posthog().addExceptionStep('User tapped Checkout');
 
       expect(fake.addExceptionStepCalls, isEmpty);
+    });
+  });
+
+  group('PostHogExceptionStepsConfig', () {
+    test('toMap serializes the native defaults', () {
+      final config = PostHogConfig('test_project_token');
+
+      expect(
+        config.errorTrackingConfig.exceptionSteps.toMap(),
+        {'enabled': true, 'maxBytes': 32768},
+      );
+    });
+
+    test('toMap reflects overridden values', () {
+      final config = PostHogConfig('test_project_token')
+        ..errorTrackingConfig.exceptionSteps.enabled = false
+        ..errorTrackingConfig.exceptionSteps.maxBytes = 1024;
+
+      expect(
+        config.errorTrackingConfig.exceptionSteps.toMap(),
+        {'enabled': false, 'maxBytes': 1024},
+      );
     });
   });
 }

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -481,4 +481,42 @@ void main() {
       expect(fake.reloadFeatureFlagsCount, 0);
     });
   });
+
+  group('Posthog addExceptionStep', () {
+    late PosthogFlutterPlatformFake fake;
+
+    setUp(() async {
+      fake = PosthogFlutterPlatformFake();
+      PosthogFlutterPlatformInterface.instance = fake;
+      await Posthog().close();
+    });
+
+    test('forwards message and properties to the platform', () async {
+      await Posthog().addExceptionStep(
+        'User tapped Checkout',
+        properties: {'screen': 'cart'},
+      );
+
+      expect(fake.addExceptionStepCalls, [
+        {
+          'message': 'User tapped Checkout',
+          'properties': {'screen': 'cart'},
+        },
+      ]);
+    });
+
+    test('forwards message without properties', () async {
+      await Posthog().addExceptionStep('Opened modal');
+
+      expect(fake.addExceptionStepCalls, [
+        {'message': 'Opened modal', 'properties': null},
+      ]);
+    });
+
+    test('is a no-op for an empty message', () async {
+      await Posthog().addExceptionStep('');
+
+      expect(fake.addExceptionStepCalls, isEmpty);
+    });
+  });
 }

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -518,5 +518,15 @@ void main() {
 
       expect(fake.addExceptionStepCalls, isEmpty);
     });
+
+    test('is a no-op when exception steps are disabled', () async {
+      final config = PostHogConfig('test_project_token')
+        ..errorTrackingConfig.exceptionSteps.enabled = false;
+      await Posthog().setup(config);
+
+      await Posthog().addExceptionStep('User tapped Checkout');
+
+      expect(fake.addExceptionStepCalls, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds **exception steps** to error tracking for the Flutter SDK.

Exception steps are breadcrumb-style context records that accumulate over time and attach to every captured `$exception` as `$exception_steps`, giving the error-tracking UI a timeline of what happened right before the exception.

```dart
Posthog().addExceptionStep('User tapped Checkout', properties: {'screen': 'cart'});
```

> [!NOTE]
> Requires the released native SDKs that carry the feature: **posthog-android ≥ 3.51.0** and **posthog-ios ≥ 3.61.0**. The dependency pins are bumped accordingly in this PR.

### What's included

- **`addExceptionStep(message, {properties})`** public API on `Posthog`, forwarding to the native layer (where the buffer, byte-budget eviction, serialization, and crash-durable persistence live).
- **`PostHogExceptionStepsConfig`** on `errorTrackingConfig.exceptionSteps` — `enabled` (default `true`) and `maxBytes` (default `32768`) — forwarded to the native config at `setup`.
- **Native wiring** in the Android (Kotlin) and iOS (Swift) plugins: method-channel handlers + config plumbing. Steps attach to Flutter-captured exceptions because they flow through the native `$exception` capture path.
- **Dependency bumps**: `posthog-android` → `[3.51.0,4.0.0)`; `posthog-ios` → `3.61.0..<4.0.0` (SPM + podspec).
- **Web**: forwarded to posthog-js's `addExceptionStep` (guarded for older builds). Note: on web, steps attach to exceptions captured by posthog-js, not to those captured via `Posthog().captureException()` — documented on the API.
- **Example app**: a dedicated "Exception Steps" screen for manual testing (add single/batch steps with mixed property types, high-frequency flood, and trigger handled / unhandled / native-crash exceptions).

## :green_heart: How did you test it?

- Unit tests for the public API (forwarding + empty-message no-op), the method-channel IO layer (message + normalized properties), and the web handler. `flutter analyze` clean; all Dart + web tests pass.
- Verified end-to-end on the iOS Simulator and Android emulator via the example screen, building against the released native SDKs (iOS 3.61.0 / Android 3.51.0): confirmed the captured `$exception` carries `$exception_steps` with correctly normalized properties (nested maps, lists, numbers, bools, `DateTime`), across the handled, unhandled, and native-crash paths.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
