### PR TITLE
docs: remove unsupported macOS platform view note

### DIFF
--- a/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_platform_view.dart
@@ -16,9 +16,6 @@ enum PostHogPlatformViewPrivacy {
   /// platform view types (Google Maps, ARKit, camera previews, etc.) are masked
   /// regardless of this policy, because the iOS compositor cannot safely
   /// snapshot arbitrary CALayer-backed views without leaking unmasked content.
-  ///
-  /// **macOS note:** capture is not supported on macOS; all platform views are
-  /// masked regardless of this policy.
   capture,
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removes a misleading Dartdoc note from `PostHogPlatformViewPrivacy.capture` that referenced macOS behavior, since this SDK does not support macOS.

Addresses review feedback from https://github.com/PostHog/posthog-flutter/pull/453#discussion_r3518097503.

## :green_heart: How did you test it?

Not run; comment-only documentation change.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. The change is intentionally limited to removing the macOS-specific Dartdoc note because macOS is not a supported platform for this SDK.
