### PR TITLE
ci: update SDK harness to 0.9.0

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "0.8.0"
+      test-harness-version: "0.9.0"

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.8.0
+    image: ghcr.io/posthog/sdk-test-harness:0.9.0
     command:
       [
         "run",


### PR DESCRIPTION
## :bulb: Motivation and Context

Update this SDK's compliance setup to use posthog-sdk-test-harness 0.9.0. The reusable workflow is pinned to the 0.9.0 release commit SHA (
`68498bcf3ae95ac941476e6ca3d42d6086e1c7fd`) instead of a tag, while the harness Docker image uses the published `0.9.0` image tag.

## :green_heart: How did you test it?

- Confirmed the PR branch has no remaining references to the previous harness workflow SHA or `0.8.0` harness image/version.
- Parsed changed GitHub Actions workflow YAML locally where workflow files changed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Updated SDK compliance harness references only. Kept the change limited to workflow, Docker Compose, and local compliance docs where those references existed.
