### PR TITLE
fix: Retry adapter flags requests on 502 and 504

### DIFF
--- a/.changeset/gentle-flags-retry.md
+++ b/.changeset/gentle-flags-retry.md
@@ -1,5 +1,0 @@
----
-'posthog_flutter': patch
----
-
-Retry SDK compliance adapter `/flags` requests when the flags endpoint returns HTTP 502 or 504.

--- a/.changeset/gentle-flags-retry.md
+++ b/.changeset/gentle-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Retry SDK compliance adapter `/flags` requests when the flags endpoint returns HTTP 502 or 504.

--- a/sdk_compliance_adapter/lib/adapter_server.dart
+++ b/sdk_compliance_adapter/lib/adapter_server.dart
@@ -496,22 +496,28 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
     Object? value = false;
     try {
       final uri = Uri.parse(_host!).resolve('/flags/?v=2');
-      final request = await client.postUrl(uri);
-      request.headers.contentType = ContentType.json;
-      request.write(jsonEncode(payload));
-      final response = await request.close();
-      final body = await utf8.decoder.bind(response).join();
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        state.lastError =
-            'Feature flag request failed with HTTP ${response.statusCode}';
-        throw HttpException(state.lastError!, uri: uri);
-      }
-      final decoded = body.isEmpty ? null : jsonDecode(body);
-      if (decoded is Map) {
-        final flags = decoded['featureFlags'] ?? decoded['flags'];
-        if (flags is Map && flags.containsKey(key)) {
-          value = flags[key];
+      for (var attempt = 0; attempt <= _maxRetries; attempt++) {
+        final request = await client.postUrl(uri);
+        request.headers.contentType = ContentType.json;
+        request.write(jsonEncode(payload));
+        final response = await request.close();
+        final body = await utf8.decoder.bind(response).join();
+        final statusCode = response.statusCode;
+        if (statusCode < 200 || statusCode >= 300) {
+          if (attempt < _maxRetries && _shouldRetryFlags(statusCode)) {
+            continue;
+          }
+          state.lastError = 'Feature flag request failed with HTTP $statusCode';
+          throw HttpException(state.lastError!, uri: uri);
         }
+        final decoded = body.isEmpty ? null : jsonDecode(body);
+        if (decoded is Map) {
+          final flags = decoded['featureFlags'] ?? decoded['flags'];
+          if (flags is Map && flags.containsKey(key)) {
+            value = flags[key];
+          }
+        }
+        break;
       }
     } finally {
       client.close(force: true);
@@ -537,6 +543,9 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
 
     return value;
   }
+
+  bool _shouldRetryFlags(int statusCode) =>
+      statusCode == 502 || statusCode == 504;
 
   int? _retryAfterMs(HttpHeaders headers) {
     final value = headers.value(HttpHeaders.retryAfterHeader);

--- a/sdk_compliance_adapter/lib/adapter_server.dart
+++ b/sdk_compliance_adapter/lib/adapter_server.dart
@@ -501,10 +501,17 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
         request.headers.contentType = ContentType.json;
         request.write(jsonEncode(payload));
         final response = await request.close();
+        final retryAfterMs = _retryAfterMs(response.headers);
         final body = await utf8.decoder.bind(response).join();
         final statusCode = response.statusCode;
+        if (attempt > 0) {
+          state.totalRetries++;
+        }
         if (statusCode < 200 || statusCode >= 300) {
           if (attempt < _maxRetries && _shouldRetryFlags(statusCode)) {
+            await Future<void>.delayed(
+              Duration(milliseconds: retryAfterMs ?? 100),
+            );
             continue;
           }
           state.lastError = 'Feature flag request failed with HTTP $statusCode';

--- a/sdk_compliance_adapter/test/flags_retry_test.dart
+++ b/sdk_compliance_adapter/test/flags_retry_test.dart
@@ -36,9 +36,52 @@ void main() {
         expect(response['success'], isTrue);
         expect(response['value'], 'retry-success');
         expect(flagsServer.flagsRequestCount, 2);
+
+        final state = await _getJson('$adapterBase/state');
+        expect(state['total_retries'], 1);
       },
     );
   }
+
+  test('propagates error after /flags retries are exhausted', () async {
+    final flagsServer = await _FlagsServer.start([
+      HttpStatus.badGateway,
+      HttpStatus.badGateway,
+    ]);
+    addTearDown(flagsServer.close);
+
+    final adapter = ComplianceAdapter();
+    final adapterServer = await adapter.start(port: 0);
+    addTearDown(adapter.close);
+
+    final adapterBase = 'http://127.0.0.1:${adapterServer.port}';
+    await _postJson('$adapterBase/init', {
+      'api_key': 'test-api-key',
+      'host': flagsServer.url,
+      'max_retries': 1,
+      'flush_interval_ms': 60000,
+    });
+
+    await expectLater(
+      _postJson('$adapterBase/get_feature_flag', {
+        'key': 'retry-flag',
+        'distinct_id': 'test-user',
+      }),
+      throwsA(
+        isA<HttpException>().having(
+          (error) => error.message,
+          'message',
+          contains('HTTP 500'),
+        ),
+      ),
+    );
+
+    expect(flagsServer.flagsRequestCount, 2);
+
+    final state = await _getJson('$adapterBase/state');
+    expect(state['total_retries'], 1);
+    expect(state['last_error'], 'Feature flag request failed with HTTP 502');
+  });
 }
 
 Future<Map<String, Object?>> _postJson(
@@ -50,6 +93,21 @@ Future<Map<String, Object?>> _postJson(
     final request = await client.postUrl(Uri.parse(url));
     request.headers.contentType = ContentType.json;
     request.write(jsonEncode(payload));
+    final response = await request.close();
+    final body = await utf8.decoder.bind(response).join();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException('HTTP ${response.statusCode}: $body');
+    }
+    return Map<String, Object?>.from(jsonDecode(body) as Map);
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<Map<String, Object?>> _getJson(String url) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(Uri.parse(url));
     final response = await request.close();
     final body = await utf8.decoder.bind(response).join();
     if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -86,9 +144,8 @@ class _FlagsServer {
           request.uri.path == '/flags/' &&
           request.uri.queryParameters['v'] == '2') {
         flagsRequestCount++;
-        final statusCode = _statuses.isEmpty
-            ? HttpStatus.ok
-            : _statuses.removeAt(0);
+        final statusCode =
+            _statuses.isEmpty ? HttpStatus.ok : _statuses.removeAt(0);
         request.response.statusCode = statusCode;
         request.response.headers.contentType = ContentType.json;
         if (statusCode == HttpStatus.ok) {

--- a/sdk_compliance_adapter/test/flags_retry_test.dart
+++ b/sdk_compliance_adapter/test/flags_retry_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter_sdk_compliance_adapter/adapter_server.dart';
+
+void main() {
+  for (final statusCode in [502, 504]) {
+    test(
+      'retries /flags after HTTP $statusCode and returns flag value',
+      () async {
+        final flagsServer = await _FlagsServer.start([
+          statusCode,
+          HttpStatus.ok,
+        ]);
+        addTearDown(flagsServer.close);
+
+        final adapter = ComplianceAdapter();
+        final adapterServer = await adapter.start(port: 0);
+        addTearDown(adapter.close);
+
+        final adapterBase = 'http://127.0.0.1:${adapterServer.port}';
+        await _postJson('$adapterBase/init', {
+          'api_key': 'test-api-key',
+          'host': flagsServer.url,
+          'max_retries': 1,
+          'flush_interval_ms': 60000,
+        });
+
+        final response = await _postJson('$adapterBase/get_feature_flag', {
+          'key': 'retry-flag',
+          'distinct_id': 'test-user',
+        });
+
+        expect(response['success'], isTrue);
+        expect(response['value'], 'retry-success');
+        expect(flagsServer.flagsRequestCount, 2);
+      },
+    );
+  }
+}
+
+Future<Map<String, Object?>> _postJson(
+  String url,
+  Map<String, Object?> payload,
+) async {
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(Uri.parse(url));
+    request.headers.contentType = ContentType.json;
+    request.write(jsonEncode(payload));
+    final response = await request.close();
+    final body = await utf8.decoder.bind(response).join();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException('HTTP ${response.statusCode}: $body');
+    }
+    return Map<String, Object?>.from(jsonDecode(body) as Map);
+  } finally {
+    client.close(force: true);
+  }
+}
+
+class _FlagsServer {
+  _FlagsServer._(this._server, this._statuses);
+
+  final HttpServer _server;
+  final List<int> _statuses;
+  int flagsRequestCount = 0;
+
+  String get url => 'http://127.0.0.1:${_server.port}';
+
+  static Future<_FlagsServer> start(List<int> statuses) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final flagsServer = _FlagsServer._(server, List<int>.from(statuses));
+    unawaited(flagsServer._serve());
+    return flagsServer;
+  }
+
+  Future<void> close() => _server.close(force: true);
+
+  Future<void> _serve() async {
+    await for (final request in _server) {
+      await utf8.decoder.bind(request).join();
+      if (request.method == 'POST' &&
+          request.uri.path == '/flags/' &&
+          request.uri.queryParameters['v'] == '2') {
+        flagsRequestCount++;
+        final statusCode = _statuses.isEmpty
+            ? HttpStatus.ok
+            : _statuses.removeAt(0);
+        request.response.statusCode = statusCode;
+        request.response.headers.contentType = ContentType.json;
+        if (statusCode == HttpStatus.ok) {
+          request.response.write(
+            jsonEncode({
+              'featureFlags': {'retry-flag': 'retry-success'},
+            }),
+          );
+        } else {
+          request.response.write(jsonEncode({'error': 'temporary failure'}));
+        }
+        await request.response.close();
+        continue;
+      }
+
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- retry SDK compliance adapter `/flags/?v=2` requests on HTTP 502 and 504 using the adapter `max_retries` setting
- add focused adapter tests for 502 -> 200 and 504 -> 200 flag evaluation retries

## Validation
- `flutter test sdk_compliance_adapter/test/flags_retry_test.dart`
- `flutter analyze sdk_compliance_adapter/lib/adapter_server.dart sdk_compliance_adapter/test/flags_retry_test.dart`
