### PR TITLE
chore: group codeql-action Dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       interval: weekly
     reviewers:
       - "PostHog/team-client-libraries"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Problem

`github/codeql-action` is a monorepo published as separate sub-actions (`init`, `analyze`, ...) that **must run the same version** in a job. Dependabot was opening a separate PR per sub-action, so each PR bumped only one and left the other behind, producing:

```
Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

We hit this with #470 / #471 (had to manually consolidate both bumps into #470 so CodeQL would pass).

## Fix

Group the `github/codeql-action*` actions so `init` and `analyze` always bump together in a single, self-consistent PR. Scoped to only the codeql-action family — every other action still updates in its own PR as before.