### PR TITLE
feat: capture exception cause chains

### DIFF
--- a/.changeset/error-tracking-signal-improvements.md
+++ b/.changeset/error-tracking-signal-improvements.md
@@ -2,4 +2,4 @@
 "posthog_flutter": minor
 ---
 
-Improve error-tracking cause handling: `captureException` now walks an error's cause chain (`AsyncError`, `ParallelWaitError`, and exceptions exposing a `cause` getter) into multiple `$exception_list` items, outermost-first (wrapper first, root cause last), with a cycle guard and a depth cap of 10.
+Improve error-tracking cause handling: `captureException` now walks an error's cause chain (`AsyncError`, all enumerable `ParallelWaitError` failures, and exceptions exposing a `cause` getter) into multiple `$exception_list` items, outermost-first (wrapper first, root cause last), with a cycle guard and a depth cap of 10.

--- a/.changeset/error-tracking-signal-improvements.md
+++ b/.changeset/error-tracking-signal-improvements.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": minor
+---
+
+Improve error-tracking cause handling: `captureException` now walks an error's cause chain (`AsyncError`, `ParallelWaitError`, and exceptions exposing a `cause` getter) into multiple `$exception_list` items, outermost-first (wrapper first, root cause last), with a cycle guard and a depth cap of 10.

--- a/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
+++ b/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 Sentry
 // Licensed under the MIT License: https://github.com/getsentry/sentry-dart/blob/main/LICENSE
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:posthog_flutter/src/util/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -13,6 +15,10 @@ import 'chunk_ids.dart';
 typedef ChunkIdMapType = Map<String, String>;
 
 class DartExceptionProcessor {
+  /// Maximum number of exception items in `$exception_list` when walking an
+  /// error's cause chain (outermost error plus its causes).
+  static const maxExceptionChainLength = 10;
+
   /// Converts Dart error/exception and stack trace to PostHog exception format
   static Map<String, dynamic> processException({
     required Object error,
@@ -52,7 +58,7 @@ class DartExceptionProcessor {
     // Check if we still have an empty stack trace
     final hasValidStackTrace = effectiveStackTrace != StackTrace.empty;
 
-    // Process single exception for now
+    // Process primary exception
     final frames = hasValidStackTrace
         ? _parseStackTrace(
             effectiveStackTrace,
@@ -98,14 +104,141 @@ class DartExceptionProcessor {
       exceptionData['thread_id'] = threadId;
     }
 
+    // Walk the error's cause chain into additional exception items,
+    // outermost-first (wrapper first, root cause last)
+    final exceptionList = <Map<String, dynamic>>[exceptionData];
+    _appendCauses(
+      exceptionList,
+      currentError,
+      handled: handled,
+      mechanismType: mechanismType,
+      threadId: threadId,
+      inAppIncludes: inAppIncludes,
+      inAppExcludes: inAppExcludes,
+      inAppByDefault: inAppByDefault,
+    );
+
     // Final result, merging system properties with user properties (user properties take precedence)
     final result = <String, dynamic>{
       '\$exception_level': 'error', // Never crashes, so always error
-      '\$exception_list': [exceptionData],
+      '\$exception_list': exceptionList,
       if (properties != null) ...properties,
     };
 
     return result;
+  }
+
+  /// Appends one exception item per cause of [error] to [exceptionList],
+  /// outermost-first, guarding against cycles and capping the chain at
+  /// [maxExceptionChainLength] items.
+  static void _appendCauses(
+    List<Map<String, dynamic>> exceptionList,
+    Object error, {
+    required bool handled,
+    required String mechanismType,
+    required int? threadId,
+    List<String>? inAppIncludes,
+    List<String>? inAppExcludes,
+    bool inAppByDefault = true,
+  }) {
+    final seen = Set<Object>.identity()..add(error);
+    var cause = _getCause(error);
+
+    while (cause != null &&
+        exceptionList.length < maxExceptionChainLength &&
+        seen.add(cause)) {
+      final causeType = _getExceptionType(cause);
+      final causeData = <String, dynamic>{
+        'type': causeType ?? 'Error',
+        'mechanism': {
+          'handled': handled,
+          'synthetic': causeType == null,
+          'type': mechanismType,
+        },
+      };
+
+      final causeMessage = cause.toString();
+      if (causeMessage.isNotEmpty) {
+        causeData['value'] = causeMessage;
+      }
+
+      // Only use the cause's own stack trace; never generate one for causes
+      final causeStackTrace = _extractOwnStackTrace(cause);
+      if (causeStackTrace != null) {
+        final frames = _parseStackTrace(
+          causeStackTrace,
+          inAppIncludes: inAppIncludes,
+          inAppExcludes: inAppExcludes,
+          inAppByDefault: inAppByDefault,
+        );
+        if (frames.isNotEmpty) {
+          causeData['stacktrace'] = {'frames': frames, 'type': 'raw'};
+        }
+      }
+
+      if (threadId != null) {
+        causeData['thread_id'] = threadId;
+      }
+
+      exceptionList.add(causeData);
+      cause = _getCause(cause);
+    }
+  }
+
+  /// Extracts the cause of an error, if the error type exposes one.
+  ///
+  /// Supports [AsyncError] (unwraps to the original error),
+  /// [ParallelWaitError] (takes the first non-null error) and the common
+  /// duck-typed `cause` getter convention used by custom exceptions.
+  static Object? _getCause(Object error) {
+    if (error is AsyncError) {
+      return error.error;
+    }
+
+    if (error is ParallelWaitError) {
+      return _firstParallelError(error.errors);
+    }
+
+    try {
+      // ignore: avoid_dynamic_calls
+      final cause = (error as dynamic).cause;
+      if (cause is Object && !identical(cause, error)) {
+        return cause;
+      }
+    } catch (_) {
+      // Error type doesn't expose a `cause` getter
+    }
+
+    return null;
+  }
+
+  /// Returns the first non-null error from a [ParallelWaitError.errors]
+  /// collection, if it is enumerable (e.g. `List<Future>.wait` produces a
+  /// `List<AsyncError?>`; record-based `wait` produces a record, skipped here)
+  static Object? _firstParallelError(Object? errors) {
+    if (errors is Iterable) {
+      for (final error in errors) {
+        if (error != null) {
+          return error as Object;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Returns the error's own stack trace, if it carries a usable one
+  static StackTrace? _extractOwnStackTrace(Object error) {
+    StackTrace? stackTrace;
+    if (error is AsyncError) {
+      stackTrace = error.stackTrace;
+    } else if (error is Error) {
+      stackTrace = error.stackTrace;
+    }
+
+    if (stackTrace == null || stackTrace == StackTrace.empty) {
+      return null;
+    }
+    return stackTrace;
   }
 
   /// Determines if a stack frame belongs to PostHog SDK (just check package for now)

--- a/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
+++ b/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
@@ -142,11 +142,35 @@ class DartExceptionProcessor {
     bool inAppByDefault = true,
   }) {
     final seen = Set<Object>.identity()..add(error);
-    var cause = _getCause(error);
+    _appendCauseItems(
+      exceptionList,
+      _getCauses(error),
+      seen,
+      handled: handled,
+      mechanismType: mechanismType,
+      threadId: threadId,
+      inAppIncludes: inAppIncludes,
+      inAppExcludes: inAppExcludes,
+      inAppByDefault: inAppByDefault,
+    );
+  }
 
-    while (cause != null &&
-        exceptionList.length < maxExceptionChainLength &&
-        seen.add(cause)) {
+  static void _appendCauseItems(
+    List<Map<String, dynamic>> exceptionList,
+    Iterable<Object> causes,
+    Set<Object> seen, {
+    required bool handled,
+    required String mechanismType,
+    required int? threadId,
+    List<String>? inAppIncludes,
+    List<String>? inAppExcludes,
+    bool inAppByDefault = true,
+  }) {
+    for (final cause in causes) {
+      if (exceptionList.length >= maxExceptionChainLength || !seen.add(cause)) {
+        continue;
+      }
+
       final causeType = _getExceptionType(cause);
       final causeData = <String, dynamic>{
         'type': causeType ?? 'Error',
@@ -181,49 +205,58 @@ class DartExceptionProcessor {
       }
 
       exceptionList.add(causeData);
-      cause = _getCause(cause);
+      _appendCauseItems(
+        exceptionList,
+        _getCauses(cause),
+        seen,
+        handled: handled,
+        mechanismType: mechanismType,
+        threadId: threadId,
+        inAppIncludes: inAppIncludes,
+        inAppExcludes: inAppExcludes,
+        inAppByDefault: inAppByDefault,
+      );
     }
   }
 
-  /// Extracts the cause of an error, if the error type exposes one.
+  /// Extracts the causes of an error, if the error type exposes any.
   ///
   /// Supports [AsyncError] (unwraps to the original error),
-  /// [ParallelWaitError] (takes the first non-null error) and the common
-  /// duck-typed `cause` getter convention used by custom exceptions.
-  static Object? _getCause(Object error) {
+  /// [ParallelWaitError] (walks all non-null errors) and the common duck-typed
+  /// `cause` getter convention used by custom exceptions.
+  static Iterable<Object> _getCauses(Object error) sync* {
     if (error is AsyncError) {
-      return error.error;
+      yield error.error;
+      return;
     }
 
     if (error is ParallelWaitError) {
-      return _firstParallelError(error.errors);
+      yield* _parallelErrors(error.errors);
+      return;
     }
 
     try {
       // ignore: avoid_dynamic_calls
       final cause = (error as dynamic).cause;
       if (cause is Object && !identical(cause, error)) {
-        return cause;
+        yield cause;
       }
     } catch (_) {
       // Error type doesn't expose a `cause` getter
     }
-
-    return null;
   }
 
-  /// Returns the first non-null error from a [ParallelWaitError.errors]
-  /// collection, if it is enumerable (e.g. `List<Future>.wait` produces a
+  /// Returns all non-null errors from a [ParallelWaitError.errors] collection,
+  /// if it is enumerable (e.g. `List<Future>.wait` produces a
   /// `List<AsyncError?>`; record-based `wait` produces a record, skipped here)
-  static Object? _firstParallelError(Object? errors) {
+  static Iterable<Object> _parallelErrors(Object? errors) sync* {
     if (errors is Iterable) {
       for (final error in errors) {
         if (error != null) {
-          return error as Object;
+          yield error as Object;
         }
       }
     }
-    return null;
   }
 
   /// Returns the error's own stack trace, if it carries a usable one

--- a/posthog_flutter/test/dart_exception_processor_test.dart
+++ b/posthog_flutter/test/dart_exception_processor_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_dynamic_calls
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:posthog_flutter/src/error_tracking/dart_exception_processor.dart';
 import 'package:posthog_flutter/src/error_tracking/posthog_exception.dart';
@@ -590,7 +592,169 @@ void main() {
         expect(exceptionData['mechanism']['type'], equals('test_mechanism'));
       }
     });
+
+    group('cause chain', () {
+      test('walks AsyncError into multiple exception items, outermost-first',
+          () {
+        late StateError rootError;
+        try {
+          throw StateError('root cause');
+        } catch (error) {
+          rootError = error as StateError;
+        }
+
+        final asyncError = AsyncError(rootError, rootError.stackTrace!);
+
+        final result = DartExceptionProcessor.processException(
+          error: asyncError,
+        );
+
+        final exceptionList =
+            result['\$exception_list'] as List<Map<String, dynamic>>;
+
+        expect(exceptionList, hasLength(2));
+        // Wrapper first, root cause last
+        expect(exceptionList[0]['type'], equals('AsyncError'));
+        expect(exceptionList[1]['type'], equals('StateError'));
+        expect(exceptionList[1]['value'], equals('Bad state: root cause'));
+
+        // The cause carries its own (thrown) stack trace
+        expect(exceptionList[1]['stacktrace'], isNotNull);
+        expect(
+          (exceptionList[1]['stacktrace']['frames'] as List).isNotEmpty,
+          isTrue,
+        );
+
+        // Causes reuse the outer mechanism
+        expect(exceptionList[1]['mechanism']['handled'], isTrue);
+        expect(exceptionList[1]['mechanism']['type'], equals('generic'));
+        expect(exceptionList[1]['mechanism']['synthetic'], isFalse);
+      });
+
+      test('walks duck-typed cause getters', () {
+        final root = FormatException('root');
+        final middle = _ChainedException('middle', root);
+        final outer = _ChainedException('outer', middle);
+
+        final result = DartExceptionProcessor.processException(
+          error: outer,
+          stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
+        );
+
+        final exceptionList =
+            result['\$exception_list'] as List<Map<String, dynamic>>;
+
+        expect(exceptionList, hasLength(3));
+        expect(exceptionList[0]['type'], equals('_ChainedException'));
+        expect(exceptionList[0]['value'], equals('outer'));
+        expect(exceptionList[1]['type'], equals('_ChainedException'));
+        expect(exceptionList[1]['value'], equals('middle'));
+        expect(exceptionList[2]['type'], equals('FormatException'));
+      });
+
+      test('walks ParallelWaitError to the first failed future', () async {
+        Object? caught;
+        try {
+          await [
+            Future<int>.error(StateError('parallel failure')),
+            Future<int>.value(1),
+          ].wait;
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught, isA<ParallelWaitError>());
+
+        final result = DartExceptionProcessor.processException(error: caught!);
+
+        final exceptionList =
+            result['\$exception_list'] as List<Map<String, dynamic>>;
+
+        expect(exceptionList.length, greaterThanOrEqualTo(3));
+        expect(exceptionList[0]['type'], startsWith('ParallelWaitError'));
+        expect(exceptionList[1]['type'], equals('AsyncError'));
+        expect(exceptionList[2]['type'], equals('StateError'));
+        expect(
+          exceptionList[2]['value'],
+          equals('Bad state: parallel failure'),
+        );
+      });
+
+      test('guards against cause cycles', () {
+        final a = _MutableCauseException('a');
+        final b = _MutableCauseException('b');
+        a.cause = b;
+        b.cause = a;
+
+        final result = DartExceptionProcessor.processException(
+          error: a,
+          stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
+        );
+
+        final exceptionList =
+            result['\$exception_list'] as List<Map<String, dynamic>>;
+
+        expect(exceptionList, hasLength(2));
+        expect(exceptionList[0]['value'], equals('a'));
+        expect(exceptionList[1]['value'], equals('b'));
+      });
+
+      test('caps the cause chain length', () {
+        Object error = FormatException('root');
+        for (var i = 0; i < 20; i++) {
+          error = _ChainedException('wrapper $i', error);
+        }
+
+        final result = DartExceptionProcessor.processException(
+          error: error,
+          stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
+        );
+
+        final exceptionList =
+            result['\$exception_list'] as List<Map<String, dynamic>>;
+
+        expect(
+          exceptionList,
+          hasLength(DartExceptionProcessor.maxExceptionChainLength),
+        );
+        expect(exceptionList.first['value'], equals('wrapper 19'));
+      });
+
+      test('does not add causes for errors without one', () {
+        final result = DartExceptionProcessor.processException(
+          error: StateError('no cause'),
+          stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
+        );
+
+        final exceptionList =
+            result['\$exception_list'] as List<Map<String, dynamic>>;
+
+        expect(exceptionList, hasLength(1));
+      });
+    });
   });
+}
+
+/// Exception exposing the common duck-typed `cause` convention
+class _ChainedException implements Exception {
+  final String message;
+  final Object? cause;
+
+  _ChainedException(this.message, this.cause);
+
+  @override
+  String toString() => message;
+}
+
+/// Exception with a mutable cause, used to build cause cycles
+class _MutableCauseException implements Exception {
+  final String message;
+  Object? cause;
+
+  _MutableCauseException(this.message);
+
+  @override
+  String toString() => message;
 }
 
 // Helper functions to generate async stack traces for testing

--- a/posthog_flutter/test/dart_exception_processor_test.dart
+++ b/posthog_flutter/test/dart_exception_processor_test.dart
@@ -594,70 +594,98 @@ void main() {
     });
 
     group('cause chain', () {
-      test('walks AsyncError into multiple exception items, outermost-first',
-          () {
-        late StateError rootError;
-        try {
-          throw StateError('root cause');
-        } catch (error) {
-          rootError = error as StateError;
-        }
+      final synchronousCases = <({
+        String description,
+        Object Function() buildError,
+        StackTrace? stackTrace,
+        List<String> expectedTypes,
+        Map<int, String> expectedValues,
+        void Function(List<Map<String, dynamic>>) extraExpectations,
+      })>[
+        (
+          description:
+              'walks AsyncError into multiple exception items, outermost-first',
+          buildError: () {
+            late StateError rootError;
+            try {
+              throw StateError('root cause');
+            } catch (error) {
+              rootError = error as StateError;
+            }
 
-        final asyncError = AsyncError(rootError, rootError.stackTrace!);
+            return AsyncError(rootError, rootError.stackTrace!);
+          },
+          stackTrace: null,
+          expectedTypes: ['AsyncError', 'StateError'],
+          expectedValues: {1: 'Bad state: root cause'},
+          extraExpectations: (exceptionList) {
+            // The cause carries its own (thrown) stack trace
+            expect(exceptionList[1]['stacktrace'], isNotNull);
+            expect(
+              (exceptionList[1]['stacktrace']['frames'] as List).isNotEmpty,
+              isTrue,
+            );
 
-        final result = DartExceptionProcessor.processException(
-          error: asyncError,
-        );
-
-        final exceptionList =
-            result['\$exception_list'] as List<Map<String, dynamic>>;
-
-        expect(exceptionList, hasLength(2));
-        // Wrapper first, root cause last
-        expect(exceptionList[0]['type'], equals('AsyncError'));
-        expect(exceptionList[1]['type'], equals('StateError'));
-        expect(exceptionList[1]['value'], equals('Bad state: root cause'));
-
-        // The cause carries its own (thrown) stack trace
-        expect(exceptionList[1]['stacktrace'], isNotNull);
-        expect(
-          (exceptionList[1]['stacktrace']['frames'] as List).isNotEmpty,
-          isTrue,
-        );
-
-        // Causes reuse the outer mechanism
-        expect(exceptionList[1]['mechanism']['handled'], isTrue);
-        expect(exceptionList[1]['mechanism']['type'], equals('generic'));
-        expect(exceptionList[1]['mechanism']['synthetic'], isFalse);
-      });
-
-      test('walks duck-typed cause getters', () {
-        final root = FormatException('root');
-        final middle = _ChainedException('middle', root);
-        final outer = _ChainedException('outer', middle);
-
-        final result = DartExceptionProcessor.processException(
-          error: outer,
+            // Causes reuse the outer mechanism
+            expect(exceptionList[1]['mechanism']['handled'], isTrue);
+            expect(exceptionList[1]['mechanism']['type'], equals('generic'));
+            expect(exceptionList[1]['mechanism']['synthetic'], isFalse);
+          },
+        ),
+        (
+          description: 'walks duck-typed cause getters',
+          buildError: () {
+            final root = FormatException('root');
+            final middle = _ChainedException('middle', root);
+            return _ChainedException('outer', middle);
+          },
           stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
-        );
+          expectedTypes: [
+            '_ChainedException',
+            '_ChainedException',
+            'FormatException',
+          ],
+          expectedValues: {0: 'outer', 1: 'middle'},
+          extraExpectations: (_) {},
+        ),
+        (
+          description: 'does not add causes for errors without one',
+          buildError: () => StateError('no cause'),
+          stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
+          expectedTypes: ['StateError'],
+          expectedValues: const {},
+          extraExpectations: (_) {},
+        ),
+      ];
 
-        final exceptionList =
-            result['\$exception_list'] as List<Map<String, dynamic>>;
+      for (final testCase in synchronousCases) {
+        test(testCase.description, () {
+          final result = DartExceptionProcessor.processException(
+            error: testCase.buildError(),
+            stackTrace: testCase.stackTrace,
+          );
 
-        expect(exceptionList, hasLength(3));
-        expect(exceptionList[0]['type'], equals('_ChainedException'));
-        expect(exceptionList[0]['value'], equals('outer'));
-        expect(exceptionList[1]['type'], equals('_ChainedException'));
-        expect(exceptionList[1]['value'], equals('middle'));
-        expect(exceptionList[2]['type'], equals('FormatException'));
-      });
+          final exceptionList =
+              result['\$exception_list'] as List<Map<String, dynamic>>;
 
-      test('walks ParallelWaitError to the first failed future', () async {
+          expect(exceptionList, hasLength(testCase.expectedTypes.length));
+          for (final (index, expectedType) in testCase.expectedTypes.indexed) {
+            expect(exceptionList[index]['type'], equals(expectedType));
+          }
+          for (final entry in testCase.expectedValues.entries) {
+            expect(exceptionList[entry.key]['value'], equals(entry.value));
+          }
+          testCase.extraExpectations(exceptionList);
+        });
+      }
+
+      test('walks ParallelWaitError to every failed future', () async {
         Object? caught;
         try {
           await [
-            Future<int>.error(StateError('parallel failure')),
+            Future<int>.error(StateError('first parallel failure')),
             Future<int>.value(1),
+            Future<int>.error(FormatException('second parallel failure')),
           ].wait;
         } catch (error) {
           caught = error;
@@ -670,13 +698,19 @@ void main() {
         final exceptionList =
             result['\$exception_list'] as List<Map<String, dynamic>>;
 
-        expect(exceptionList.length, greaterThanOrEqualTo(3));
+        expect(exceptionList, hasLength(5));
         expect(exceptionList[0]['type'], startsWith('ParallelWaitError'));
         expect(exceptionList[1]['type'], equals('AsyncError'));
         expect(exceptionList[2]['type'], equals('StateError'));
         expect(
           exceptionList[2]['value'],
-          equals('Bad state: parallel failure'),
+          equals('Bad state: first parallel failure'),
+        );
+        expect(exceptionList[3]['type'], equals('AsyncError'));
+        expect(exceptionList[4]['type'], equals('FormatException'));
+        expect(
+          exceptionList[4]['value'],
+          equals('FormatException: second parallel failure'),
         );
       });
 
@@ -718,18 +752,6 @@ void main() {
           hasLength(DartExceptionProcessor.maxExceptionChainLength),
         );
         expect(exceptionList.first['value'], equals('wrapper 19'));
-      });
-
-      test('does not add causes for errors without one', () {
-        final result = DartExceptionProcessor.processException(
-          error: StateError('no cause'),
-          stackTrace: StackTrace.fromString('#0 test (test.dart:1:1)'),
-        );
-
-        final exceptionList =
-            result['\$exception_list'] as List<Map<String, dynamic>>;
-
-        expect(exceptionList, hasLength(1));
       });
     });
   });


### PR DESCRIPTION
## :bulb: Motivation and Context
`captureException` previously emitted only the outer error in `$exception_list`, losing root-cause context for wrapped async errors and custom exceptions with a `cause` chain.

This adds cause-chain extraction for `AsyncError`, `ParallelWaitError`, and exceptions exposing a `cause` getter. Causes are emitted outermost-first with cycle protection and a maximum chain length.


## :green_heart: How did you test it?

- `flutter test posthog_flutter/test/dart_exception_processor_test.dart`


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent helped narrow the branch to the cause-chain work only, removing unrelated error-tracking signal changes from the branch diff. The implementation keeps cause stack traces only when available on the cause itself, avoids generating synthetic stacks for causes, and includes tests for async errors, parallel waits, duck-typed causes, cycles, and chain length capping.