### PR TITLE
fix(android): require posthog-android 3.54.1 to guarantee the per-touch replay ANR fix

### DIFF
--- a/.changeset/android-floor-3-54-1.md
+++ b/.changeset/android-floor-3-54-1.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+Require posthog-android 3.54.1 or newer. Earlier 3.x versions performed replay work on every touch (a network-time Binder call, a `MotionEvent` copy, and a replay-executor submission) even when session replay was disabled or sampled out, which could cause ANRs on Android. Projects with a Gradle lockfile or cached dependency resolution could stay pinned to an affected version; the raised floor guarantees the fixed SDK.

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,8 +64,8 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        // + Version 3.51.0 and the versions up to 4.0.0, not including 4.0.0 and higher
-        implementation 'com.posthog:posthog-android:[3.51.0,4.0.0]'
+        // + Version 3.54.1 and the versions up to 4.0.0, not including 4.0.0 and higher
+        implementation 'com.posthog:posthog-android:[3.54.1,4.0.0]'
     }
 
     testOptions {


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #476. `posthog_flutter` allowed `posthog-android` down to 3.51.0. Versions before 3.54.1 performed replay work on every touch — a network-time Binder IPC (`currentTimeMillis()`), a `MotionEvent` copy, and a submission to the replay executor — even with `sessionReplay = false` or a sampled-out session, which could cause main-thread ANRs under load. posthog-android 3.54.1 gates all of that on the recording state ([PostHog/posthog-android#622](https://github.com/PostHog/posthog-android/pull/622)).

Fresh builds already resolve the dynamic range to the newest 3.x and get the fix, but projects with a Gradle lockfile or cached dependency resolution can stay pinned to an affected version (the reporter was on 3.53.7). Raising the floor to 3.54.1 guarantees the fixed SDK.

## :green_heart: How did you test it?

Dependency floor bump only, no code changes. Verified against the posthog-android changelog and fix commit that 3.54.1 is the first version with the per-touch gate.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), directed by @turnipdabeets: investigated #476, confirmed the reported behavior exists in posthog-android < 3.54.1 and that the fix shipped in 3.54.1, then bumped the floor.
- Considered folding this into #473 (which raises the floor to 3.54.0 for other reasons) and rejected it: that PR is blocked on native releases and 3.54.0 predates the ANR fix; this ships independently as a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
