### PR TITLE
chore: update Flutter PopScope callback

### DIFF
--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -4619,7 +4619,7 @@
             }
         ],
         "packageName": "posthog_flutter",
-        "packageVersion": "5.27.0",
+        "packageVersion": "5.28.0",
         "sdkType": "flutter",
         "semantics": [
             "containsPlatformConstraints"

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -24,8 +24,6 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
   /// Stored configuration for accessing inAppIncludes and other settings
   PostHogConfig? _config;
 
-  // TODO: we should change the $lib and $lib_version to be the flutter one when capturing things
-
   static void registerWith(Registrar registrar) {
     final channel = MethodChannel(
       'posthog_flutter',

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -256,7 +256,7 @@ class PostHogConfig {
   ///   callbacks are not called.
   List<BeforeSendCallback> beforeSend = [];
 
-  // TODO: missing getAnonymousId, propertiesSanitizer, captureDeepLinks integrations
+  // TODO: missing getAnonymousId, captureDeepLinks integrations
 
   /// Creates a configuration for [projectToken].
   ///

--- a/posthog_flutter/lib/src/surveys/widgets/survey_bottom_sheet.dart
+++ b/posthog_flutter/lib/src/surveys/widgets/survey_bottom_sheet.dart
@@ -173,9 +173,7 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
 
     return PopScope(
       canPop: false,
-      // TODO: replace with onPopInvokedWithResult once set bump the min Flutter version to 3.24
-      // ignore: deprecated_member_use
-      onPopInvoked: (didPop) {
+      onPopInvokedWithResult: (didPop, _) {
         if (!didPop) {
           _handleClose();
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

Flutter 3.27 is now the minimum supported version, so survey UI code can use the newer PopScope callback instead of the deprecated API. This also removes a couple of stale TODO comments.


## :green_heart: How did you test it?

- `make checkApiDart`
- `cd posthog_flutter && dart analyze lib/posthog_flutter_web.dart lib/src/posthog_config.dart lib/src/surveys/widgets/survey_bottom_sheet.dart`


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Updated the survey bottom sheet to use `onPopInvokedWithResult`, which is available with the current Flutter minimum, and removed stale TODO notes in the changed files. The branch was merged with the latest `main`; the public API snapshot conflict was resolved by keeping `main`'s version-independent snapshot format.
