### PR TITLE
feat: capture platform views in session replay screenshots

### DIFF
--- a/.changeset/fiery-lamps-guess.md
+++ b/.changeset/fiery-lamps-guess.md
@@ -2,4 +2,4 @@
 "posthog_flutter": minor
 ---
 
-Platform views are now masked by default in session replay (they now appear as a black box). Use `maskAllPlatformViews = false` to disable masking globally, or wrap individual views in `PostHogPlatformView(privacy: .capture)` to reveal them selectively.
+Platform views are now masked by default in session replay (they now appear as a black box). Use `maskAllPlatformViews = false` to disable masking globally, or wrap individual views in `PostHogPlatformView(privacy: PostHogPlatformViewPrivacy.capture)` to reveal them selectively.

--- a/.changeset/fiery-lamps-guess.md
+++ b/.changeset/fiery-lamps-guess.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": minor
+---
+
+Platform views are now masked by default in session replay (they now appear as a black box). Use `maskAllPlatformViews = false` to disable masking globally, or wrap individual views in `PostHogPlatformView(privacy: .capture)` to reveal them selectively.

--- a/.gitignore
+++ b/.gitignore
@@ -644,3 +644,4 @@ PLAN.md
 # Examples build artifacts
 examples/
 .gstack/
+.ralph/

--- a/.gitignore
+++ b/.gitignore
@@ -643,3 +643,4 @@ PLAN.md
 
 # Examples build artifacts
 examples/
+.gstack/

--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -2307,6 +2307,17 @@
                         "name": "sampleRate",
                         "relativePath": "lib/src/posthog_config.dart",
                         "typeName": "double?"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "maskAllPlatformViews",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "bool"
                     }
                 ],
                 "isDeprecated": false,
@@ -4594,6 +4605,143 @@
                     "State<PostHogMaskWidget>",
                     "Object",
                     "Diagnosticable"
+                ],
+                "typeParameterNames": []
+            },
+            {
+                "entryPoints": [
+                    "posthog_flutter.dart"
+                ],
+                "executableDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "new",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": true,
+                                "isRequired": false,
+                                "name": "key",
+                                "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                                "typeName": "Key?"
+                            },
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": true,
+                                "isRequired": true,
+                                "name": "child",
+                                "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                                "typeName": "Widget"
+                            },
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": true,
+                                "isRequired": false,
+                                "name": "privacy",
+                                "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                                "typeName": "PostHogPlatformViewPrivacy"
+                            }
+                        ],
+                        "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                        "returnTypeName": "PostHogPlatformView",
+                        "type": "constructor",
+                        "typeParameterNames": []
+                    }
+                ],
+                "fieldDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": false,
+                        "name": "child",
+                        "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                        "typeName": "Widget"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": false,
+                        "name": "privacy",
+                        "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                        "typeName": "PostHogPlatformViewPrivacy"
+                    }
+                ],
+                "isDeprecated": false,
+                "isExperimental": false,
+                "isRequired": false,
+                "isSealed": false,
+                "name": "PostHogPlatformView",
+                "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                "superTypeNames": [
+                    "StatelessWidget",
+                    "Widget",
+                    "DiagnosticableTree",
+                    "Object",
+                    "Diagnosticable"
+                ],
+                "typeParameterNames": []
+            },
+            {
+                "entryPoints": [
+                    "posthog_flutter.dart"
+                ],
+                "executableDeclarations": [],
+                "fieldDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": true,
+                        "isWriteable": false,
+                        "name": "mask",
+                        "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                        "typeName": "PostHogPlatformViewPrivacy"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": true,
+                        "isWriteable": false,
+                        "name": "capture",
+                        "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                        "typeName": "PostHogPlatformViewPrivacy"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": true,
+                        "isWriteable": false,
+                        "name": "values",
+                        "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                        "typeName": "List<PostHogPlatformViewPrivacy>"
+                    }
+                ],
+                "isDeprecated": false,
+                "isExperimental": false,
+                "isRequired": false,
+                "isSealed": false,
+                "name": "PostHogPlatformViewPrivacy",
+                "relativePath": "lib/src/replay/mask/posthog_platform_view.dart",
+                "superTypeNames": [
+                    "Enum",
+                    "Object"
                 ],
                 "typeParameterNames": []
             }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="PostHog Flutter Example"
         android:name="${applicationName}"
@@ -50,5 +52,11 @@
        <meta-data
             android:name="com.posthog.posthog.AUTO_INIT"
             android:value="false" />
+
+        <!-- Dummy key: Maps SDK still creates its SurfaceView (shows error tiles).
+             This is intentional — we're testing the capture/mask pipeline, not map rendering. -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyDummyKeyForTestingPurposesOnly00001" />
     </application>
 </manifest>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '13.0'
+platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,30 +1,38 @@
 PODS:
   - Flutter (1.0.0)
-  - PostHog (3.56.0)
-  - posthog_flutter (0.0.1):
+  - Google-Maps-iOS-Utils (5.0.0):
+    - GoogleMaps (~> 8.0)
+  - google_maps_flutter_ios (0.0.1):
     - Flutter
-    - FlutterMacOS
-    - PostHog (< 4.0.0, >= 3.56.0)
+    - Google-Maps-iOS-Utils (< 7.0, >= 5.0)
+    - GoogleMaps (< 11.0, >= 8.4)
+  - GoogleMaps (8.4.0):
+    - GoogleMaps/Maps (= 8.4.0)
+  - GoogleMaps/Base (8.4.0)
+  - GoogleMaps/Maps (8.4.0):
+    - GoogleMaps/Base
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - posthog_flutter (from `.symlinks/plugins/posthog_flutter/darwin`)
+  - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
 
 SPEC REPOS:
   trunk:
-    - PostHog
+    - Google-Maps-iOS-Utils
+    - GoogleMaps
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  posthog_flutter:
-    :path: ".symlinks/plugins/posthog_flutter/darwin"
+  google_maps_flutter_ios:
+    :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  PostHog: 646b20ce2db3f07f71ce7fb004a9b3a4ba4afa4b
-  posthog_flutter: 03b15ff7a78e2a4162baaf11f8db37b079412106
+  Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
+  google_maps_flutter_ios: 17552876e72723da1d41accc22f03b5f7afbde69
+  GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
 
-PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5
+PODFILE CHECKSUM: 1959d098c91d8a792531a723c4a9d7e9f6a01e38
 
 COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -196,8 +196,8 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				5C9C96BF1E7D401D439369FA /* [CP] Embed Pods Frameworks */,
 				A809B0FD2F61AD8000637A80 /* PostHog upload symbols */,
+				DDA5D9F35A5F7C4CDB7932B0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -241,7 +241,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Runner */;
 			projectDirPath = "";
@@ -313,27 +313,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
-		5C9C96BF1E7D401D439369FA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -367,6 +346,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# uncomment to upload mapping files to PostHog\n# POSTHOG_INCLUDE_SOURCE=1 ${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh\n";
+		};
+		DDA5D9F35A5F7C4CDB7932B0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		E0EB70FF4694C64F4A64348B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -482,7 +478,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -501,7 +497,7 @@
 				DEVELOPMENT_TEAM = PNC2XCH2XP;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -522,7 +518,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.posthogFlutterExample.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -541,7 +537,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.posthogFlutterExample.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -558,7 +554,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.posthogFlutterExample.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -614,7 +610,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -663,7 +659,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -684,7 +680,7 @@
 				DEVELOPMENT_TEAM = PNC2XCH2XP;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -708,7 +704,7 @@
 				DEVELOPMENT_TEAM = PNC2XCH2XP;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -757,7 +753,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "9fcdb83e79b155c0dae104eadf5c269079dcbddb",
+        "version" : "3.62.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "9fcdb83e79b155c0dae104eadf5c269079dcbddb",
+        "version" : "3.62.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:posthog_flutter_example/error_example.dart';
 
 import 'exception_steps_screen.dart';
 import 'masking_tests_screen.dart';
+import 'platform_views_screen.dart';
 
 Future<void> main() async {
   final config = PostHogConfig(
@@ -44,9 +45,10 @@ Future<void> main() async {
   config.captureApplicationLifecycleEvents = false;
   config.host = 'https://us.i.posthog.com';
   config.surveys = false;
-  config.sessionReplay = false;
+  config.sessionReplay = true;
   config.sessionReplayConfig.maskAllTexts = false;
   config.sessionReplayConfig.maskAllImages = false;
+  config.sessionReplayConfig.maskAllPlatformViews = true;
   config.sessionReplayConfig.throttleDelay = const Duration(milliseconds: 1000);
   config.flushAt = 1;
 
@@ -178,6 +180,23 @@ class InitialScreenState extends State<InitialScreen> {
                     );
                   },
                   child: const Text('Exception Steps'),
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.deepPurple,
+                    foregroundColor: Colors.white,
+                  ),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const PlatformViewsScreen(),
+                        settings: const RouteSettings(name: 'platform_views'),
+                      ),
+                    );
+                  },
+                  child: const Text('Platform Views (Replay)'),
                 ),
                 const Padding(
                   padding: EdgeInsets.all(8.0),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,8 @@ import 'exception_steps_screen.dart';
 import 'masking_tests_screen.dart';
 import 'platform_views_screen.dart';
 
+const kMaskAllPlatformViews = true;
+
 Future<void> main() async {
   final config = PostHogConfig(
     'phc_6lqCaCDCBEWdIGieihq5R2dZpPVbAUFISA75vFZow06',
@@ -48,7 +50,7 @@ Future<void> main() async {
   config.sessionReplay = true;
   config.sessionReplayConfig.maskAllTexts = false;
   config.sessionReplayConfig.maskAllImages = false;
-  config.sessionReplayConfig.maskAllPlatformViews = true;
+  config.sessionReplayConfig.maskAllPlatformViews = kMaskAllPlatformViews;
   config.sessionReplayConfig.throttleDelay = const Duration(milliseconds: 1000);
   config.flushAt = 1;
 

--- a/example/lib/platform_views_screen.dart
+++ b/example/lib/platform_views_screen.dart
@@ -4,6 +4,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import 'main.dart' show kMaskAllPlatformViews;
+
 /// Demonstrates session replay with platform views.
 ///
 /// Shows two scenarios:
@@ -526,7 +528,12 @@ class _CapturedAndMaskedWebViewsState
               child: WebViewWidget(controller: _left),
             ),
           ),
-          Expanded(child: WebViewWidget(controller: _right)),
+          Expanded(
+            child: PostHogPlatformView(
+              privacy: PostHogPlatformViewPrivacy.mask,
+              child: WebViewWidget(controller: _right),
+            ),
+          ),
         ],
       ),
     );
@@ -571,7 +578,8 @@ class _ExplicitMaskGlobalFalseState extends State<_ExplicitMaskGlobalFalse> {
             padding: EdgeInsets.all(8),
             child: Text(
               'LEFT: PostHogPlatformView(privacy: .mask) → always BLACK\n'
-              'RIGHT: no wrapper → follows global maskAllPlatformViews',
+              'RIGHT: no wrapper → follows global maskAllPlatformViews '
+              '(currently: $kMaskAllPlatformViews)',
               textAlign: TextAlign.center,
               style: TextStyle(fontSize: 12),
             ),

--- a/example/lib/platform_views_screen.dart
+++ b/example/lib/platform_views_screen.dart
@@ -1,0 +1,626 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// Demonstrates session replay with platform views.
+///
+/// Shows two scenarios:
+///  1. Mixed screen — a native WebView embedded in a Flutter Scaffold with
+///     app bar, search bar overlay, and bottom navigation. This is the most
+///     common real-world case (e.g. a map in a Scaffold).
+///  2. Full-screen native view — the WebView fills the entire screen with no
+///     surrounding Flutter UI. Represents paywalls, full-screen maps, etc.
+class PlatformViewsScreen extends StatelessWidget {
+  const PlatformViewsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Platform Views — Session Replay')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'Masked vs captured matrix',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Masked = covered with a black box in replay (default). '
+            'Captured = revealed in replay via PostHogPlatformView(privacy: .capture).',
+          ),
+          const SizedBox(height: 24),
+          _CaseCard(
+            title: 'Mixed screen — masked',
+            subtitle:
+                'WebView in a Scaffold (app bar, search, bottom nav). '
+                'WebView area is a black box; surrounding Flutter UI is normal.',
+            onTap: () => _push(
+              context,
+              const _MixedScreen(),
+              'mixed_platform_view_masked',
+            ),
+          ),
+          _CaseCard(
+            title: 'Mixed screen — captured',
+            subtitle:
+                'Same screen, WebView wrapped with .capture — its content shows '
+                'in replay instead of a black box.',
+            onTap: () => _push(
+              context,
+              const _MixedScreenCapture(),
+              'mixed_platform_view_captured',
+            ),
+          ),
+          _CaseCard(
+            title: 'Full screen — masked',
+            subtitle:
+                'WebView fills the screen (no surrounding Flutter). '
+                'Entire area is a black box in replay.',
+            onTap: () =>
+                _push(context, const _FullScreenMasked(), 'fullscreen_masked'),
+          ),
+          _CaseCard(
+            title: 'Full screen — captured',
+            subtitle:
+                'Full-screen WebView wrapped with .capture — the whole screen '
+                'is revealed in replay.',
+            onTap: () => _push(
+              context,
+              const _FullScreenCaptured(),
+              'fullscreen_captured',
+            ),
+          ),
+          _CaseCard(
+            title: 'Two WebViews — both captured',
+            subtitle:
+                'Two WebViews side by side, both .capture — each shows its own '
+                'content in replay.',
+            onTap: () => _push(
+              context,
+              const _TwoCapturedWebViews(),
+              'two_captured_webviews',
+            ),
+          ),
+          _CaseCard(
+            title: 'Two WebViews — one captured, one masked',
+            subtitle:
+                'Left WebView is .capture (revealed), right is default (black box). '
+                'Verifies per-view policy.',
+            onTap: () => _push(
+              context,
+              const _CapturedAndMaskedWebViews(),
+              'mixed_capture_and_mask',
+            ),
+          ),
+          _CaseCard(
+            title: 'Per-view mask override',
+            subtitle:
+                'Left WebView is explicitly wrapped with '
+                'PostHogPlatformView(privacy: .mask) — always a black box. '
+                'Right has no wrapper — follows the global setting.',
+            onTap: () => _push(
+              context,
+              const _ExplicitMaskGlobalFalse(),
+              'per_view_mask_override',
+            ),
+          ),
+          if (defaultTargetPlatform == TargetPlatform.android) ...[
+            const SizedBox(height: 8),
+            const Text(
+              'Non-WebView platform view (Android)',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            _CaseCard(
+              title: 'Map — masked',
+              subtitle:
+                  'GoogleMap in a Scaffold (hybrid-composition SurfaceView). '
+                  'Map area is a black box in replay.',
+              onTap: () => _push(
+                context,
+                const _GoogleMapsMixedScreen(),
+                'google_maps_masked',
+              ),
+            ),
+            _CaseCard(
+              title: 'Map — captured',
+              subtitle:
+                  'GoogleMap wrapped with .capture — map content shows in replay.',
+              onTap: () =>
+                  _push(context, const _NonWebViewCapture(), 'map_captured'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _push(BuildContext context, Widget screen, String routeName) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => screen,
+        settings: RouteSettings(name: routeName),
+      ),
+    );
+  }
+}
+
+class _CaseCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  const _CaseCard({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Google Maps mixed screen: the exact use-case from the PR comments.
+// GoogleMap (hybrid-composition SurfaceView) inside a Scaffold.
+// API key is intentionally invalid — we test capture/mask, not map tiles.
+// ---------------------------------------------------------------------------
+
+class _GoogleMapsMixedScreen extends StatefulWidget {
+  const _GoogleMapsMixedScreen();
+
+  @override
+  State<_GoogleMapsMixedScreen> createState() => _GoogleMapsMixedScreenState();
+}
+
+class _GoogleMapsMixedScreenState extends State<_GoogleMapsMixedScreen> {
+  static const _initialCamera = CameraPosition(
+    target: LatLng(37.7749, -122.4194),
+    zoom: 12,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Google Maps in Scaffold')),
+      body: Stack(
+        children: [
+          // The real google_maps_flutter platform view.
+          // With an invalid API key it shows grey/error tiles but the
+          // SurfaceView is present in the hierarchy — that is what we test.
+          const GoogleMap(initialCameraPosition: _initialCamera),
+          Positioned(
+            top: 12,
+            left: 12,
+            right: 12,
+            child: Material(
+              elevation: 4,
+              borderRadius: BorderRadius.circular(8),
+              child: const TextField(
+                decoration: InputDecoration(
+                  hintText: 'Search location…',
+                  prefixIcon: Icon(Icons.search),
+                  contentPadding: EdgeInsets.symmetric(vertical: 0),
+                  border: InputBorder.none,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'List'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mixed screen: Flutter Scaffold + embedded WebView + Flutter overlays
+// ---------------------------------------------------------------------------
+
+class _MixedScreen extends StatefulWidget {
+  const _MixedScreen();
+
+  @override
+  State<_MixedScreen> createState() => _MixedScreenState();
+}
+
+class _MixedScreenState extends State<_MixedScreen> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://www.openstreetmap.org'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mixed: WebView (masked)'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _controller.reload(),
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          // The platform view (WebView / native map)
+          WebViewWidget(controller: _controller),
+
+          // Flutter overlay on top of the platform view — simulates a search
+          // bar or FAB rendered over a map. This Flutter content should be
+          // visible in session replay; the WebView underneath is auto-masked.
+          Positioned(
+            top: 12,
+            left: 12,
+            right: 12,
+            child: Material(
+              elevation: 4,
+              borderRadius: BorderRadius.circular(8),
+              child: const TextField(
+                decoration: InputDecoration(
+                  hintText: 'Search location…',
+                  prefixIcon: Icon(Icons.search),
+                  contentPadding: EdgeInsets.symmetric(vertical: 0),
+                  border: InputBorder.none,
+                ),
+              ),
+            ),
+          ),
+
+          // FAB-style Flutter button over the map
+          Positioned(
+            bottom: 80,
+            right: 16,
+            child: FloatingActionButton(
+              onPressed: () {},
+              child: const Icon(Icons.my_location),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'List'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mixed screen (captured): same as _MixedScreen but wrapped in
+// PostHogPlatformView(privacy: .capture) — should reveal WebView in replay.
+// ---------------------------------------------------------------------------
+
+class _MixedScreenCapture extends StatefulWidget {
+  const _MixedScreenCapture();
+
+  @override
+  State<_MixedScreenCapture> createState() => _MixedScreenCaptureState();
+}
+
+class _MixedScreenCaptureState extends State<_MixedScreenCapture> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://www.openstreetmap.org'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mixed: WebView (captured)'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _controller.reload(),
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          PostHogPlatformView(
+            privacy: PostHogPlatformViewPrivacy.capture,
+            child: WebViewWidget(controller: _controller),
+          ),
+          Positioned(
+            top: 12,
+            left: 12,
+            right: 12,
+            child: Material(
+              elevation: 4,
+              borderRadius: BorderRadius.circular(8),
+              child: const TextField(
+                decoration: InputDecoration(
+                  hintText: 'Search location…',
+                  prefixIcon: Icon(Icons.search),
+                  contentPadding: EdgeInsets.symmetric(vertical: 0),
+                  border: InputBorder.none,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'List'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Full-screen native view: WebView fills the entire screen
+// ---------------------------------------------------------------------------
+
+class _FullScreenMasked extends StatefulWidget {
+  const _FullScreenMasked();
+
+  @override
+  State<_FullScreenMasked> createState() => _FullScreenMaskedState();
+}
+
+class _FullScreenMaskedState extends State<_FullScreenMasked> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://example.com'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WebViewWidget(controller: _controller);
+  }
+}
+
+class _FullScreenCaptured extends StatefulWidget {
+  const _FullScreenCaptured();
+
+  @override
+  State<_FullScreenCaptured> createState() => _FullScreenCapturedState();
+}
+
+class _FullScreenCapturedState extends State<_FullScreenCaptured> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://example.com'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PostHogPlatformView(
+      privacy: PostHogPlatformViewPrivacy.capture,
+      child: WebViewWidget(controller: _controller),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Two captured WebViews: tests multiple platform views with capture policy
+// ---------------------------------------------------------------------------
+
+class _TwoCapturedWebViews extends StatefulWidget {
+  const _TwoCapturedWebViews();
+
+  @override
+  State<_TwoCapturedWebViews> createState() => _TwoCapturedWebViewsState();
+}
+
+class _TwoCapturedWebViewsState extends State<_TwoCapturedWebViews> {
+  late final WebViewController _left;
+  late final WebViewController _right;
+
+  @override
+  void initState() {
+    super.initState();
+    _left = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://example.com'));
+    _right = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://www.wikipedia.org'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Two Captured WebViews')),
+      body: Row(
+        children: [
+          Expanded(
+            child: PostHogPlatformView(
+              privacy: PostHogPlatformViewPrivacy.capture,
+              child: WebViewWidget(controller: _left),
+            ),
+          ),
+          Expanded(
+            child: PostHogPlatformView(
+              privacy: PostHogPlatformViewPrivacy.capture,
+              child: WebViewWidget(controller: _right),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CapturedAndMaskedWebViews extends StatefulWidget {
+  const _CapturedAndMaskedWebViews();
+
+  @override
+  State<_CapturedAndMaskedWebViews> createState() =>
+      _CapturedAndMaskedWebViewsState();
+}
+
+class _CapturedAndMaskedWebViewsState
+    extends State<_CapturedAndMaskedWebViews> {
+  late final WebViewController _left;
+  late final WebViewController _right;
+
+  @override
+  void initState() {
+    super.initState();
+    _left = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://example.com'));
+    _right = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://www.wikipedia.org'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Captured (left) + Masked (right)')),
+      body: Row(
+        children: [
+          Expanded(
+            child: PostHogPlatformView(
+              privacy: PostHogPlatformViewPrivacy.capture,
+              child: WebViewWidget(controller: _left),
+            ),
+          ),
+          Expanded(child: WebViewWidget(controller: _right)),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Security fix regression: maskAllPlatformViews=false + explicit .mask wrapper.
+// The left WebView must still be black in replay; the right must be captured.
+// ---------------------------------------------------------------------------
+
+class _ExplicitMaskGlobalFalse extends StatefulWidget {
+  const _ExplicitMaskGlobalFalse();
+
+  @override
+  State<_ExplicitMaskGlobalFalse> createState() =>
+      _ExplicitMaskGlobalFalseState();
+}
+
+class _ExplicitMaskGlobalFalseState extends State<_ExplicitMaskGlobalFalse> {
+  late final WebViewController _left;
+  late final WebViewController _right;
+
+  @override
+  void initState() {
+    super.initState();
+    _left = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://example.com'));
+    _right = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse('https://www.wikipedia.org'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Per-view mask override')),
+      body: Column(
+        children: [
+          const Padding(
+            padding: EdgeInsets.all(8),
+            child: Text(
+              'LEFT: PostHogPlatformView(privacy: .mask) → always BLACK\n'
+              'RIGHT: no wrapper → follows global maskAllPlatformViews',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 12),
+            ),
+          ),
+          Expanded(
+            child: Row(
+              children: [
+                Expanded(
+                  child: PostHogPlatformView(
+                    privacy: PostHogPlatformViewPrivacy.mask,
+                    child: WebViewWidget(controller: _left),
+                  ),
+                ),
+                Expanded(child: WebViewWidget(controller: _right)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Non-WebView capture: GoogleMap wrapped with capture policy.
+// Android: map content visible. iOS: no WKWebView → falls back to mask.
+// ---------------------------------------------------------------------------
+
+class _NonWebViewCapture extends StatefulWidget {
+  const _NonWebViewCapture();
+
+  @override
+  State<_NonWebViewCapture> createState() => _NonWebViewCaptureState();
+}
+
+class _NonWebViewCaptureState extends State<_NonWebViewCapture> {
+  static const _initialCamera = CameraPosition(
+    target: LatLng(37.7749, -122.4194),
+    zoom: 12,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Map — captured')),
+      body: PostHogPlatformView(
+        privacy: PostHogPlatformViewPrivacy.capture,
+        child: const GoogleMap(initialCameraPosition: _initialCamera),
+      ),
+    );
+  }
+}

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import posthog_flutter
+import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PosthogFlutterPlugin.register(with: registry.registrar(forPlugin: "PosthogFlutterPlugin"))
+  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.3
+  webview_flutter: ^4.10.0
+  google_maps_flutter: ^2.9.0
 
 dev_dependencies:
 

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -5,20 +5,20 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
+import android.os.Build
 import android.os.Handler
+import androidx.annotation.RequiresApi
 import android.os.Looper
-import android.util.Log
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
 import android.view.PixelCopy
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
+import android.util.Log
 import com.posthog.PersonProfiles
 import com.posthog.PostHog
 import com.posthog.PostHogConfig
@@ -27,9 +27,9 @@ import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.internal.getApplicationInfo
 import com.posthog.logs.PostHogLogSeverity
-import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -258,6 +258,10 @@ class PosthogFlutterPlugin :
 
             "captureNativeScreenshot" -> {
                 handleCaptureNativeScreenshot(call, result)
+            }
+
+            "captureNativeScreenshots" -> {
+                handleCaptureNativeScreenshots(call, result)
             }
 
             "isSessionReplayActive" -> {
@@ -542,53 +546,74 @@ class PosthogFlutterPlugin :
         result: Result,
     ) {
         try {
-            val currentActivity = activity
-            if (currentActivity == null) {
-                result.success(null)
-                return
-            }
-
+            val currentActivity = activity ?: run { result.success(null); return }
             val x = call.argument<Int>("x") ?: 0
             val y = call.argument<Int>("y") ?: 0
             val width = call.argument<Int>("width") ?: 0
             val height = call.argument<Int>("height") ?: 0
-
             if (width <= 0 || height <= 0) {
                 result.error("INVALID_ARGUMENT", "Width or height is 0", null)
                 return
             }
-
-            captureNativeScreenshot(
-                activity = currentActivity,
-                x = x,
-                y = y,
-                width = width,
-                height = height,
-                result = result,
-            )
+            captureOneNative(currentActivity, x, y, width, height) { bytes ->
+                result.success(bytes)
+            }
         } catch (e: Throwable) {
             result.error("PosthogFlutterException", e.localizedMessage, null)
         }
     }
 
-    private fun captureNativeScreenshot(
+    private fun handleCaptureNativeScreenshots(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val currentActivity = activity ?: run { result.success(emptyList<ByteArray?>()); return }
+            @Suppress("UNCHECKED_CAST")
+            val views = call.argument<List<Map<String, Int>>>("views") ?: emptyList()
+            if (views.isEmpty()) {
+                result.success(emptyList<ByteArray?>())
+                return
+            }
+            val results = ArrayList<ByteArray?>(views.size)
+            fun captureNext(index: Int) {
+                if (index >= views.size) {
+                    result.success(results)
+                    return
+                }
+                val v = views[index]
+                val x = v["x"] ?: 0
+                val y = v["y"] ?: 0
+                val w = v["width"] ?: 0
+                val h = v["height"] ?: 0
+                captureOneNative(currentActivity, x, y, w, h) { bytes ->
+                    results.add(bytes)
+                    captureNext(index + 1)
+                }
+            }
+            captureNext(0)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun captureOneNative(
         activity: Activity,
         x: Int,
         y: Int,
         width: Int,
         height: Int,
-        result: Result,
+        onResult: (ByteArray?) -> Unit,
     ) {
-        val contentView =
-            activity.findViewById<View>(android.R.id.content) ?: run {
-                result.success(null)
-                return
-            }
+        val contentView = activity.findViewById<View>(android.R.id.content) ?: run {
+            onResult(null)
+            return
+        }
 
         val contentWidthPx = contentView.width
         val contentHeightPx = contentView.height
         if (contentWidthPx <= 0 || contentHeightPx <= 0) {
-            result.success(null)
+            onResult(null)
             return
         }
 
@@ -618,49 +643,33 @@ class PosthogFlutterPlugin :
             val platformViewSvs = allSurfaceViews.filter { !it.javaClass.name.startsWith("io.flutter") }
 
             if (flutterSv == null) {
-                // No FlutterSurfaceView — fall back to window PixelCopy (handles TextureView-based
-                // Flutter configurations where Flutter renders via the window surface directly).
-                val svLocation = locationInWindow
-                val srcRect =
-                    Rect(
-                        svLocation[0] + cropLeft,
-                        svLocation[1] + cropTop,
-                        svLocation[0] + cropRight,
-                        svLocation[1] + cropBottom,
-                    )
+                val srcRect = Rect(
+                    locationInWindow[0] + cropLeft,
+                    locationInWindow[1] + cropTop,
+                    locationInWindow[0] + cropRight,
+                    locationInWindow[1] + cropBottom,
+                )
                 PixelCopy.request(
-                    activity.window,
-                    srcRect,
-                    bitmap,
+                    activity.window, srcRect, bitmap,
                     { copyResult ->
                         if (copyResult != PixelCopy.SUCCESS) {
                             bitmap.recycle()
-                            captureNativeScreenshotFallback(
-                                contentView,
-                                cropLeft,
-                                cropTop,
-                                cropRight,
-                                cropBottom,
-                                logicalWidth,
-                                logicalHeight,
-                                result,
-                            )
+                            captureNativeScreenshotFallback(contentView, cropLeft, cropTop, cropRight, cropBottom, logicalWidth, logicalHeight, onResult)
                             return@request
                         }
-                        compressBitmapToPngAsync(bitmap, result)
+                        compressBitmapAsync(bitmap, onResult)
                     },
                     mainHandler,
                 )
                 return
             }
 
-            // Compute srcRect within the FlutterSurfaceView's local coordinate space.
             val fsvLocation = IntArray(2)
             flutterSv.getLocationInWindow(fsvLocation)
             val fsvSrcLeft = (locationInWindow[0] + cropLeft - fsvLocation[0]).coerceIn(0, flutterSv.width - 1)
-            val fsvSrcTop = (locationInWindow[1] + cropTop - fsvLocation[1]).coerceIn(0, flutterSv.height - 1)
-            val fsvSrcRight = (locationInWindow[0] + cropRight - fsvLocation[0]).coerceIn(fsvSrcLeft + 1, flutterSv.width)
-            val fsvSrcBottom = (locationInWindow[1] + cropBottom - fsvLocation[1]).coerceIn(fsvSrcTop + 1, flutterSv.height)
+            val fsvSrcTop  = (locationInWindow[1] + cropTop  - fsvLocation[1]).coerceIn(0, flutterSv.height - 1)
+            val fsvSrcRight  = (locationInWindow[0] + cropRight  - fsvLocation[0]).coerceIn(fsvSrcLeft + 1, flutterSv.width)
+            val fsvSrcBottom = (locationInWindow[1] + cropBottom - fsvLocation[1]).coerceIn(fsvSrcTop  + 1, flutterSv.height)
             val fsvSrcRect = Rect(fsvSrcLeft, fsvSrcTop, fsvSrcRight, fsvSrcBottom)
 
             PixelCopy.request(
@@ -670,23 +679,13 @@ class PosthogFlutterPlugin :
                 { copyResult ->
                     if (copyResult != PixelCopy.SUCCESS) {
                         bitmap.recycle()
-                        captureNativeScreenshotFallback(
-                            contentView,
-                            cropLeft,
-                            cropTop,
-                            cropRight,
-                            cropBottom,
-                            logicalWidth,
-                            logicalHeight,
-                            result,
-                        )
+                        captureNativeScreenshotFallback(contentView, cropLeft, cropTop, cropRight, cropBottom, logicalWidth, logicalHeight, onResult)
                         return@request
                     }
 
                     if (platformViewSvs.isEmpty()) {
-                        compressBitmapToPngAsync(bitmap, result)
+                        compressBitmapAsync(bitmap, onResult)
                     } else {
-                        // Composite platform-view SurfaceViews (WebView, Maps) on top.
                         compositeSurfaceViewsOnto(
                             svList = platformViewSvs,
                             destBitmap = bitmap,
@@ -696,7 +695,7 @@ class PosthogFlutterPlugin :
                             density = density,
                             index = 0,
                         ) {
-                            compressBitmapToPngAsync(bitmap, result)
+                            compressBitmapAsync(bitmap, onResult)
                         }
                     }
                 },
@@ -713,7 +712,7 @@ class PosthogFlutterPlugin :
             cropBottom = cropBottom,
             logicalWidth = logicalWidth,
             logicalHeight = logicalHeight,
-            result = result,
+            onResult = onResult,
         )
     }
 
@@ -759,7 +758,6 @@ class PosthogFlutterPlugin :
         val svLocation = IntArray(2)
         sv.getLocationInWindow(svLocation)
 
-        // SurfaceView position relative to the PixelCopy crop origin (physical px → logical px)
         val destX = ((svLocation[0] - contentViewLocation[0] - cropLeft) / density).roundToInt()
         val destY = ((svLocation[1] - contentViewLocation[1] - cropTop) / density).roundToInt()
         val svLogW = (sv.width / density).roundToInt().coerceAtLeast(1)
@@ -780,17 +778,16 @@ class PosthogFlutterPlugin :
         val svBitmap = Bitmap.createBitmap(svLogW, svLogH, Bitmap.Config.ARGB_8888)
         PixelCopy.request(
             sv,
-            null, // capture the full SurfaceView content
+            null,
             svBitmap,
             { svCopyResult ->
                 if (svCopyResult == PixelCopy.SUCCESS) {
                     val canvas = android.graphics.Canvas(destBitmap)
-                    val paint =
-                        android.graphics.Paint().apply {
-                            // SRC replaces the destination, including any background fill in the
-                            // "hole" left by the SurfaceView in the window surface.
-                            xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
-                        }
+                    val paint = android.graphics.Paint().apply {
+                        // SRC replaces the destination, including any background fill in the
+                        // "hole" left by the SurfaceView in the window surface.
+                        xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
+                    }
                     canvas.drawBitmap(svBitmap, destX.toFloat(), destY.toFloat(), paint)
                 }
                 svBitmap.recycle()
@@ -808,7 +805,7 @@ class PosthogFlutterPlugin :
         cropBottom: Int,
         logicalWidth: Int,
         logicalHeight: Int,
-        result: Result,
+        onResult: (ByteArray?) -> Unit,
     ) {
         val contentBitmap =
             Bitmap.createBitmap(contentView.width, contentView.height, Bitmap.Config.ARGB_8888)
@@ -835,7 +832,7 @@ class PosthogFlutterPlugin :
                 }
             }
 
-        compressBitmapToPngAsync(outputBitmap, result)
+        compressBitmapAsync(outputBitmap, onResult)
     }
 
     private fun bitmapToPng(bitmap: Bitmap): ByteArray {
@@ -845,9 +842,9 @@ class PosthogFlutterPlugin :
         return outputStream.toByteArray()
     }
 
-    private fun compressBitmapToPngAsync(
+    private fun compressBitmapAsync(
         bitmap: Bitmap,
-        result: Result,
+        onResult: (ByteArray?) -> Unit,
     ) {
         // A PixelCopy callback can fire after onDetachedFromEngine shut the
         // executor down. Guard the submission so it neither crashes the main
@@ -856,25 +853,15 @@ class PosthogFlutterPlugin :
             screenshotCompressionExecutor.execute {
                 try {
                     val pngBytes = bitmapToPng(bitmap)
-                    mainHandler.post {
-                        result.success(pngBytes)
-                    }
+                    mainHandler.post { onResult(pngBytes) }
                 } catch (e: Throwable) {
-                    if (!bitmap.isRecycled) {
-                        bitmap.recycle()
-                    }
-                    mainHandler.post {
-                        result.error("PosthogFlutterException", e.localizedMessage, null)
-                    }
+                    if (!bitmap.isRecycled) bitmap.recycle()
+                    mainHandler.post { onResult(null) }
                 }
             }
         } catch (e: RejectedExecutionException) {
-            if (!bitmap.isRecycled) {
-                bitmap.recycle()
-            }
-            mainHandler.post {
-                result.success(null)
-            }
+            if (!bitmap.isRecycled) bitmap.recycle()
+            mainHandler.post { onResult(null) }
         }
     }
 

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -595,6 +595,11 @@ class PosthogFlutterPlugin :
                 val y = v["y"] ?: 0
                 val w = v["width"] ?: 0
                 val h = v["height"] ?: 0
+                if (w <= 0 || h <= 0) {
+                    results.add(null)
+                    captureNext(index + 1)
+                    return
+                }
                 captureOneNative(currentActivity, x, y, w, h) { bytes ->
                     results.add(bytes)
                     captureNext(index + 1)

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -693,6 +693,11 @@ class PosthogFlutterPlugin :
                 return
             }
 
+            if (flutterSv.width <= 0 || flutterSv.height <= 0) {
+                bitmap.recycle()
+                onResult(null)
+                return
+            }
             val fsvLocation = IntArray(2)
             flutterSv.getLocationInWindow(fsvLocation)
             val fsvSrcLeft = (locationInWindow[0] + cropLeft - fsvLocation[0]).coerceIn(0, flutterSv.width - 1)

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -39,6 +39,8 @@ import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import kotlin.math.roundToInt
 
+private const val FLUTTER_VIEW_CLASS_PREFIX = "io.flutter"
+
 /** PosthogFlutterPlugin */
 class PosthogFlutterPlugin :
     FlutterPlugin,
@@ -654,8 +656,8 @@ class PosthogFlutterPlugin :
             // on top.
             val allSurfaceViews = collectAllSurfaceViews(contentView)
 
-            val flutterSv = allSurfaceViews.firstOrNull { it.javaClass.name.startsWith("io.flutter") }
-            val platformViewSvs = allSurfaceViews.filter { !it.javaClass.name.startsWith("io.flutter") }
+            val flutterSv = allSurfaceViews.firstOrNull { it.javaClass.name.startsWith(FLUTTER_VIEW_CLASS_PREFIX) }
+            val platformViewSvs = allSurfaceViews.filter { !it.javaClass.name.startsWith(FLUTTER_VIEW_CLASS_PREFIX) }
 
             if (flutterSv == null) {
                 val srcRect =

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -5,20 +5,20 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.Rect
-import android.net.Uri
-import android.os.Bundle
-import android.os.Build
-import android.os.Handler
-import androidx.annotation.RequiresApi
-import android.os.Looper
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
+import android.graphics.Rect
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import android.view.PixelCopy
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
-import android.util.Log
+import androidx.annotation.RequiresApi
 import com.posthog.PersonProfiles
 import com.posthog.PostHog
 import com.posthog.PostHogConfig
@@ -27,9 +27,9 @@ import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.internal.getApplicationInfo
 import com.posthog.logs.PostHogLogSeverity
+import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
-import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -546,7 +546,11 @@ class PosthogFlutterPlugin :
         result: Result,
     ) {
         try {
-            val currentActivity = activity ?: run { result.success(null); return }
+            val currentActivity =
+                activity ?: run {
+                    result.success(null)
+                    return
+                }
             val x = call.argument<Int>("x") ?: 0
             val y = call.argument<Int>("y") ?: 0
             val width = call.argument<Int>("width") ?: 0
@@ -568,7 +572,12 @@ class PosthogFlutterPlugin :
         result: Result,
     ) {
         try {
-            val currentActivity = activity ?: run { result.success(emptyList<ByteArray?>()); return }
+            val currentActivity =
+                activity ?: run {
+                    result.success(emptyList<ByteArray?>())
+                    return
+                }
+
             @Suppress("UNCHECKED_CAST")
             val views = call.argument<List<Map<String, Int>>>("views") ?: emptyList()
             if (views.isEmpty()) {
@@ -576,6 +585,7 @@ class PosthogFlutterPlugin :
                 return
             }
             val results = ArrayList<ByteArray?>(views.size)
+
             fun captureNext(index: Int) {
                 if (index >= views.size) {
                     result.success(results)
@@ -605,10 +615,11 @@ class PosthogFlutterPlugin :
         height: Int,
         onResult: (ByteArray?) -> Unit,
     ) {
-        val contentView = activity.findViewById<View>(android.R.id.content) ?: run {
-            onResult(null)
-            return
-        }
+        val contentView =
+            activity.findViewById<View>(android.R.id.content) ?: run {
+                onResult(null)
+                return
+            }
 
         val contentWidthPx = contentView.width
         val contentHeightPx = contentView.height
@@ -643,18 +654,30 @@ class PosthogFlutterPlugin :
             val platformViewSvs = allSurfaceViews.filter { !it.javaClass.name.startsWith("io.flutter") }
 
             if (flutterSv == null) {
-                val srcRect = Rect(
-                    locationInWindow[0] + cropLeft,
-                    locationInWindow[1] + cropTop,
-                    locationInWindow[0] + cropRight,
-                    locationInWindow[1] + cropBottom,
-                )
+                val srcRect =
+                    Rect(
+                        locationInWindow[0] + cropLeft,
+                        locationInWindow[1] + cropTop,
+                        locationInWindow[0] + cropRight,
+                        locationInWindow[1] + cropBottom,
+                    )
                 PixelCopy.request(
-                    activity.window, srcRect, bitmap,
+                    activity.window,
+                    srcRect,
+                    bitmap,
                     { copyResult ->
                         if (copyResult != PixelCopy.SUCCESS) {
                             bitmap.recycle()
-                            captureNativeScreenshotFallback(contentView, cropLeft, cropTop, cropRight, cropBottom, logicalWidth, logicalHeight, onResult)
+                            captureNativeScreenshotFallback(
+                                contentView,
+                                cropLeft,
+                                cropTop,
+                                cropRight,
+                                cropBottom,
+                                logicalWidth,
+                                logicalHeight,
+                                onResult,
+                            )
                             return@request
                         }
                         compressBitmapAsync(bitmap, onResult)
@@ -667,9 +690,9 @@ class PosthogFlutterPlugin :
             val fsvLocation = IntArray(2)
             flutterSv.getLocationInWindow(fsvLocation)
             val fsvSrcLeft = (locationInWindow[0] + cropLeft - fsvLocation[0]).coerceIn(0, flutterSv.width - 1)
-            val fsvSrcTop  = (locationInWindow[1] + cropTop  - fsvLocation[1]).coerceIn(0, flutterSv.height - 1)
-            val fsvSrcRight  = (locationInWindow[0] + cropRight  - fsvLocation[0]).coerceIn(fsvSrcLeft + 1, flutterSv.width)
-            val fsvSrcBottom = (locationInWindow[1] + cropBottom - fsvLocation[1]).coerceIn(fsvSrcTop  + 1, flutterSv.height)
+            val fsvSrcTop = (locationInWindow[1] + cropTop - fsvLocation[1]).coerceIn(0, flutterSv.height - 1)
+            val fsvSrcRight = (locationInWindow[0] + cropRight - fsvLocation[0]).coerceIn(fsvSrcLeft + 1, flutterSv.width)
+            val fsvSrcBottom = (locationInWindow[1] + cropBottom - fsvLocation[1]).coerceIn(fsvSrcTop + 1, flutterSv.height)
             val fsvSrcRect = Rect(fsvSrcLeft, fsvSrcTop, fsvSrcRight, fsvSrcBottom)
 
             PixelCopy.request(
@@ -679,7 +702,16 @@ class PosthogFlutterPlugin :
                 { copyResult ->
                     if (copyResult != PixelCopy.SUCCESS) {
                         bitmap.recycle()
-                        captureNativeScreenshotFallback(contentView, cropLeft, cropTop, cropRight, cropBottom, logicalWidth, logicalHeight, onResult)
+                        captureNativeScreenshotFallback(
+                            contentView,
+                            cropLeft,
+                            cropTop,
+                            cropRight,
+                            cropBottom,
+                            logicalWidth,
+                            logicalHeight,
+                            onResult,
+                        )
                         return@request
                     }
 
@@ -783,11 +815,12 @@ class PosthogFlutterPlugin :
             { svCopyResult ->
                 if (svCopyResult == PixelCopy.SUCCESS) {
                     val canvas = android.graphics.Canvas(destBitmap)
-                    val paint = android.graphics.Paint().apply {
-                        // SRC replaces the destination, including any background fill in the
-                        // "hole" left by the SurfaceView in the window surface.
-                        xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
-                    }
+                    val paint =
+                        android.graphics.Paint().apply {
+                            // SRC replaces the destination, including any background fill in the
+                            // "hole" left by the SurfaceView in the window surface.
+                            xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
+                        }
                     canvas.drawBitmap(svBitmap, destX.toFloat(), destY.toFloat(), paint)
                 }
                 svBitmap.recycle()

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -1,13 +1,24 @@
 package com.posthog.flutter
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.Rect
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.PixelCopy
+import android.view.SurfaceView
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
 import com.posthog.PersonProfiles
 import com.posthog.PostHog
 import com.posthog.PostHogConfig
@@ -17,15 +28,22 @@ import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.internal.getApplicationInfo
 import com.posthog.logs.PostHogLogSeverity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import java.io.ByteArrayOutputStream
 import java.util.Date
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import kotlin.math.roundToInt
 
 /** PosthogFlutterPlugin */
 class PosthogFlutterPlugin :
     FlutterPlugin,
+    ActivityAware,
     MethodCallHandler {
     // / The MethodChannel that will be the communication between Flutter and native Android
     // /
@@ -34,7 +52,10 @@ class PosthogFlutterPlugin :
     private lateinit var channel: MethodChannel
 
     private lateinit var applicationContext: Context
+    private var activity: Activity? = null
 
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val screenshotCompressionExecutor = Executors.newSingleThreadExecutor()
     private val snapshotSender = SnapshotSender()
 
     // The surveys delegate
@@ -233,6 +254,10 @@ class PosthogFlutterPlugin :
 
             "sendFullSnapshot" -> {
                 handleSendFullSnapshot(call, result)
+            }
+
+            "captureNativeScreenshot" -> {
+                handleCaptureNativeScreenshot(call, result)
             }
 
             "isSessionReplayActive" -> {
@@ -471,8 +496,25 @@ class PosthogFlutterPlugin :
         PostHogAndroid.setup(applicationContext, config)
     }
 
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        activity = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivity() {
+        activity = null
+    }
+
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        screenshotCompressionExecutor.shutdown()
     }
 
     private fun handleSendFullSnapshot(
@@ -492,6 +534,347 @@ class PosthogFlutterPlugin :
             }
         } catch (e: Throwable) {
             result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun handleCaptureNativeScreenshot(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val currentActivity = activity
+            if (currentActivity == null) {
+                result.success(null)
+                return
+            }
+
+            val x = call.argument<Int>("x") ?: 0
+            val y = call.argument<Int>("y") ?: 0
+            val width = call.argument<Int>("width") ?: 0
+            val height = call.argument<Int>("height") ?: 0
+
+            if (width <= 0 || height <= 0) {
+                result.error("INVALID_ARGUMENT", "Width or height is 0", null)
+                return
+            }
+
+            captureNativeScreenshot(
+                activity = currentActivity,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                result = result,
+            )
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
+        }
+    }
+
+    private fun captureNativeScreenshot(
+        activity: Activity,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+        result: Result,
+    ) {
+        val contentView =
+            activity.findViewById<View>(android.R.id.content) ?: run {
+                result.success(null)
+                return
+            }
+
+        val contentWidthPx = contentView.width
+        val contentHeightPx = contentView.height
+        if (contentWidthPx <= 0 || contentHeightPx <= 0) {
+            result.success(null)
+            return
+        }
+
+        val density = activity.resources.displayMetrics.density
+        val cropLeft = (x * density).roundToInt().coerceIn(0, contentWidthPx - 1)
+        val cropTop = (y * density).roundToInt().coerceIn(0, contentHeightPx - 1)
+        val cropRight = ((x + width) * density).roundToInt().coerceIn(cropLeft + 1, contentWidthPx)
+        val cropBottom = ((y + height) * density).roundToInt().coerceIn(cropTop + 1, contentHeightPx)
+
+        val logicalWidth = width.coerceAtLeast(1)
+        val logicalHeight = height.coerceAtLeast(1)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val locationInWindow = IntArray(2)
+            contentView.getLocationInWindow(locationInWindow)
+
+            val bitmap = Bitmap.createBitmap(logicalWidth, logicalHeight, Bitmap.Config.ARGB_8888)
+
+            // Flutter renders on FlutterSurfaceView — a SurfaceView that lives OUTSIDE the
+            // window surface in its own hardware-composited layer. Capturing activity.window
+            // gives only the (empty) window background. We must capture FlutterSurfaceView
+            // directly, then composite any platform-view SurfaceViews (e.g. google_maps_flutter)
+            // on top.
+            val allSurfaceViews = collectAllSurfaceViews(contentView)
+
+            val flutterSv = allSurfaceViews.firstOrNull { it.javaClass.name.startsWith("io.flutter") }
+            val platformViewSvs = allSurfaceViews.filter { !it.javaClass.name.startsWith("io.flutter") }
+
+            if (flutterSv == null) {
+                // No FlutterSurfaceView — fall back to window PixelCopy (handles TextureView-based
+                // Flutter configurations where Flutter renders via the window surface directly).
+                val svLocation = locationInWindow
+                val srcRect =
+                    Rect(
+                        svLocation[0] + cropLeft,
+                        svLocation[1] + cropTop,
+                        svLocation[0] + cropRight,
+                        svLocation[1] + cropBottom,
+                    )
+                PixelCopy.request(
+                    activity.window,
+                    srcRect,
+                    bitmap,
+                    { copyResult ->
+                        if (copyResult != PixelCopy.SUCCESS) {
+                            bitmap.recycle()
+                            captureNativeScreenshotFallback(
+                                contentView,
+                                cropLeft,
+                                cropTop,
+                                cropRight,
+                                cropBottom,
+                                logicalWidth,
+                                logicalHeight,
+                                result,
+                            )
+                            return@request
+                        }
+                        compressBitmapToPngAsync(bitmap, result)
+                    },
+                    mainHandler,
+                )
+                return
+            }
+
+            // Compute srcRect within the FlutterSurfaceView's local coordinate space.
+            val fsvLocation = IntArray(2)
+            flutterSv.getLocationInWindow(fsvLocation)
+            val fsvSrcLeft = (locationInWindow[0] + cropLeft - fsvLocation[0]).coerceIn(0, flutterSv.width - 1)
+            val fsvSrcTop = (locationInWindow[1] + cropTop - fsvLocation[1]).coerceIn(0, flutterSv.height - 1)
+            val fsvSrcRight = (locationInWindow[0] + cropRight - fsvLocation[0]).coerceIn(fsvSrcLeft + 1, flutterSv.width)
+            val fsvSrcBottom = (locationInWindow[1] + cropBottom - fsvLocation[1]).coerceIn(fsvSrcTop + 1, flutterSv.height)
+            val fsvSrcRect = Rect(fsvSrcLeft, fsvSrcTop, fsvSrcRight, fsvSrcBottom)
+
+            PixelCopy.request(
+                flutterSv,
+                fsvSrcRect,
+                bitmap,
+                { copyResult ->
+                    if (copyResult != PixelCopy.SUCCESS) {
+                        bitmap.recycle()
+                        captureNativeScreenshotFallback(
+                            contentView,
+                            cropLeft,
+                            cropTop,
+                            cropRight,
+                            cropBottom,
+                            logicalWidth,
+                            logicalHeight,
+                            result,
+                        )
+                        return@request
+                    }
+
+                    if (platformViewSvs.isEmpty()) {
+                        compressBitmapToPngAsync(bitmap, result)
+                    } else {
+                        // Composite platform-view SurfaceViews (WebView, Maps) on top.
+                        compositeSurfaceViewsOnto(
+                            svList = platformViewSvs,
+                            destBitmap = bitmap,
+                            contentViewLocation = locationInWindow,
+                            cropLeft = cropLeft,
+                            cropTop = cropTop,
+                            density = density,
+                            index = 0,
+                        ) {
+                            compressBitmapToPngAsync(bitmap, result)
+                        }
+                    }
+                },
+                mainHandler,
+            )
+            return
+        }
+
+        captureNativeScreenshotFallback(
+            contentView = contentView,
+            cropLeft = cropLeft,
+            cropTop = cropTop,
+            cropRight = cropRight,
+            cropBottom = cropBottom,
+            logicalWidth = logicalWidth,
+            logicalHeight = logicalHeight,
+            result = result,
+        )
+    }
+
+    private fun collectAllSurfaceViews(view: View): List<SurfaceView> {
+        val result = mutableListOf<SurfaceView>()
+        if (view is SurfaceView) {
+            result.add(view)
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                result.addAll(collectAllSurfaceViews(view.getChildAt(i)))
+            }
+        }
+        return result
+    }
+
+    @Suppress("SameParameterValue")
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun compositeSurfaceViewsOnto(
+        svList: List<SurfaceView>,
+        destBitmap: Bitmap,
+        contentViewLocation: IntArray,
+        cropLeft: Int,
+        cropTop: Int,
+        density: Float,
+        index: Int,
+        onComplete: () -> Unit,
+    ) {
+        if (index >= svList.size) {
+            onComplete()
+            return
+        }
+        val sv = svList[index]
+        val advance = {
+            compositeSurfaceViewsOnto(svList, destBitmap, contentViewLocation, cropLeft, cropTop, density, index + 1, onComplete)
+        }
+
+        if (!sv.isAttachedToWindow || sv.width <= 0 || sv.height <= 0) {
+            advance()
+            return
+        }
+
+        val svLocation = IntArray(2)
+        sv.getLocationInWindow(svLocation)
+
+        // SurfaceView position relative to the PixelCopy crop origin (physical px → logical px)
+        val destX = ((svLocation[0] - contentViewLocation[0] - cropLeft) / density).roundToInt()
+        val destY = ((svLocation[1] - contentViewLocation[1] - cropTop) / density).roundToInt()
+        val svLogW = (sv.width / density).roundToInt().coerceAtLeast(1)
+        val svLogH = (sv.height / density).roundToInt().coerceAtLeast(1)
+
+        // Skip a SurfaceView extending well beyond the captured region: it's a
+        // different platform view (e.g. a masked map) that merely overlaps, so
+        // compositing it would leak masked content. Slack absorbs rounding.
+        val tolerance = 8
+        if (destX < -tolerance || destY < -tolerance ||
+            destX + svLogW > destBitmap.width + tolerance ||
+            destY + svLogH > destBitmap.height + tolerance
+        ) {
+            advance()
+            return
+        }
+
+        val svBitmap = Bitmap.createBitmap(svLogW, svLogH, Bitmap.Config.ARGB_8888)
+        PixelCopy.request(
+            sv,
+            null, // capture the full SurfaceView content
+            svBitmap,
+            { svCopyResult ->
+                if (svCopyResult == PixelCopy.SUCCESS) {
+                    val canvas = android.graphics.Canvas(destBitmap)
+                    val paint =
+                        android.graphics.Paint().apply {
+                            // SRC replaces the destination, including any background fill in the
+                            // "hole" left by the SurfaceView in the window surface.
+                            xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
+                        }
+                    canvas.drawBitmap(svBitmap, destX.toFloat(), destY.toFloat(), paint)
+                }
+                svBitmap.recycle()
+                advance()
+            },
+            mainHandler,
+        )
+    }
+
+    private fun captureNativeScreenshotFallback(
+        contentView: View,
+        cropLeft: Int,
+        cropTop: Int,
+        cropRight: Int,
+        cropBottom: Int,
+        logicalWidth: Int,
+        logicalHeight: Int,
+        result: Result,
+    ) {
+        val contentBitmap =
+            Bitmap.createBitmap(contentView.width, contentView.height, Bitmap.Config.ARGB_8888)
+        // Software Canvas cannot read GPU-composited surfaces like SurfaceView or TextureView,
+        // so those platform views may still appear blank when we hit this fallback path.
+        contentView.draw(android.graphics.Canvas(contentBitmap))
+
+        val croppedBitmap =
+            Bitmap.createBitmap(
+                contentBitmap,
+                cropLeft,
+                cropTop,
+                cropRight - cropLeft,
+                cropBottom - cropTop,
+            )
+        contentBitmap.recycle()
+
+        val outputBitmap =
+            if (croppedBitmap.width == logicalWidth && croppedBitmap.height == logicalHeight) {
+                croppedBitmap
+            } else {
+                Bitmap.createScaledBitmap(croppedBitmap, logicalWidth, logicalHeight, true).also {
+                    croppedBitmap.recycle()
+                }
+            }
+
+        compressBitmapToPngAsync(outputBitmap, result)
+    }
+
+    private fun bitmapToPng(bitmap: Bitmap): ByteArray {
+        val outputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        bitmap.recycle()
+        return outputStream.toByteArray()
+    }
+
+    private fun compressBitmapToPngAsync(
+        bitmap: Bitmap,
+        result: Result,
+    ) {
+        // A PixelCopy callback can fire after onDetachedFromEngine shut the
+        // executor down. Guard the submission so it neither crashes the main
+        // thread (RejectedExecutionException) nor leaks the bitmap.
+        try {
+            screenshotCompressionExecutor.execute {
+                try {
+                    val pngBytes = bitmapToPng(bitmap)
+                    mainHandler.post {
+                        result.success(pngBytes)
+                    }
+                } catch (e: Throwable) {
+                    if (!bitmap.isRecycled) {
+                        bitmap.recycle()
+                    }
+                    mainHandler.post {
+                        result.error("PosthogFlutterException", e.localizedMessage, null)
+                    }
+                }
+            }
+        } catch (e: RejectedExecutionException) {
+            if (!bitmap.isRecycled) {
+                bitmap.recycle()
+            }
+            mainHandler.post {
+                result.success(null)
+            }
         }
     }
 

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -812,26 +812,31 @@ class PosthogFlutterPlugin :
         }
 
         val svBitmap = Bitmap.createBitmap(svLogW, svLogH, Bitmap.Config.ARGB_8888)
-        PixelCopy.request(
-            sv,
-            null,
-            svBitmap,
-            { svCopyResult ->
-                if (svCopyResult == PixelCopy.SUCCESS) {
-                    val canvas = android.graphics.Canvas(destBitmap)
-                    val paint =
-                        android.graphics.Paint().apply {
-                            // SRC replaces the destination, including any background fill in the
-                            // "hole" left by the SurfaceView in the window surface.
-                            xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
-                        }
-                    canvas.drawBitmap(svBitmap, destX.toFloat(), destY.toFloat(), paint)
-                }
-                svBitmap.recycle()
-                advance()
-            },
-            mainHandler,
-        )
+        try {
+            PixelCopy.request(
+                sv,
+                null,
+                svBitmap,
+                { svCopyResult ->
+                    if (svCopyResult == PixelCopy.SUCCESS) {
+                        val canvas = android.graphics.Canvas(destBitmap)
+                        val paint =
+                            android.graphics.Paint().apply {
+                                // SRC replaces the destination, including any background fill in the
+                                // "hole" left by the SurfaceView in the window surface.
+                                xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
+                            }
+                        canvas.drawBitmap(svBitmap, destX.toFloat(), destY.toFloat(), paint)
+                    }
+                    svBitmap.recycle()
+                    advance()
+                },
+                mainHandler,
+            )
+        } catch (e: Throwable) {
+            svBitmap.recycle()
+            advance()
+        }
     }
 
     private fun captureNativeScreenshotFallback(

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -56,7 +56,7 @@ class PosthogFlutterPlugin :
     private var activity: Activity? = null
 
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val screenshotCompressionExecutor = Executors.newSingleThreadExecutor()
+    private val bitmapExportExecutor = Executors.newSingleThreadExecutor()
     private val snapshotSender = SnapshotSender()
 
     // The surveys delegate
@@ -519,7 +519,7 @@ class PosthogFlutterPlugin :
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
-        screenshotCompressionExecutor.shutdown()
+        bitmapExportExecutor.shutdown()
     }
 
     private fun handleSendFullSnapshot(
@@ -907,7 +907,7 @@ class PosthogFlutterPlugin :
         // executor down. Guard the submission so it neither crashes the main
         // thread (RejectedExecutionException) nor leaks the bitmap.
         try {
-            screenshotCompressionExecutor.execute {
+            bitmapExportExecutor.execute {
                 try {
                     val rgbaBytes = bitmapToRawRgba(bitmap)
                     mainHandler.post { onResult(rgbaBytes) }

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -34,7 +34,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import java.io.ByteArrayOutputStream
 import java.util.Date
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
@@ -680,7 +679,7 @@ class PosthogFlutterPlugin :
                             )
                             return@request
                         }
-                        compressBitmapAsync(bitmap, onResult)
+                        exportBitmapAsync(bitmap, onResult)
                     },
                     mainHandler,
                 )
@@ -716,7 +715,7 @@ class PosthogFlutterPlugin :
                     }
 
                     if (platformViewSvs.isEmpty()) {
-                        compressBitmapAsync(bitmap, onResult)
+                        exportBitmapAsync(bitmap, onResult)
                     } else {
                         compositeSurfaceViewsOnto(
                             svList = platformViewSvs,
@@ -727,7 +726,7 @@ class PosthogFlutterPlugin :
                             density = density,
                             index = 0,
                         ) {
-                            compressBitmapAsync(bitmap, onResult)
+                            exportBitmapAsync(bitmap, onResult)
                         }
                     }
                 },
@@ -865,17 +864,25 @@ class PosthogFlutterPlugin :
                 }
             }
 
-        compressBitmapAsync(outputBitmap, onResult)
+        exportBitmapAsync(outputBitmap, onResult)
     }
 
-    private fun bitmapToPng(bitmap: Bitmap): ByteArray {
-        val outputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+    private fun bitmapToRawRgba(bitmap: Bitmap): ByteArray {
+        val pixels = IntArray(bitmap.width * bitmap.height)
+        bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
         bitmap.recycle()
-        return outputStream.toByteArray()
+        val bytes = ByteArray(pixels.size * 4)
+        for (i in pixels.indices) {
+            val pixel = pixels[i]
+            bytes[i * 4] = ((pixel shr 16) and 0xFF).toByte() // R
+            bytes[i * 4 + 1] = ((pixel shr 8) and 0xFF).toByte() // G
+            bytes[i * 4 + 2] = (pixel and 0xFF).toByte() // B
+            bytes[i * 4 + 3] = ((pixel shr 24) and 0xFF).toByte() // A
+        }
+        return bytes
     }
 
-    private fun compressBitmapAsync(
+    private fun exportBitmapAsync(
         bitmap: Bitmap,
         onResult: (ByteArray?) -> Unit,
     ) {
@@ -885,8 +892,8 @@ class PosthogFlutterPlugin :
         try {
             screenshotCompressionExecutor.execute {
                 try {
-                    val pngBytes = bitmapToPng(bitmap)
-                    mainHandler.post { onResult(pngBytes) }
+                    val rgbaBytes = bitmapToRawRgba(bitmap)
+                    mainHandler.post { onResult(rgbaBytes) }
                 } catch (e: Throwable) {
                     if (!bitmap.isRecycled) bitmap.recycle()
                     mainHandler.post { onResult(null) }

--- a/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
+++ b/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
@@ -1,5 +1,7 @@
 package com.posthog.flutter
 
+import android.app.Activity
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import org.mockito.Mockito
@@ -73,6 +75,46 @@ internal class PosthogFlutterPluginTest {
 
         Mockito.verify(mockResult).error(
             Mockito.eq("PosthogFlutterException"),
+            Mockito.any(),
+            Mockito.isNull(),
+        )
+    }
+
+    @Test
+    fun onMethodCall_captureNativeScreenshot_noActivity_returnsNull() {
+        val plugin = PosthogFlutterPlugin()
+
+        val call =
+            MethodCall(
+                "captureNativeScreenshot",
+                mapOf("x" to 0, "y" to 0, "width" to 10, "height" to 10),
+            )
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        // No activity attached, so capture degrades to null rather than crashing.
+        Mockito.verify(mockResult).success(null)
+    }
+
+    @Test
+    fun onMethodCall_captureNativeScreenshot_invalidDimensions_returnsError() {
+        val plugin = PosthogFlutterPlugin()
+        val binding = Mockito.mock(ActivityPluginBinding::class.java)
+        Mockito.`when`(binding.activity).thenReturn(Mockito.mock(Activity::class.java))
+        plugin.onAttachedToActivity(binding)
+
+        // Dimensions are validated before any activity view access, so a bare
+        // mock Activity is enough to reach the zero-dimension guard.
+        val call =
+            MethodCall(
+                "captureNativeScreenshot",
+                mapOf("x" to 0, "y" to 0, "width" to 0, "height" to 0),
+            )
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENT"),
             Mockito.any(),
             Mockito.isNull(),
         )

--- a/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
+++ b/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
@@ -121,6 +121,59 @@ internal class PosthogFlutterPluginTest {
     }
 
     @Test
+    fun onMethodCall_captureNativeScreenshots_noActivity_returnsEmptyList() {
+        val plugin = PosthogFlutterPlugin()
+
+        val call =
+            MethodCall(
+                "captureNativeScreenshots",
+                mapOf("views" to listOf(mapOf("x" to 0, "y" to 0, "width" to 10, "height" to 10))),
+            )
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).success(emptyList<ByteArray?>())
+    }
+
+    @Test
+    fun onMethodCall_captureNativeScreenshots_emptyViews_returnsEmptyList() {
+        val plugin = PosthogFlutterPlugin()
+        val binding = Mockito.mock(ActivityPluginBinding::class.java)
+        Mockito.`when`(binding.activity).thenReturn(Mockito.mock(Activity::class.java))
+        plugin.onAttachedToActivity(binding)
+
+        val call = MethodCall("captureNativeScreenshots", mapOf("views" to emptyList<Map<String, Int>>()))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).success(emptyList<ByteArray?>())
+    }
+
+    @Test
+    fun onMethodCall_captureNativeScreenshots_zeroDimensionEntry_producesNullInResult() {
+        val plugin = PosthogFlutterPlugin()
+        val binding = Mockito.mock(ActivityPluginBinding::class.java)
+        Mockito.`when`(binding.activity).thenReturn(Mockito.mock(Activity::class.java))
+        plugin.onAttachedToActivity(binding)
+
+        // Zero-dimension guard fires before any activity view access, so
+        // captureNext inserts null and advances without crashing.
+        val call =
+            MethodCall(
+                "captureNativeScreenshots",
+                mapOf("views" to listOf(mapOf("x" to 0, "y" to 0, "width" to 0, "height" to 0))),
+            )
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        @Suppress("UNCHECKED_CAST")
+        val captor = org.mockito.ArgumentCaptor.forClass(List::class.java) as org.mockito.ArgumentCaptor<List<ByteArray?>>
+        Mockito.verify(mockResult).success(captor.capture())
+        assert(captor.value.size == 1) { "Expected result list of size 1, got ${captor.value.size}" }
+        assert(captor.value[0] == null) { "Expected null for zero-dimension entry" }
+    }
+
+    @Test
     fun onMethodCall_getFeatureFlagResult_missingKey_returnsError() {
         val plugin = PosthogFlutterPlugin()
 

--- a/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
+++ b/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.mockito.Mockito
 import kotlin.test.Test
 
@@ -169,8 +171,8 @@ internal class PosthogFlutterPluginTest {
         @Suppress("UNCHECKED_CAST")
         val captor = org.mockito.ArgumentCaptor.forClass(List::class.java) as org.mockito.ArgumentCaptor<List<ByteArray?>>
         Mockito.verify(mockResult).success(captor.capture())
-        assert(captor.value.size == 1) { "Expected result list of size 1, got ${captor.value.size}" }
-        assert(captor.value[0] == null) { "Expected null for zero-dimension entry" }
+        assertEquals(1, captor.value.size)
+        assertNull(captor.value[0])
     }
 
     @Test

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -7,25 +7,25 @@ let package = Package(
     name: "posthog_flutter",
     platforms: [
         .iOS("13.0"),
-        .macOS("10.15")
+        .macOS("10.15"),
     ],
     products: [
-        .library(name: "posthog-flutter", targets: ["posthog_flutter"])
+        .library(name: "posthog-flutter", targets: ["posthog_flutter"]),
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.61.0"..<"4.0.0")
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.61.0" ..< "4.0.0"),
     ],
     targets: [
         .target(
             name: "posthog_flutter",
             dependencies: [
                 .product(name: "FlutterFramework", package: "FlutterFramework"),
-                .product(name: "PostHog", package: "posthog-ios")
+                .product(name: "PostHog", package: "posthog-ios"),
             ],
             resources: [
-                .process("PrivacyInfo.xcprivacy")
+                .process("PrivacyInfo.xcprivacy"),
             ]
-        )
+        ),
     ]
 )

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -331,6 +331,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             sendFullSnapshot(call, result: result)
         case "captureNativeScreenshot":
             captureNativeScreenshot(call, result: result)
+        case "captureNativeScreenshots":
+            captureNativeScreenshots(call, result: result)
         case "isSessionReplayActive":
             isSessionReplayActive(result: result)
         case "startSessionRecording":
@@ -473,20 +475,46 @@ extension PosthogFlutterPlugin {
                 _badArgumentError(result)
                 return
             }
-
             let x = args["x"] as? Int ?? 0
             let y = args["y"] as? Int ?? 0
             let width = args["width"] as? Int ?? 0
             let height = args["height"] as? Int ?? 0
-
             guard width > 0, height > 0 else {
                 _badArgumentError(result)
                 return
             }
+            captureOneNative(x: x, y: y, width: width, height: height) { bytes in
+                result(bytes)
+            }
+        #else
+            result(nil)
+        #endif
+    }
 
+    private func captureNativeScreenshots(_ call: FlutterMethodCall,
+                                          result: @escaping FlutterResult)
+    {
+        #if os(iOS)
+            guard let args = call.arguments as? [String: Any],
+                  let views = args["views"] as? [[String: Int]] else {
+                result([])
+                return
+            }
+            captureNextNative(views: views, index: 0, acc: []) { results in
+                result(results)
+            }
+        #else
+            result([])
+        #endif
+    }
+
+    #if os(iOS)
+        private func captureOneNative(x: Int, y: Int, width: Int, height: Int,
+                                      onResult: @escaping (FlutterStandardTypedData?) -> Void)
+        {
             DispatchQueue.main.async {
                 guard let window = self.captureWindow() else {
-                    result(nil)
+                    onResult(nil)
                     return
                 }
 
@@ -494,14 +522,14 @@ extension PosthogFlutterPlugin {
                 // etc.) Flutter has no widget rects for it, so capturing would
                 // include unmasked native content. Fall back to Flutter-only.
                 if window.rootViewController?.presentedViewController != nil {
-                    result(nil)
+                    onResult(nil)
                     return
                 }
 
                 let cropRect = CGRect(x: x, y: y, width: width, height: height)
                     .intersection(window.bounds)
                 guard !cropRect.isNull, !cropRect.isEmpty else {
-                    result(nil)
+                    onResult(nil)
                     return
                 }
 
@@ -513,15 +541,15 @@ extension PosthogFlutterPlugin {
                     let config = WKSnapshotConfiguration()
                     config.rect = webView.convert(cropRect, from: nil).intersection(webView.bounds)
                     guard !config.rect.isNull, !config.rect.isEmpty else {
-                        result(nil)
+                        onResult(nil)
                         return
                     }
                     webView.takeSnapshot(with: config) { snapshotImage, error in
                         guard error == nil, let snapshotImage = snapshotImage else {
-                            result(nil)
+                            onResult(nil)
                             return
                         }
-                        result(snapshotImage.pngData().map(FlutterStandardTypedData.init(bytes:)) ?? nil)
+                        onResult(snapshotImage.pngData().map(FlutterStandardTypedData.init(bytes:)) ?? nil)
                     }
                     return
                 }
@@ -530,18 +558,32 @@ extension PosthogFlutterPlugin {
                 // keeps this safe: drawHierarchy over the full window would
                 // include any masked CALayer-backed platform view overlapping
                 // the crop region and leak it into replay.
-                result(nil)
+                onResult(nil)
             }
-        #else
-            result(nil)
-        #endif
-    }
+        }
 
-    #if os(iOS)
+        private func captureNextNative(views: [[String: Int]], index: Int,
+                                       acc: [FlutterStandardTypedData?],
+                                       completion: @escaping ([FlutterStandardTypedData?]) -> Void)
+        {
+            guard index < views.count else {
+                completion(acc)
+                return
+            }
+            let v = views[index]
+            let x = v["x"] ?? 0
+            let y = v["y"] ?? 0
+            let width = v["width"] ?? 0
+            let height = v["height"] ?? 0
+            captureOneNative(x: x, y: y, width: width, height: height) { bytes in
+                self.captureNextNative(views: views, index: index + 1, acc: acc + [bytes], completion: completion)
+            }
+        }
+
         private func captureWindow() -> UIWindow? {
             return UIApplication.shared.connectedScenes
                 .compactMap { $0 as? UIWindowScene }
-                .flatMap(\.windows)
+                .flatMap { $0.windows }
                 .first(where: \.isKeyWindow) ?? UIApplication.shared.windows.first
         }
 

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -2,6 +2,7 @@ import PostHog
 #if os(iOS)
     import Flutter
     import UIKit
+    import WebKit
 #elseif os(macOS)
     import AppKit
     import FlutterMacOS
@@ -328,6 +329,8 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             sendMetaEvent(call, result: result)
         case "sendFullSnapshot":
             sendFullSnapshot(call, result: result)
+        case "captureNativeScreenshot":
+            captureNativeScreenshot(call, result: result)
         case "isSessionReplayActive":
             isSessionReplayActive(result: result)
         case "startSessionRecording":
@@ -462,6 +465,99 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
 #endif
 
 extension PosthogFlutterPlugin {
+    private func captureNativeScreenshot(_ call: FlutterMethodCall,
+                                         result: @escaping FlutterResult)
+    {
+        #if os(iOS)
+            guard let args = call.arguments as? [String: Any] else {
+                _badArgumentError(result)
+                return
+            }
+
+            let x = args["x"] as? Int ?? 0
+            let y = args["y"] as? Int ?? 0
+            let width = args["width"] as? Int ?? 0
+            let height = args["height"] as? Int ?? 0
+
+            guard width > 0, height > 0 else {
+                _badArgumentError(result)
+                return
+            }
+
+            DispatchQueue.main.async {
+                guard let window = self.captureWindow() else {
+                    result(nil)
+                    return
+                }
+
+                // If a native VC is presented over Flutter (paywall, system sheet,
+                // etc.) Flutter has no widget rects for it, so capturing would
+                // include unmasked native content. Fall back to Flutter-only.
+                if window.rootViewController?.presentedViewController != nil {
+                    result(nil)
+                    return
+                }
+
+                let cropRect = CGRect(x: x, y: y, width: width, height: height)
+                    .intersection(window.bounds)
+                guard !cropRect.isNull, !cropRect.isEmpty else {
+                    result(nil)
+                    return
+                }
+
+                // Only reveal a web view that the capture rect fully covers, and
+                // snapshot only the crop region. Requiring containment (not mere
+                // intersection) stops a neighboring MASKED web view that overlaps
+                // this captured view's rect from being snapshotted and leaked.
+                if let webView = self.findWKWebView(in: window, containedBy: cropRect) {
+                    let config = WKSnapshotConfiguration()
+                    config.rect = webView.convert(cropRect, from: nil).intersection(webView.bounds)
+                    guard !config.rect.isNull, !config.rect.isEmpty else {
+                        result(nil)
+                        return
+                    }
+                    webView.takeSnapshot(with: config) { snapshotImage, error in
+                        guard error == nil, let snapshotImage = snapshotImage else {
+                            result(nil)
+                            return
+                        }
+                        result(snapshotImage.pngData().map(FlutterStandardTypedData.init(bytes:)) ?? nil)
+                    }
+                    return
+                }
+
+                // No WKWebView found for the captured rect. Returning nil here
+                // keeps this safe: drawHierarchy over the full window would
+                // include any masked CALayer-backed platform view overlapping
+                // the crop region and leak it into replay.
+                result(nil)
+            }
+        #else
+            result(nil)
+        #endif
+    }
+
+    #if os(iOS)
+        private func captureWindow() -> UIWindow? {
+            return UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap(\.windows)
+                .first(where: \.isKeyWindow) ?? UIApplication.shared.windows.first
+        }
+
+        private func findWKWebView(in view: UIView, containedBy rect: CGRect) -> WKWebView? {
+            if let webView = view as? WKWebView {
+                let frameInWindow = webView.convert(webView.bounds, to: nil)
+                // 1pt slack absorbs rounding between Flutter's rect and the native frame.
+                if rect.insetBy(dx: -1, dy: -1).contains(frameInWindow) { return webView }
+            }
+            for sub in view.subviews {
+                if let found = findWKWebView(in: sub, containedBy: rect) { return found }
+            }
+            return nil
+        }
+    #endif
+
     private func sendMetaEvent(_ call: FlutterMethodCall,
                                result: @escaping FlutterResult)
     {

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -594,7 +594,7 @@ extension PosthogFlutterPlugin {
                 bitsPerComponent: 8,
                 bytesPerRow: bytesPerRow,
                 space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
             ) else { return nil }
             context.draw(cgImage, in: CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
             return Data(buffer)

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -583,8 +583,10 @@ extension PosthogFlutterPlugin {
 
         private func imageToRawRgba(_ image: UIImage) -> Data? {
             guard let cgImage = image.cgImage else { return nil }
-            let width = cgImage.width
-            let height = cgImage.height
+            // image.size is in points; cgImage.width/height are physical pixels (2×/3× on Retina).
+            // Dart decodes at logical-pixel dimensions, so the buffer must be point-sized.
+            let width = Int(image.size.width)
+            let height = Int(image.size.height)
             let bytesPerRow = width * 4
             var buffer = [UInt8](repeating: 0, count: height * bytesPerRow)
             guard let context = CGContext(

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -550,7 +550,7 @@ extension PosthogFlutterPlugin {
                             onResult(nil)
                             return
                         }
-                        onResult(snapshotImage.pngData().map(FlutterStandardTypedData.init(bytes:)) ?? nil)
+                        onResult(self.imageToRawRgba(snapshotImage).map(FlutterStandardTypedData.init(bytes:)))
                     }
                     return
                 }
@@ -579,6 +579,25 @@ extension PosthogFlutterPlugin {
             captureOneNative(x: x, y: y, width: width, height: height) { bytes in
                 self.captureNextNative(views: views, index: index + 1, acc: acc + [bytes], completion: completion)
             }
+        }
+
+        private func imageToRawRgba(_ image: UIImage) -> Data? {
+            guard let cgImage = image.cgImage else { return nil }
+            let width = cgImage.width
+            let height = cgImage.height
+            let bytesPerRow = width * 4
+            var buffer = [UInt8](repeating: 0, count: height * bytesPerRow)
+            guard let context = CGContext(
+                data: &buffer,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else { return nil }
+            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+            return Data(buffer)
         }
 
         private func captureWindow() -> UIWindow? {

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -496,7 +496,8 @@ extension PosthogFlutterPlugin {
     {
         #if os(iOS)
             guard let args = call.arguments as? [String: Any],
-                  let views = args["views"] as? [[String: Int]] else {
+                  let views = args["views"] as? [[String: Int]]
+            else {
                 result([])
                 return
             }
@@ -583,7 +584,7 @@ extension PosthogFlutterPlugin {
         private func captureWindow() -> UIWindow? {
             return UIApplication.shared.connectedScenes
                 .compactMap { $0 as? UIWindowScene }
-                .flatMap { $0.windows }
+                .flatMap(\.windows)
                 .first(where: \.isKeyWindow) ?? UIApplication.shared.windows.first
         }
 

--- a/posthog_flutter/lib/posthog_flutter.dart
+++ b/posthog_flutter/lib/posthog_flutter.dart
@@ -11,3 +11,4 @@ export 'src/posthog_event.dart';
 export 'src/posthog_observer.dart';
 export 'src/posthog_widget.dart';
 export 'src/replay/mask/posthog_mask_widget.dart';
+export 'src/replay/mask/posthog_platform_view.dart';

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -478,6 +478,15 @@ class PostHogSessionReplayConfig {
   /// If null, sampling is controlled by remote config (when available).
   double? sampleRate;
 
+  /// Mask all platform views (WebView, Maps, etc.) in session replay.
+  ///
+  /// Default: true.
+  ///
+  /// When true, every platform view is covered with a black rectangle in
+  /// session replay screenshots. Set to false to opt out globally, or wrap
+  /// individual views with [PostHogPlatformView] for per-view control.
+  var maskAllPlatformViews = true;
+
   /// Converts this session replay configuration to a platform-channel map.
   ///
   /// Returns values consumed by the Android and Apple session replay
@@ -487,6 +496,7 @@ class PostHogSessionReplayConfig {
       'maskAllImages': maskAllImages,
       'maskAllTexts': maskAllTexts,
       'throttleDelayMs': throttleDelay.inMilliseconds,
+      'maskAllPlatformViews': maskAllPlatformViews,
       if (sampleRate != null) 'sampleRate': sampleRate,
     };
   }

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -108,6 +108,11 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
     try {
       final imageInfo = await _screenshotCapturer?.captureScreenshot();
+      // Refresh this before the null check: a dropped frame (null) on a static
+      // captured-view screen must still keep forced frames scheduled, otherwise
+      // the screen would never produce another snapshot.
+      _changeDetector?.hasCapturedPlatformViews =
+          _screenshotCapturer?.hasCapturedPlatformViews ?? false;
       if (imageInfo == null || _disposed) {
         return;
       }

--- a/posthog_flutter/lib/src/replay/change_detector.dart
+++ b/posthog_flutter/lib/src/replay/change_detector.dart
@@ -26,6 +26,8 @@ class ChangeDetector {
   bool _isRunning = false;
   Timer? _timer;
 
+  bool hasCapturedPlatformViews = false;
+
   /// Creates a [ChangeDetector] with the given [onChange] callback.
   ///
   /// [interval] controls how often to check for changes.
@@ -62,6 +64,9 @@ class ChangeDetector {
       return;
     }
 
+    if (hasCapturedPlatformViews) {
+      WidgetsBinding.instance.scheduleFrame();
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_isRunning) {
         onChange();

--- a/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
@@ -16,6 +16,9 @@ enum PostHogPlatformViewPrivacy {
   /// platform view types (Google Maps, ARKit, camera previews, etc.) are masked
   /// regardless of this policy, because the iOS compositor cannot safely
   /// snapshot arbitrary CALayer-backed views without leaking unmasked content.
+  ///
+  /// **macOS note:** capture is not supported on macOS; all platform views are
+  /// masked regardless of this policy.
   capture,
 }
 

--- a/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
@@ -10,6 +10,12 @@ enum PostHogPlatformViewPrivacy {
   /// On Android texture mode the content is already in the Flutter render base,
   /// so no extra capture work is done. On iOS and hybrid composition the
   /// compositor fills the transparent hole via a native capture + srcOver.
+  ///
+  /// **iOS note:** only [WKWebView]-backed platform views (e.g. `webview_flutter`
+  /// in the default web-view mode) are actually captured on iOS. All other
+  /// platform view types (Google Maps, ARKit, camera previews, etc.) are masked
+  /// regardless of this policy, because the iOS compositor cannot safely
+  /// snapshot arbitrary CALayer-backed views without leaking unmasked content.
   capture,
 }
 

--- a/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/widgets.dart';
+
+/// Controls how a platform view is handled in session replay.
+enum PostHogPlatformViewPrivacy {
+  /// Mask the view with a black rectangle (default).
+  mask,
+
+  /// Reveal the view content in session replay.
+  ///
+  /// On Android texture mode the content is already in the Flutter render base,
+  /// so no extra capture work is done. On iOS and hybrid composition the
+  /// compositor fills the transparent hole via a native capture + srcOver.
+  capture,
+}
+
+/// Session replay policy marker for an embedded platform view.
+///
+/// Wrap a platform view (e.g. [WebViewWidget], [GoogleMap]) to override the
+/// global [PostHogSessionReplayConfig.maskAllPlatformViews] setting for that
+/// specific view.
+///
+/// The privacy policy applies to **every** platform view in the wrapped
+/// subtree, not just the nearest one. Wrapping a container that embeds several
+/// platform views in `privacy: capture` reveals all of them. A nested
+/// [PostHogPlatformView] overrides the inherited policy for its own subtree.
+///
+/// ```dart
+/// PostHogPlatformView(
+///   privacy: PostHogPlatformViewPrivacy.capture,
+///   child: WebViewWidget(controller: _controller),
+/// )
+/// ```
+///
+/// This widget has no runtime state — it is a pure marker. The compositor reads
+/// [privacy] from the element tree during each capture frame.
+class PostHogPlatformView extends StatelessWidget {
+  final Widget child;
+  final PostHogPlatformViewPrivacy privacy;
+
+  const PostHogPlatformView({
+    super.key,
+    required this.child,
+    this.privacy = PostHogPlatformViewPrivacy.mask,
+  });
+
+  @override
+  Widget build(BuildContext context) => child;
+}

--- a/posthog_flutter/lib/src/replay/native_communicator.dart
+++ b/posthog_flutter/lib/src/replay/native_communicator.dart
@@ -52,30 +52,24 @@ class NativeCommunicator {
     }
   }
 
-  Future<Uint8List?> captureNativeScreenshot({
-    required int x,
-    required int y,
-    required int width,
-    required int height,
-  }) async {
-    if (kIsWeb) {
-      return null;
+  Future<List<Uint8List?>> captureNativeScreenshots(
+      List<Map<String, int>> views) async {
+    if (kIsWeb || views.isEmpty) {
+      return List.filled(views.length, null);
     }
     try {
-      final bytes = await _channel.invokeMethod<Uint8List>(
-        'captureNativeScreenshot',
-        {'x': x, 'y': y, 'width': width, 'height': height},
+      final raw = await _channel.invokeListMethod<Object?>(
+        'captureNativeScreenshots',
+        {'views': views},
       ).timeout(
         const Duration(seconds: 5),
         onTimeout: () => null,
       );
-      if (bytes == null || bytes.isEmpty) {
-        return null;
-      }
-      return bytes;
+      if (raw == null) return List.filled(views.length, null);
+      return raw.map((e) => e as Uint8List?).toList();
     } catch (e) {
-      printIfDebug('Error capturing native screenshot: $e');
-      return null;
+      printIfDebug('Error capturing native screenshots: $e');
+      return List.filled(views.length, null);
     }
   }
 }

--- a/posthog_flutter/lib/src/replay/native_communicator.dart
+++ b/posthog_flutter/lib/src/replay/native_communicator.dart
@@ -51,4 +51,31 @@ class NativeCommunicator {
       return false;
     }
   }
+
+  Future<Uint8List?> captureNativeScreenshot({
+    required int x,
+    required int y,
+    required int width,
+    required int height,
+  }) async {
+    if (kIsWeb) {
+      return null;
+    }
+    try {
+      final bytes = await _channel.invokeMethod<Uint8List>(
+        'captureNativeScreenshot',
+        {'x': x, 'y': y, 'width': width, 'height': height},
+      ).timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => null,
+      );
+      if (bytes == null || bytes.isEmpty) {
+        return null;
+      }
+      return bytes;
+    } catch (e) {
+      printIfDebug('Error capturing native screenshot: $e');
+      return null;
+    }
+  }
 }

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -216,14 +216,16 @@ class ScreenshotCapturer {
   }
 
   Future<ui.Image?> _decodeImage(Uint8List bytes) async {
+    ui.Codec? codec;
     try {
-      final codec = await ui.instantiateImageCodec(bytes);
+      codec = await ui.instantiateImageCodec(bytes);
       final frame = await codec.getNextFrame();
-      codec.dispose();
       return frame.image;
     } catch (e) {
       printIfDebug('Error decoding image bytes: $e');
       return null;
+    } finally {
+      codec?.dispose();
     }
   }
 

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart' show Element, WidgetsBinding;
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:posthog_flutter/src/replay/element_parsers/element_data.dart';
 import 'package:posthog_flutter/src/replay/image_extension.dart';
@@ -45,6 +46,12 @@ class ViewTreeSnapshotStatus {
   ViewTreeSnapshotStatus(this.sentMetaEvent);
 }
 
+class _PlatformViewRects {
+  final List<ElementData> masked;
+  final List<ElementData> captured;
+  const _PlatformViewRects({required this.masked, required this.captured});
+}
+
 class ScreenshotCapturer {
   final PostHogConfig _config;
   final ImageMaskPainter _imageMaskPainter = ImageMaskPainter();
@@ -52,6 +59,8 @@ class ScreenshotCapturer {
   final _snapshotManager = SnapshotManager();
 
   bool _cancelled = false;
+
+  bool hasCapturedPlatformViews = false;
 
   ScreenshotCapturer(this._config);
 
@@ -88,6 +97,141 @@ class ScreenshotCapturer {
     }
   }
 
+  bool _isPlatformViewRenderObject(RenderObject ro) =>
+      ro is PlatformViewRenderBox ||
+      ro is RenderDarwinPlatformView ||
+      ro is TextureBox;
+
+  _PlatformViewRects _collectPlatformViewRects(
+      PostHogPlatformViewPrivacy defaultPolicy) {
+    final masked = <ElementData>[];
+    final captured = <ElementData>[];
+    final ancestor = PostHogMaskController.instance.containerKey.currentContext
+        ?.findRenderObject();
+    final seen = <int>{};
+
+    final rootElement = WidgetsBinding.instance.rootElement;
+    if (rootElement != null) {
+      _visitElementForPlatformViews(
+          rootElement, ancestor, masked, captured, seen, defaultPolicy);
+    }
+
+    printIfDebug(
+        'Found ${masked.length} masked and ${captured.length} captured platform view rect(s)');
+    return _PlatformViewRects(masked: masked, captured: captured);
+  }
+
+  void _visitElementForPlatformViews(
+    Element element,
+    RenderObject? ancestor,
+    List<ElementData> masked,
+    List<ElementData> captured,
+    Set<int> seen,
+    PostHogPlatformViewPrivacy inheritedPolicy,
+  ) {
+    PostHogPlatformViewPrivacy policy = inheritedPolicy;
+    if (element.widget is PostHogPlatformView) {
+      policy = (element.widget as PostHogPlatformView).privacy;
+    }
+
+    final ro = element.renderObject;
+    if (ro is RenderBox &&
+        ro.hasSize &&
+        ro.size.isValidSize &&
+        _isPlatformViewRenderObject(ro)) {
+      _addIfNew(ro, ancestor, masked, captured, seen, policy);
+    }
+    element.visitChildren(
+      (child) => _visitElementForPlatformViews(
+          child, ancestor, masked, captured, seen, policy),
+    );
+  }
+
+  void _addIfNew(
+    RenderBox ro,
+    RenderObject? ancestor,
+    List<ElementData> masked,
+    List<ElementData> captured,
+    Set<int> seen,
+    PostHogPlatformViewPrivacy policy,
+  ) {
+    if (!seen.add(identityHashCode(ro))) return;
+    try {
+      final transform = ro.getTransformTo(ancestor);
+      final data = ElementData(
+        rect: ro.paintBounds,
+        type: 'platformView',
+        transform: transform,
+      );
+      if (policy == PostHogPlatformViewPrivacy.capture) {
+        captured.add(data);
+      } else {
+        masked.add(data);
+      }
+    } catch (e) {
+      printIfDebug('Error collecting platform view rect: $e');
+    }
+  }
+
+  Future<void> _compositeRevealedView(
+    Canvas canvas,
+    ElementData viewRect,
+    Offset globalPosition,
+    double pixelRatio,
+  ) async {
+    // Android texture mode: content already in Flutter base image — skip.
+    // iOS UiKitView: capture native content and composite with srcOver.
+    // Returns null on Android texture mode or failure → fail-closed mask.
+    final transform = viewRect.transform;
+    if (transform == null) return;
+    final transformedRect = MatrixUtils.transformRect(transform, viewRect.rect);
+    final nativeX = (globalPosition.dx + transformedRect.left).round();
+    final nativeY = (globalPosition.dy + transformedRect.top).round();
+    final nativeW = transformedRect.width.round();
+    final nativeH = transformedRect.height.round();
+    if (nativeW <= 0 || nativeH <= 0) return;
+
+    final bytes = await _nativeCommunicator.captureNativeScreenshot(
+      x: nativeX,
+      y: nativeY,
+      width: nativeW,
+      height: nativeH,
+    );
+    if (bytes == null) {
+      // Android texture mode (null return) or failure → fail-closed with mask.
+      _imageMaskPainter.drawMaskedImage(canvas, [viewRect], pixelRatio);
+      return;
+    }
+    final nativeImage = await _decodeImage(bytes);
+    if (nativeImage == null) {
+      _imageMaskPainter.drawMaskedImage(canvas, [viewRect], pixelRatio);
+      return;
+    }
+    final destRect = transformedRect;
+    canvas.drawImageRect(
+      nativeImage,
+      Rect.fromLTWH(
+          0, 0, nativeImage.width.toDouble(), nativeImage.height.toDouble()),
+      destRect,
+      Paint()..blendMode = ui.BlendMode.srcOver,
+    );
+    nativeImage.dispose();
+  }
+
+  Future<ui.Image?> _decodeImage(Uint8List bytes) async {
+    ui.Codec? codec;
+    try {
+      codec = await ui.instantiateImageCodec(bytes);
+      final frame = await codec.getNextFrame();
+      return frame.image;
+    } catch (e) {
+      printIfDebug('Error decoding image bytes: $e');
+      return null;
+    } finally {
+      codec?.dispose();
+    }
+  }
+
   /// Computes a hash of the full raw RGBA byte array for change detection.
   /// This avoids retaining the full image bytes while still hashing every byte.
   int _computeImageHash(Uint8List bytes) {
@@ -98,9 +242,23 @@ class ScreenshotCapturer {
     hash ^= length;
     hash = (hash * 0x01000193) & 0x7fffffff;
 
-    for (var i = 0; i < length; i++) {
-      hash ^= bytes[i];
-      hash = (hash * 0x01000193) & 0x7fffffff;
+    if (bytes.offsetInBytes % 4 == 0) {
+      final wordCount = length ~/ 4;
+      final words =
+          Uint32List.view(bytes.buffer, bytes.offsetInBytes, wordCount);
+      for (var i = 0; i < wordCount; i++) {
+        hash ^= words[i];
+        hash = (hash * 0x01000193) & 0x7fffffff;
+      }
+      for (var i = wordCount * 4; i < length; i++) {
+        hash ^= bytes[i];
+        hash = (hash * 0x01000193) & 0x7fffffff;
+      }
+    } else {
+      for (var i = 0; i < length; i++) {
+        hash ^= bytes[i];
+        hash = (hash * 0x01000193) & 0x7fffffff;
+      }
     }
 
     return hash;
@@ -140,8 +298,6 @@ class ScreenshotCapturer {
         srcHeight: srcHeight,
       );
 
-      final syncImage = renderObject.toImage(pixelRatio: pixelRatio);
-
       final replayConfig = _config.sessionReplayConfig;
 
       final postHogWidgetWrapperElements =
@@ -154,9 +310,6 @@ class ScreenshotCapturer {
             PostHogMaskController.instance.getCurrentWidgetsElements();
       }
 
-      /// we firstly get current image (syncImage) and masks
-      /// (postHogWidgetWrapperElements, elementsDataWidgets) synchronously and
-      /// then executed the main process asynchronous
       ui.Image? image;
       ui.PictureRecorder? recorder;
       ui.Picture? picture;
@@ -169,10 +322,16 @@ class ScreenshotCapturer {
           completer.complete(null);
           return;
         }
+        if (!isSessionReplayActive) {
+          _snapshotManager.clear();
+          completer.complete(null);
+          return;
+        }
 
         // wait the UI to settle
         await SchedulerBinding.instance.endOfFrame;
-        image = await syncImage;
+        image = await renderObject.toImage(pixelRatio: pixelRatio);
+
         final currentImage = image;
         if (_cancelled) {
           currentImage?.dispose();
@@ -201,7 +360,6 @@ class ScreenshotCapturer {
         }
         final canvas = Canvas(currentRecorder);
 
-        // using rawRgba for the diff check because it is faster than png encoding
         Uint8List? imageBytes = await _getImageBytes(
           currentImage,
           format: ui.ImageByteFormat.rawRgba,
@@ -227,12 +385,19 @@ class ScreenshotCapturer {
           return;
         }
 
-        final currentHash = _computeImageHash(imageBytes);
+        final preMaskHash = _computeImageHash(imageBytes);
         imageBytes = null;
 
-        if (currentHash == statusView.imageBytesHash) {
+        final defaultPolicy = replayConfig.maskAllPlatformViews
+            ? PostHogPlatformViewPrivacy.mask
+            : PostHogPlatformViewPrivacy.capture;
+        final pvRects = _collectPlatformViewRects(defaultPolicy);
+        final hasCapturedViews = pvRects.captured.isNotEmpty;
+        hasCapturedPlatformViews = hasCapturedViews;
+
+        if (!hasCapturedViews && preMaskHash == statusView.imageBytesHash) {
           printIfDebug(
-            'Debug: Snapshot is the same as the last one, nothing changed, do nothing.',
+            'Snapshot is the same as the last one, nothing changed, do nothing.',
           );
           currentRecorder.endRecording().dispose();
           recorder = null;
@@ -241,8 +406,6 @@ class ScreenshotCapturer {
           completer.complete(null);
           return;
         }
-
-        statusView.imageBytesHash = currentHash;
 
         try {
           canvas.drawImage(currentImage, Offset.zero, Paint());
@@ -277,6 +440,18 @@ class ScreenshotCapturer {
           }
         }
 
+        if (pvRects.masked.isNotEmpty) {
+          _imageMaskPainter.drawMaskedImage(
+            canvas,
+            pvRects.masked,
+            pixelRatio,
+          );
+        }
+        for (final capturedRect in pvRects.captured) {
+          await _compositeRevealedView(
+              canvas, capturedRect, globalPosition, pixelRatio);
+        }
+
         picture = currentRecorder.endRecording();
         recorder = null;
 
@@ -308,12 +483,13 @@ class ScreenshotCapturer {
           }
 
           try {
+            statusView.imageBytesHash = preMaskHash;
+
             final pngBytes = await _getImageBytes(currentFinalImage);
             if (_cancelled || pngBytes == null || pngBytes.isEmpty) {
               completer.complete(null);
               return;
             }
-
             final imageInfo = ImageInfo(
               viewId,
               globalPosition.dx.toInt(),

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -191,6 +191,8 @@ class ScreenshotCapturer {
     Canvas canvas,
     ElementData viewRect,
     Uint8List? bytes,
+    int nativeW,
+    int nativeH,
     double pixelRatio,
   ) async {
     final transform = viewRect.transform;
@@ -200,7 +202,7 @@ class ScreenshotCapturer {
       _imageMaskPainter.drawMaskedImage(canvas, [viewRect], pixelRatio);
       return;
     }
-    final nativeImage = await _decodeImage(bytes);
+    final nativeImage = await _decodeRawPixels(bytes, nativeW, nativeH);
     if (nativeImage == null) {
       _imageMaskPainter.drawMaskedImage(canvas, [viewRect], pixelRatio);
       return;
@@ -215,18 +217,22 @@ class ScreenshotCapturer {
     nativeImage.dispose();
   }
 
-  Future<ui.Image?> _decodeImage(Uint8List bytes) async {
-    ui.Codec? codec;
+  Future<ui.Image?> _decodeRawPixels(Uint8List bytes, int width, int height) {
+    if (width <= 0 || height <= 0 || bytes.isEmpty) return Future.value(null);
+    final completer = Completer<ui.Image?>();
     try {
-      codec = await ui.instantiateImageCodec(bytes);
-      final frame = await codec.getNextFrame();
-      return frame.image;
+      ui.decodeImageFromPixels(
+        bytes,
+        width,
+        height,
+        ui.PixelFormat.rgba8888,
+        (image) => completer.complete(image),
+      );
     } catch (e) {
-      printIfDebug('Error decoding image bytes: $e');
-      return null;
-    } finally {
-      codec?.dispose();
+      printIfDebug('Error decoding raw pixels: $e');
+      completer.complete(null);
     }
+    return completer.future;
   }
 
   /// Computes a hash of the full raw RGBA byte array for change detection.
@@ -451,8 +457,10 @@ class ScreenshotCapturer {
           final bytesList =
               await _nativeCommunicator.captureNativeScreenshots(specs);
           for (var i = 0; i < pvRects.captured.length; i++) {
+            final spec = specs[i];
             await _compositeRevealedView(
-                canvas, pvRects.captured[i], bytesList[i], pixelRatio);
+                canvas, pvRects.captured[i], bytesList[i],
+                spec['width']!, spec['height']!, pixelRatio);
           }
         }
 

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -458,9 +458,8 @@ class ScreenshotCapturer {
               await _nativeCommunicator.captureNativeScreenshots(specs);
           for (var i = 0; i < pvRects.captured.length; i++) {
             final spec = specs[i];
-            await _compositeRevealedView(
-                canvas, pvRects.captured[i], bytesList[i],
-                spec['width']!, spec['height']!, pixelRatio);
+            await _compositeRevealedView(canvas, pvRects.captured[i],
+                bytesList[i], spec['width']!, spec['height']!, pixelRatio);
           }
         }
 

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart' show Element, WidgetsBinding;
@@ -131,10 +132,7 @@ class ScreenshotCapturer {
     Set<int> seen,
     PostHogPlatformViewPrivacy inheritedPolicy,
   ) {
-    PostHogPlatformViewPrivacy policy = inheritedPolicy;
-    if (element.widget is PostHogPlatformView) {
-      policy = (element.widget as PostHogPlatformView).privacy;
-    }
+    final policy = resolvePrivacyPolicyForElement(element, inheritedPolicy);
 
     final ro = element.renderObject;
     if (ro is RenderBox &&
@@ -458,8 +456,9 @@ class ScreenshotCapturer {
               await _nativeCommunicator.captureNativeScreenshots(specs);
           for (var i = 0; i < pvRects.captured.length; i++) {
             final spec = specs[i];
-            await _compositeRevealedView(canvas, pvRects.captured[i],
-                bytesList[i], spec['width']!, spec['height']!, pixelRatio);
+            final bytes = i < bytesList.length ? bytesList[i] : null;
+            await _compositeRevealedView(canvas, pvRects.captured[i], bytes,
+                spec['width']!, spec['height']!, pixelRatio);
           }
         }
 
@@ -561,4 +560,15 @@ class ScreenshotCapturer {
       return Future.value(null);
     }
   }
+}
+
+@visibleForTesting
+PostHogPlatformViewPrivacy resolvePrivacyPolicyForElement(
+  Element element,
+  PostHogPlatformViewPrivacy inherited,
+) {
+  if (element.widget is PostHogPlatformView) {
+    return (element.widget as PostHogPlatformView).privacy;
+  }
+  return inherited;
 }

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -43,6 +43,8 @@ class ViewTreeSnapshotStatus {
   /// holding ~8MB+ of raw pixel data in memory permanently.
   int? imageBytesHash;
 
+  int? compositedBytesHash;
+
   ViewTreeSnapshotStatus(this.sentMetaEvent);
 }
 
@@ -173,32 +175,28 @@ class ScreenshotCapturer {
     }
   }
 
+  Map<String, int> _viewSpec(ElementData viewRect, Offset globalPosition) {
+    final transform = viewRect.transform;
+    if (transform == null) return {'x': 0, 'y': 0, 'width': 0, 'height': 0};
+    final rect = MatrixUtils.transformRect(transform, viewRect.rect);
+    return {
+      'x': (globalPosition.dx + rect.left).round(),
+      'y': (globalPosition.dy + rect.top).round(),
+      'width': rect.width.round(),
+      'height': rect.height.round(),
+    };
+  }
+
   Future<void> _compositeRevealedView(
     Canvas canvas,
     ElementData viewRect,
-    Offset globalPosition,
+    Uint8List? bytes,
     double pixelRatio,
   ) async {
-    // Android texture mode: content already in Flutter base image — skip.
-    // iOS UiKitView: capture native content and composite with srcOver.
-    // Returns null on Android texture mode or failure → fail-closed mask.
     final transform = viewRect.transform;
     if (transform == null) return;
     final transformedRect = MatrixUtils.transformRect(transform, viewRect.rect);
-    final nativeX = (globalPosition.dx + transformedRect.left).round();
-    final nativeY = (globalPosition.dy + transformedRect.top).round();
-    final nativeW = transformedRect.width.round();
-    final nativeH = transformedRect.height.round();
-    if (nativeW <= 0 || nativeH <= 0) return;
-
-    final bytes = await _nativeCommunicator.captureNativeScreenshot(
-      x: nativeX,
-      y: nativeY,
-      width: nativeW,
-      height: nativeH,
-    );
     if (bytes == null) {
-      // Android texture mode (null return) or failure → fail-closed with mask.
       _imageMaskPainter.drawMaskedImage(canvas, [viewRect], pixelRatio);
       return;
     }
@@ -207,28 +205,25 @@ class ScreenshotCapturer {
       _imageMaskPainter.drawMaskedImage(canvas, [viewRect], pixelRatio);
       return;
     }
-    final destRect = transformedRect;
     canvas.drawImageRect(
       nativeImage,
       Rect.fromLTWH(
           0, 0, nativeImage.width.toDouble(), nativeImage.height.toDouble()),
-      destRect,
+      transformedRect,
       Paint()..blendMode = ui.BlendMode.srcOver,
     );
     nativeImage.dispose();
   }
 
   Future<ui.Image?> _decodeImage(Uint8List bytes) async {
-    ui.Codec? codec;
     try {
-      codec = await ui.instantiateImageCodec(bytes);
+      final codec = await ui.instantiateImageCodec(bytes);
       final frame = await codec.getNextFrame();
+      codec.dispose();
       return frame.image;
     } catch (e) {
       printIfDebug('Error decoding image bytes: $e');
       return null;
-    } finally {
-      codec?.dispose();
     }
   }
 
@@ -447,9 +442,16 @@ class ScreenshotCapturer {
             pixelRatio,
           );
         }
-        for (final capturedRect in pvRects.captured) {
-          await _compositeRevealedView(
-              canvas, capturedRect, globalPosition, pixelRatio);
+        if (pvRects.captured.isNotEmpty) {
+          final specs = pvRects.captured
+              .map((r) => _viewSpec(r, globalPosition))
+              .toList();
+          final bytesList =
+              await _nativeCommunicator.captureNativeScreenshots(specs);
+          for (var i = 0; i < pvRects.captured.length; i++) {
+            await _compositeRevealedView(
+                canvas, pvRects.captured[i], bytesList[i], pixelRatio);
+          }
         }
 
         picture = currentRecorder.endRecording();
@@ -490,6 +492,19 @@ class ScreenshotCapturer {
               completer.complete(null);
               return;
             }
+
+            if (hasCapturedViews) {
+              final compositedHash = _computeImageHash(pngBytes);
+              if (compositedHash == statusView.compositedBytesHash) {
+                printIfDebug(
+                  'Composited snapshot is the same as the last one, nothing changed, do nothing.',
+                );
+                completer.complete(null);
+                return;
+              }
+              statusView.compositedBytesHash = compositedHash;
+            }
+
             final imageInfo = ImageInfo(
               viewId,
               globalPosition.dx.toInt(),

--- a/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
+++ b/posthog_flutter/lib/src/replay/screenshot/screenshot_capturer.dart
@@ -119,8 +119,10 @@ class ScreenshotCapturer {
           rootElement, ancestor, masked, captured, seen, defaultPolicy);
     }
 
-    printIfDebug(
-        'Found ${masked.length} masked and ${captured.length} captured platform view rect(s)');
+    if (masked.isNotEmpty || captured.isNotEmpty) {
+      printIfDebug(
+          'Found ${masked.length} masked and ${captured.length} captured platform view rect(s)');
+    }
     return _PlatformViewRects(masked: masked, captured: captured);
   }
 
@@ -156,6 +158,11 @@ class ScreenshotCapturer {
     PostHogPlatformViewPrivacy policy,
   ) {
     if (!seen.add(identityHashCode(ro))) return;
+    // TextureBox content is already composited into the Flutter image, so no
+    // native screenshot is needed when revealing. Only mask it when requested.
+    if (ro is TextureBox && policy == PostHogPlatformViewPrivacy.capture) {
+      return;
+    }
     try {
       final transform = ro.getTransformTo(ancestor);
       final data = ElementData(
@@ -454,6 +461,12 @@ class ScreenshotCapturer {
               .toList();
           final bytesList =
               await _nativeCommunicator.captureNativeScreenshots(specs);
+          if (_cancelled) {
+            currentRecorder.endRecording().dispose();
+            recorder = null;
+            completer.complete(null);
+            return;
+          }
           for (var i = 0; i < pvRects.captured.length; i++) {
             final spec = specs[i];
             final bytes = i < bytesList.length ? bytesList[i] : null;

--- a/posthog_flutter/test/native_communicator_test.dart
+++ b/posthog_flutter/test/native_communicator_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:posthog_flutter/src/replay/native_communicator.dart';
@@ -9,52 +11,62 @@ void main() {
   final messenger =
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
 
-  group('NativeCommunicator.captureNativeScreenshot', () {
+  group('NativeCommunicator.captureNativeScreenshots', () {
     tearDown(() {
       messenger.setMockMethodCallHandler(channel, null);
     });
 
-    test('returns the bytes when native returns a non-empty payload', () async {
-      final payload = Uint8List.fromList([1, 2, 3, 4]);
+    test('returns list of bytes for each view', () async {
+      final a = Uint8List.fromList([1, 2, 3, 4]);
+      final b = Uint8List.fromList([5, 6, 7, 8]);
       messenger.setMockMethodCallHandler(channel, (call) async {
-        expect(call.method, 'captureNativeScreenshot');
-        return payload;
+        expect(call.method, 'captureNativeScreenshots');
+        return [a, b];
       });
 
-      final result = await NativeCommunicator()
-          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+      final result = await NativeCommunicator().captureNativeScreenshots([
+        {'x': 0, 'y': 0, 'width': 10, 'height': 10},
+        {'x': 10, 'y': 0, 'width': 10, 'height': 10},
+      ]);
 
-      expect(result, payload);
+      expect(result, [a, b]);
     });
 
-    test('returns null when native returns null', () async {
-      messenger.setMockMethodCallHandler(channel, (_) async => null);
+    test('returns list with nulls when native returns nulls', () async {
+      messenger.setMockMethodCallHandler(channel, (_) async => [null, null]);
 
-      final result = await NativeCommunicator()
-          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+      final result = await NativeCommunicator().captureNativeScreenshots([
+        {'x': 0, 'y': 0, 'width': 10, 'height': 10},
+        {'x': 10, 'y': 0, 'width': 10, 'height': 10},
+      ]);
 
-      expect(result, isNull);
+      expect(result, [null, null]);
     });
 
-    test('returns null when native returns empty bytes', () async {
-      messenger.setMockMethodCallHandler(channel, (_) async => Uint8List(0));
+    test('returns empty list for empty input without calling native', () async {
+      var called = false;
+      messenger.setMockMethodCallHandler(channel, (_) async {
+        called = true;
+        return [];
+      });
 
-      final result = await NativeCommunicator()
-          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+      final result = await NativeCommunicator().captureNativeScreenshots([]);
 
-      expect(result, isNull);
+      expect(result, isEmpty);
+      expect(called, isFalse);
     });
 
-    test('returns null when the channel throws', () async {
+    test('returns null-filled list when the channel throws', () async {
       messenger.setMockMethodCallHandler(
         channel,
         (_) async => throw PlatformException(code: 'boom'),
       );
 
-      final result = await NativeCommunicator()
-          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+      final result = await NativeCommunicator().captureNativeScreenshots([
+        {'x': 0, 'y': 0, 'width': 10, 'height': 10},
+      ]);
 
-      expect(result, isNull);
+      expect(result, [null]);
     });
   });
 }

--- a/posthog_flutter/test/native_communicator_test.dart
+++ b/posthog_flutter/test/native_communicator_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:posthog_flutter/src/replay/native_communicator.dart';

--- a/posthog_flutter/test/native_communicator_test.dart
+++ b/posthog_flutter/test/native_communicator_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/replay/native_communicator.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('posthog_flutter');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  group('NativeCommunicator.captureNativeScreenshot', () {
+    tearDown(() {
+      messenger.setMockMethodCallHandler(channel, null);
+    });
+
+    test('returns the bytes when native returns a non-empty payload', () async {
+      final payload = Uint8List.fromList([1, 2, 3, 4]);
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'captureNativeScreenshot');
+        return payload;
+      });
+
+      final result = await NativeCommunicator()
+          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+
+      expect(result, payload);
+    });
+
+    test('returns null when native returns null', () async {
+      messenger.setMockMethodCallHandler(channel, (_) async => null);
+
+      final result = await NativeCommunicator()
+          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+
+      expect(result, isNull);
+    });
+
+    test('returns null when native returns empty bytes', () async {
+      messenger.setMockMethodCallHandler(channel, (_) async => Uint8List(0));
+
+      final result = await NativeCommunicator()
+          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+
+      expect(result, isNull);
+    });
+
+    test('returns null when the channel throws', () async {
+      messenger.setMockMethodCallHandler(
+        channel,
+        (_) async => throw PlatformException(code: 'boom'),
+      );
+
+      final result = await NativeCommunicator()
+          .captureNativeScreenshot(x: 0, y: 0, width: 10, height: 10);
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/posthog_flutter/test/platform_view_privacy_test.dart
+++ b/posthog_flutter/test/platform_view_privacy_test.dart
@@ -72,19 +72,16 @@ void main() {
         ),
       );
 
-      // Outer wrapper overrides the global-default capture policy with mask.
       final outerElement = tester.element(find.byKey(const Key('outer')));
       final outerPolicy = resolvePrivacyPolicyForElement(
           outerElement, PostHogPlatformViewPrivacy.capture);
       expect(outerPolicy, PostHogPlatformViewPrivacy.mask);
 
-      // Inner wrapper then overrides the outer mask with capture.
       final innerElement = tester.element(find.byKey(const Key('inner')));
       final innerPolicy =
           resolvePrivacyPolicyForElement(innerElement, outerPolicy);
       expect(innerPolicy, PostHogPlatformViewPrivacy.capture);
 
-      // Leaf has no wrapper; the innermost capture policy is preserved.
       final leafElement = tester.element(find.byKey(const Key('leaf')));
       final leafPolicy =
           resolvePrivacyPolicyForElement(leafElement, innerPolicy);

--- a/posthog_flutter/test/platform_view_privacy_test.dart
+++ b/posthog_flutter/test/platform_view_privacy_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/replay/mask/posthog_platform_view.dart';
+import 'package:posthog_flutter/src/replay/screenshot/screenshot_capturer.dart';
+
+void main() {
+  group('resolvePrivacyPolicyForElement — privacy inheritance', () {
+    testWidgets('unwrapped widget inherits the default mask policy',
+        (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(key: Key('leaf')),
+        ),
+      );
+      final element = tester.element(find.byKey(const Key('leaf')));
+      final policy = resolvePrivacyPolicyForElement(
+          element, PostHogPlatformViewPrivacy.mask);
+      expect(policy, PostHogPlatformViewPrivacy.mask);
+    });
+
+    testWidgets('capture wrapper overrides an inherited mask policy',
+        (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: PostHogPlatformView(
+            key: Key('wrapper'),
+            privacy: PostHogPlatformViewPrivacy.capture,
+            child: SizedBox(),
+          ),
+        ),
+      );
+      final element = tester.element(find.byKey(const Key('wrapper')));
+      final policy = resolvePrivacyPolicyForElement(
+          element, PostHogPlatformViewPrivacy.mask);
+      expect(policy, PostHogPlatformViewPrivacy.capture);
+    });
+
+    testWidgets('mask wrapper overrides an inherited capture policy',
+        (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: PostHogPlatformView(
+            key: Key('wrapper'),
+            privacy: PostHogPlatformViewPrivacy.mask,
+            child: SizedBox(),
+          ),
+        ),
+      );
+      final element = tester.element(find.byKey(const Key('wrapper')));
+      final policy = resolvePrivacyPolicyForElement(
+          element, PostHogPlatformViewPrivacy.capture);
+      expect(policy, PostHogPlatformViewPrivacy.mask);
+    });
+
+    testWidgets('innermost nested wrapper wins over outer wrapper',
+        (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: PostHogPlatformView(
+            key: Key('outer'),
+            privacy: PostHogPlatformViewPrivacy.mask,
+            child: PostHogPlatformView(
+              key: Key('inner'),
+              privacy: PostHogPlatformViewPrivacy.capture,
+              child: SizedBox(key: Key('leaf')),
+            ),
+          ),
+        ),
+      );
+
+      // Outer wrapper overrides the global-default capture policy with mask.
+      final outerElement = tester.element(find.byKey(const Key('outer')));
+      final outerPolicy = resolvePrivacyPolicyForElement(
+          outerElement, PostHogPlatformViewPrivacy.capture);
+      expect(outerPolicy, PostHogPlatformViewPrivacy.mask);
+
+      // Inner wrapper then overrides the outer mask with capture.
+      final innerElement = tester.element(find.byKey(const Key('inner')));
+      final innerPolicy =
+          resolvePrivacyPolicyForElement(innerElement, outerPolicy);
+      expect(innerPolicy, PostHogPlatformViewPrivacy.capture);
+
+      // Leaf has no wrapper; the innermost capture policy is preserved.
+      final leafElement = tester.element(find.byKey(const Key('leaf')));
+      final leafPolicy =
+          resolvePrivacyPolicyForElement(leafElement, innerPolicy);
+      expect(leafPolicy, PostHogPlatformViewPrivacy.capture);
+    });
+  });
+}

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
@@ -137,6 +137,48 @@ void main() {
 
       expect(config.host, equals('https://us.i.posthog.com'));
       expect(config.toMap()['host'], equals('https://us.i.posthog.com'));
+    });
+
+    test('session replay masks all platform views by default', () {
+      final config = PostHogConfig('test_project_token');
+
+      expect(config.sessionReplayConfig.maskAllPlatformViews, isTrue);
+
+      final replayConfig =
+          config.toMap()['sessionReplayConfig'] as Map<String, dynamic>;
+      expect(replayConfig.containsKey('maskAllPlatformViews'), isTrue);
+      expect(replayConfig['maskAllPlatformViews'], isTrue);
+
+      config.sessionReplayConfig.maskAllPlatformViews = false;
+
+      final updatedReplayConfig =
+          config.toMap()['sessionReplayConfig'] as Map<String, dynamic>;
+      expect(updatedReplayConfig['maskAllPlatformViews'], isFalse);
+    });
+  });
+
+  group('PostHogPlatformView', () {
+    testWidgets('defaults privacy to mask', (tester) async {
+      const view = PostHogPlatformView(child: SizedBox());
+      expect(view.privacy, PostHogPlatformViewPrivacy.mask);
+    });
+
+    testWidgets('keeps the requested capture privacy', (tester) async {
+      const view = PostHogPlatformView(
+        privacy: PostHogPlatformViewPrivacy.capture,
+        child: SizedBox(),
+      );
+      expect(view.privacy, PostHogPlatformViewPrivacy.capture);
+    });
+
+    testWidgets('renders its child unchanged', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: PostHogPlatformView(child: Text('child')),
+        ),
+      );
+      expect(find.text('child'), findsOneWidget);
     });
   });
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: transitive
     description:
@@ -182,6 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -208,6 +224,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_maps:
+    dependency: transitive
+    description:
+      name: google_maps
+      sha256: "5d410c32112d7c6eb7858d359275b2aa04778eed3e36c745aeae905fb2fa6468"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.0"
+  google_maps_flutter:
+    dependency: transitive
+    description:
+      name: google_maps_flutter
+      sha256: f4040715c2998144a46cfc0fd91ee83226655af069dfed3d2b84552dc5e4facb
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.17.1"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      sha256: a404c67d460f64b8bdc48aa5e39c81aa13505552d8783ae68f9aeef074913286
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.19.12"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      sha256: f573749a75c4074b7a74ab986703607e9cd859fb2807c332872620f3656400dc
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.18.3"
+  google_maps_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_platform_interface
+      sha256: ddbe34435dfb34e83fca295c6a8dcc53c3b51487e9eec3c737ce4ae605574347
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.0"
+  google_maps_flutter_web:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_web
+      sha256: e23f2869449bb3e2ed7cfdb178d716e1da7edc684363987e4cb2c42f2bd7a9e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.2+3"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   json_annotation:
     dependency: transitive
     description:
@@ -352,6 +424,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  sanitize_html:
+    dependency: transitive
+    description:
+      name: sanitize_html
+      sha256: "12669c4a913688a26555323fb9cec373d8f9fbe091f2d01c40c723b33caa8989"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   simple_sparse_list:
     dependency: transitive
     description:
@@ -397,6 +477,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -485,6 +573,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: e4d3474277c5043f5f3100ed27d94ad693abfd5c602b0221c719a4497e4ba1e4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.14.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: a97db7a44f8e71af2f3971c45550a08cce1fb60059c1b8e534251e6cfb753490
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.26.0"
   xml:
     dependency: transitive
     description:


### PR DESCRIPTION
## :bulb: Motivation and Context

Platform views (WebView, Google Maps, etc.) rendered by Flutter are composited outside the Flutter layer tree. Without explicit handling, session replay either silently skips them (leaving blank gaps) or could inadvertently capture sensitive content. This PR adds first-class support: views are masked by default (black box), with opt-in capture on a per-view or global basis.

Closes #393.
Addresses only part 1 of #151

Note I'll address fully native views in a separate PR, that will require iOS and android SDK work as well.

## :green_heart: How did you test it?

- iOS simulator (iPhone 17, iOS 26.4): ran all 8 example app test flows — masked views appear as black boxes in PostHog replay, captured WebViews show actual content
- Android device (Pixel 4, Android 13): same flows verified
- flutter test in posthog_flutter/ — all tests pass
- Confirmed 5-second timeout fires correctly when native channel does not respond

See videos:

Android: https://us.posthog.com/shared/AYnlFG5M-DGczYUYyn27g1EC55HvDg?t=1
https://us.posthog.com/shared/kWlqsDn5LUynHgynC0Mp1t_wnAfK5w?t=2

iOS: https://us.posthog.com/shared/2G_GNlw70uTOwJQOdVcZFY_uiDasTA?t=5

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (claude-sonnet-4-6). Anna Garcia directed the work throughout.

Key decisions made during the session:

- **iOS: no drawHierarchy fallback** — when no WKWebView is found for the captured rect, we return nil rather than falling back to drawHierarchy over the full window. The fallback would composite any masked CALayer-backed platform view in the crop region and leak it into replay, defeating the privacy guarantee.
- **Android: async bitmap compression** — PixelCopy runs on the main thread; bitmap compression was moved to a single-thread executor to avoid blocking the UI thread during screenshot capture.
- **5-second timeout on captureNativeScreenshot** — if the native side never calls result(), the Dart _isCapturing flag would stay true permanently and silently kill replay. The timeout degrades gracefully to null (frame skipped) rather than freezing.
- **hasCapturedPlatformViews gate** — scheduleFrame() is only forced when at least one platform view was actually captured, avoiding unnecessary redraws on screens with only masked views.
