### PR TITLE
chore: template public API package version

### DIFF
--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -4619,7 +4619,7 @@
             }
         ],
         "packageName": "posthog_flutter",
-        "packageVersion": "5.27.0",
+        "packageVersion": "<version>",
         "sdkType": "flutter",
         "semantics": [
             "containsPlatformConstraints"

--- a/scripts/check-api-dart.sh
+++ b/scripts/check-api-dart.sh
@@ -51,8 +51,11 @@ from pathlib import Path
 raw_path = Path(sys.argv[1])
 out_path = Path(sys.argv[2])
 data = json.loads(raw_path.read_text())
+package_api = data.get("packageApi", {})
 # dart_apitool writes a temporary package path that changes on every run.
-data.get("packageApi", {}).pop("packagePath", None)
+package_api.pop("packagePath", None)
+# Keep the checked-in public API snapshot independent from release bumps.
+package_api["packageVersion"] = "<version>"
 out_path.write_text(json.dumps(data, indent=4, sort_keys=True) + "\n")
 PY
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The Dart public API snapshot currently includes `packageApi.packageVersion`, so version-only release bumps can fail unrelated PR checks when the checked-in snapshot contains an older package version.

This normalizes the package version in the generated public API snapshot to the stable `<version>` template, matching the intent that public API checks only fail on API shape changes.

## :green_heart: How did you test it?

```bash
scripts/check-api-dart.sh
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi coding agent. The public API check script now replaces the generated `packageApi.packageVersion` with `<version>` before comparing or updating the snapshot, and the checked-in snapshot was updated to use that template. No changeset was added because this is repository tooling/test infrastructure only and does not change the published package behavior.
