### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/sdk_compliance_adapter/lib/adapter_server.dart
+++ b/sdk_compliance_adapter/lib/adapter_server.dart
@@ -494,7 +494,7 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
 
     final client = HttpClient();
     Object? value = false;
-    var hasExperiment = false;
+    bool? hasExperiment;
     try {
       final uri = Uri.parse(_host!).resolve('/flags/?v=2');
       for (var attempt = 0; attempt <= _maxRetries; attempt++) {
@@ -543,7 +543,8 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
         r'$lib_version': postHogFlutterVersion,
         r'$feature_flag': key,
         r'$feature_flag_response': value,
-        r'$feature_flag_has_experiment': hasExperiment,
+        if (hasExperiment != null)
+          r'$feature_flag_has_experiment': hasExperiment,
         r'$feature/' + key: value,
       },
       'timestamp': DateTime.now().toUtc().toIso8601String(),
@@ -556,14 +557,16 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
 
   /// Reads `metadata.has_experiment` from the `/flags?v=2` entry for [key].
   ///
-  /// Defaults to `false` when the server does not send it (e.g. legacy
-  /// `featureFlags` responses).
-  bool _flagHasExperiment(Object? flags, String key) {
-    if (flags is! Map) return false;
+  /// Returns `null` when the server does not report it (e.g. legacy
+  /// `featureFlags` responses or metadata without a boolean value).
+  bool? _flagHasExperiment(Object? flags, String key) {
+    if (flags is! Map) return null;
     final details = flags[key];
-    if (details is! Map) return false;
+    if (details is! Map) return null;
     final metadata = details['metadata'];
-    return metadata is Map && metadata['has_experiment'] == true;
+    if (metadata is! Map) return null;
+    final hasExperiment = metadata['has_experiment'];
+    return hasExperiment is bool ? hasExperiment : null;
   }
 
   bool _shouldRetryFlags(int statusCode) =>

--- a/sdk_compliance_adapter/lib/adapter_server.dart
+++ b/sdk_compliance_adapter/lib/adapter_server.dart
@@ -494,6 +494,7 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
 
     final client = HttpClient();
     Object? value = false;
+    var hasExperiment = false;
     try {
       final uri = Uri.parse(_host!).resolve('/flags/?v=2');
       for (var attempt = 0; attempt <= _maxRetries; attempt++) {
@@ -523,6 +524,7 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
           if (flags is Map && flags.containsKey(key)) {
             value = flags[key];
           }
+          hasExperiment = _flagHasExperiment(decoded['flags'], key);
         }
         break;
       }
@@ -541,6 +543,7 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
         r'$lib_version': postHogFlutterVersion,
         r'$feature_flag': key,
         r'$feature_flag_response': value,
+        r'$feature_flag_has_experiment': hasExperiment,
         r'$feature/' + key: value,
       },
       'timestamp': DateTime.now().toUtc().toIso8601String(),
@@ -549,6 +552,18 @@ class _CompliancePlatform extends PosthogFlutterPlatformInterface {
     state.pendingEvents = state.queue.length;
 
     return value;
+  }
+
+  /// Reads `metadata.has_experiment` from the `/flags?v=2` entry for [key].
+  ///
+  /// Defaults to `false` when the server does not send it (e.g. legacy
+  /// `featureFlags` responses).
+  bool _flagHasExperiment(Object? flags, String key) {
+    if (flags is! Map) return false;
+    final details = flags[key];
+    if (details is! Map) return false;
+    final metadata = details['metadata'];
+    return metadata is Map && metadata['has_experiment'] == true;
   }
 
   bool _shouldRetryFlags(int statusCode) =>

--- a/sdk_compliance_adapter/test/feature_flag_has_experiment_test.dart
+++ b/sdk_compliance_adapter/test/feature_flag_has_experiment_test.dart
@@ -34,7 +34,34 @@ void main() {
   );
 
   test(
-    r'$feature_flag_has_experiment defaults to false without metadata',
+    r'$feature_flag_has_experiment is sent when the server reports false',
+    () async {
+      final mockServer = await _MockPostHogServer.start({
+        'flags': {
+          'plain-flag': {
+            'key': 'plain-flag',
+            'enabled': true,
+            'metadata': {'has_experiment': false},
+          },
+        },
+        'featureFlags': {'plain-flag': true},
+      });
+      addTearDown(mockServer.close);
+
+      final properties = await _captureFeatureFlagCalled(
+        mockServer,
+        key: 'plain-flag',
+      );
+
+      expect(properties[r'$feature_flag'], 'plain-flag');
+      expect(properties[r'$feature_flag_response'], isTrue);
+      expect(properties[r'$feature_flag_has_experiment'], isFalse);
+    },
+  );
+
+  test(
+    r'$feature_flag_has_experiment is omitted when the server does not '
+    'report it',
     () async {
       final mockServer = await _MockPostHogServer.start({
         'featureFlags': {'plain-flag': true},
@@ -48,7 +75,7 @@ void main() {
 
       expect(properties[r'$feature_flag'], 'plain-flag');
       expect(properties[r'$feature_flag_response'], isTrue);
-      expect(properties[r'$feature_flag_has_experiment'], isFalse);
+      expect(properties, isNot(contains(r'$feature_flag_has_experiment')));
     },
   );
 }

--- a/sdk_compliance_adapter/test/feature_flag_has_experiment_test.dart
+++ b/sdk_compliance_adapter/test/feature_flag_has_experiment_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter_sdk_compliance_adapter/adapter_server.dart';
+
+void main() {
+  test(
+    r'$feature_flag_called includes $feature_flag_has_experiment from v2 metadata',
+    () async {
+      final mockServer = await _MockPostHogServer.start({
+        'flags': {
+          'experiment-flag': {
+            'key': 'experiment-flag',
+            'enabled': true,
+            'variant': 'control',
+            'metadata': {'has_experiment': true},
+          },
+        },
+        'featureFlags': {'experiment-flag': 'control'},
+      });
+      addTearDown(mockServer.close);
+
+      final properties = await _captureFeatureFlagCalled(
+        mockServer,
+        key: 'experiment-flag',
+      );
+
+      expect(properties[r'$feature_flag'], 'experiment-flag');
+      expect(properties[r'$feature_flag_response'], 'control');
+      expect(properties[r'$feature_flag_has_experiment'], isTrue);
+    },
+  );
+
+  test(
+    r'$feature_flag_has_experiment defaults to false without metadata',
+    () async {
+      final mockServer = await _MockPostHogServer.start({
+        'featureFlags': {'plain-flag': true},
+      });
+      addTearDown(mockServer.close);
+
+      final properties = await _captureFeatureFlagCalled(
+        mockServer,
+        key: 'plain-flag',
+      );
+
+      expect(properties[r'$feature_flag'], 'plain-flag');
+      expect(properties[r'$feature_flag_response'], isTrue);
+      expect(properties[r'$feature_flag_has_experiment'], isFalse);
+    },
+  );
+}
+
+/// Evaluates [key] through the adapter, flushes, and returns the properties of
+/// the captured `$feature_flag_called` event.
+Future<Map<String, Object?>> _captureFeatureFlagCalled(
+  _MockPostHogServer mockServer, {
+  required String key,
+}) async {
+  final adapter = ComplianceAdapter();
+  final adapterServer = await adapter.start(port: 0);
+  addTearDown(adapter.close);
+
+  final adapterBase = 'http://127.0.0.1:${adapterServer.port}';
+  await _postJson('$adapterBase/init', {
+    'api_key': 'test-api-key',
+    'host': mockServer.url,
+    'flush_interval_ms': 60000,
+  });
+
+  final response = await _postJson('$adapterBase/get_feature_flag', {
+    'key': key,
+    'distinct_id': 'test-user',
+  });
+  expect(response['success'], isTrue);
+
+  await _postJson('$adapterBase/flush', {});
+
+  expect(mockServer.batchedEvents, hasLength(1));
+  final event = mockServer.batchedEvents.single;
+  expect(event['event'], r'$feature_flag_called');
+  return Map<String, Object?>.from(event['properties'] as Map);
+}
+
+Future<Map<String, Object?>> _postJson(
+  String url,
+  Map<String, Object?> payload,
+) async {
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(Uri.parse(url));
+    request.headers.contentType = ContentType.json;
+    request.write(jsonEncode(payload));
+    final response = await request.close();
+    final body = await utf8.decoder.bind(response).join();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException('HTTP ${response.statusCode}: $body');
+    }
+    return Map<String, Object?>.from(jsonDecode(body) as Map);
+  } finally {
+    client.close(force: true);
+  }
+}
+
+/// Serves `/flags/?v=2` with [flagsResponse] and records events posted to
+/// `/batch`.
+class _MockPostHogServer {
+  _MockPostHogServer._(this._server, this._flagsResponse);
+
+  final HttpServer _server;
+  final Map<String, Object?> _flagsResponse;
+  final List<Map<String, Object?>> batchedEvents = [];
+
+  String get url => 'http://127.0.0.1:${_server.port}';
+
+  static Future<_MockPostHogServer> start(
+    Map<String, Object?> flagsResponse,
+  ) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final mockServer = _MockPostHogServer._(server, flagsResponse);
+    unawaited(mockServer._serve());
+    return mockServer;
+  }
+
+  Future<void> close() => _server.close(force: true);
+
+  Future<void> _serve() async {
+    await for (final request in _server) {
+      final body = await utf8.decoder.bind(request).join();
+      if (request.method == 'POST' &&
+          request.uri.path == '/flags/' &&
+          request.uri.queryParameters['v'] == '2') {
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(jsonEncode(_flagsResponse));
+        await request.response.close();
+        continue;
+      }
+
+      if (request.method == 'POST' && request.uri.path == '/batch') {
+        final decoded = jsonDecode(body) as Map;
+        for (final event in decoded['batch'] as List) {
+          batchedEvents.add(Map<String, Object?>.from(event as Map));
+        }
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(jsonEncode({'status': 1}));
+        await request.response.close();
+        continue;
+      }
+
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+    }
+  }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

The shipped Flutter SDK never constructs `$feature_flag_called` in Dart: iOS/Android delegate to the native SDKs via the method channel and web delegates to posthog-js, all of which are gaining this property in their own PRs. The one place this repo builds the event is the SDK compliance adapter, updated here:

- `sdk_compliance_adapter/lib/adapter_server.dart`: `evaluateFeatureFlag` reads `metadata.has_experiment` from the v2 `flags[key]` entry via a `_flagHasExperiment` helper (omitted when the response carries no boolean `has_experiment`, including legacy `featureFlags`-only responses) and adds the property to the queued event.

No changeset: only the unpublished compliance adapter changed, matching the precedent of prior adapter-only PRs.

## :green_heart: How did you test it?

New `feature_flag_has_experiment_test.dart` (mock server serving `/flags/?v=2`, recording `/batch`): asserts the property is `true`/`false` with v2 metadata and absent without. `dart format`, `dart analyze`, and `flutter test` on the adapter tests all pass, run inside the repo's compliance image (`ghcr.io/cirruslabs/flutter:3.44.0`). The published `posthog_flutter` package is unmodified.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed; adapter-only change, nothing published)

