### PR TITLE
feat(surveys): add displaySurvey to show a survey on demand

### DIFF
--- a/.changeset/display-survey-manual-api.md
+++ b/.changeset/display-survey-manual-api.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": minor
+---
+
+Add `Posthog().displaySurvey(surveyId)` to display a survey on demand, bypassing display conditions (targeting flags, event triggers, and seen/wait-period checks). This is the counterpart of the web SDK's `posthog.displaySurvey()` and also enables API-type surveys, which are never auto-displayed. On Android and iOS the survey is displayed by the native SDK (requires posthog-android >= 3.56.0 / posthog-ios >= 3.67.0); on Web it is displayed by the JS SDK as a popover.

--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -718,6 +718,28 @@
                         "isDeprecated": false,
                         "isExperimental": false,
                         "isStatic": false,
+                        "name": "displaySurvey",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": false,
+                                "isRequired": true,
+                                "name": "surveyId",
+                                "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                                "typeName": "String"
+                            }
+                        ],
+                        "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                        "returnTypeName": "Future<void>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
                         "name": "group",
                         "parameters": [
                             {
@@ -1588,6 +1610,28 @@
                                 "name": "survey",
                                 "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
                                 "typeName": "Map<String, dynamic>"
+                            }
+                        ],
+                        "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                        "returnTypeName": "Future<void>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "displaySurvey",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": false,
+                                "isRequired": true,
+                                "name": "surveyId",
+                                "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
+                                "typeName": "String"
                             }
                         ],
                         "relativePath": "lib/src/posthog_flutter_platform_interface.dart",
@@ -4366,6 +4410,28 @@
                         "parameters": [],
                         "relativePath": "lib/src/posthog.dart",
                         "returnTypeName": "Future<bool>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "displaySurvey",
+                        "parameters": [
+                            {
+                                "isDeprecated": false,
+                                "isExperimental": false,
+                                "isNamed": false,
+                                "isRequired": true,
+                                "name": "surveyId",
+                                "relativePath": "lib/src/posthog.dart",
+                                "typeName": "String"
+                            }
+                        ],
+                        "relativePath": "lib/src/posthog.dart",
+                        "returnTypeName": "Future<void>",
                         "type": "method",
                         "typeParameterNames": []
                     },

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,7 +64,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.posthog:posthog-android:[3.55.0,4.0.0)'
+        implementation 'com.posthog:posthog-android:[3.56.0,4.0.0)'
     }
 
     testOptions {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -392,6 +392,10 @@ class PosthogFlutterPlugin :
                 handleSurveyAction(call, result)
             }
 
+            "displaySurvey" -> {
+                displaySurvey(call, result)
+            }
+
             else -> {
                 result.notImplemented()
             }
@@ -1810,6 +1814,19 @@ class PosthogFlutterPlugin :
             Handler(Looper.getMainLooper()).post {
                 channel.invokeMethod(method, arguments)
             }
+        }
+    }
+
+    private fun displaySurvey(
+        call: MethodCall,
+        result: Result,
+    ) {
+        try {
+            val surveyId: String = call.argument("surveyId")!!
+            PostHog.displaySurvey(surveyId)
+            result.success(null)
+        } catch (e: Throwable) {
+            result.error("PosthogFlutterException", e.localizedMessage, null)
         }
     }
 

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -21,8 +21,8 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.66.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.66.0', '< 4.0.0'
+  # ~> Version 3.67.0 up to, but not including, 4.0.0
+  s.dependency 'PostHog', '>= 3.67.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.66.0" ..< "4.0.0"),
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.67.0" ..< "4.0.0"),
     ],
     targets: [
         .target(

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -422,6 +422,13 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
                 // surveys only supported on iOS
                 result(nil)
             #endif
+        case "displaySurvey":
+            #if os(iOS)
+                displaySurvey(call, result: result)
+            #else
+                // surveys only supported on iOS
+                result(nil)
+            #endif
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -459,6 +466,18 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
 
             // Notify Flutter side that surveys have been cleaned up
             invokeFlutterMethod("hideSurveys", arguments: nil)
+        }
+
+        private func displaySurvey(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+            guard let args = call.arguments as? [String: Any],
+                  let surveyId = args["surveyId"] as? String
+            else {
+                result(FlutterError(code: "InvalidArguments", message: "Missing surveyId", details: nil))
+                return
+            }
+
+            PostHogSDK.shared.displaySurvey(surveyId)
+            result(nil)
         }
 
         private func handleSurveyAction(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -365,6 +365,13 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
   }
 
   @override
+  Future<void> displaySurvey(String surveyId) async {
+    return handleWebMethodCall(
+      MethodCall('displaySurvey', {'surveyId': surveyId}),
+    );
+  }
+
+  @override
   Future<void> captureException({
     required Object error,
     StackTrace? stackTrace,

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -765,5 +765,23 @@ class Posthog {
   /// current platform.
   Future<bool> isSessionReplayActive() => _posthog.isSessionReplayActive();
 
+  /// Displays the survey with the given ID on demand, regardless of its
+  /// display conditions.
+  ///
+  /// The survey must be running and part of your project's surveys. Display
+  /// conditions (targeting flags, event triggers, and the seen/wait-period
+  /// checks) are bypassed, so this also works for API-type surveys, which are
+  /// never displayed automatically. If another survey is already being
+  /// displayed, this call is ignored.
+  ///
+  /// Surveys must be enabled via `PostHogConfig.surveys` (mobile) or in your
+  /// web snippet configuration. On Android and iOS the survey is rendered by
+  /// the native SDK through the regular Flutter survey UI; on Web it is
+  /// rendered by the JS SDK as a popover.
+  ///
+  /// Returns a [Future] that completes when the display request has been sent.
+  Future<void> displaySurvey(String surveyId) =>
+      _posthog.displaySurvey(surveyId);
+
   Posthog._internal();
 }

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -512,6 +512,21 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   }
 
   @override
+  Future<void> displaySurvey(String surveyId) async {
+    if (!isSupportedPlatform()) {
+      return;
+    }
+
+    try {
+      await _methodChannel.invokeMethod('displaySurvey', {
+        'surveyId': surveyId,
+      });
+    } on PlatformException catch (exception) {
+      printIfDebug('Exception on displaySurvey: $exception');
+    }
+  }
+
+  @override
   Future<bool> isFeatureEnabled(String key) async {
     if (!isSupportedPlatform()) {
       return false;

--- a/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_platform_interface.dart
@@ -165,6 +165,10 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
     throw UnimplementedError('showSurvey() has not been implemented.');
   }
 
+  Future<void> displaySurvey(String surveyId) {
+    throw UnimplementedError('displaySurvey() has not been implemented.');
+  }
+
   Future<void> group({
     required String groupType,
     required String groupKey,

--- a/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_web_handler.dart
@@ -66,6 +66,8 @@ extension PostHogExtension on PostHog {
   external void startSessionRecording();
   external void stopSessionRecording();
   external bool sessionRecordingStarted();
+  // May be absent on older posthog-js builds; the call site guards with try/catch.
+  external void displaySurvey(JSAny surveyId, JSAny options);
   external SessionManager? get sessionManager;
   // ignore: non_constant_identifier_names
   external void _overrideSDKInfo(JSAny sdkName, JSAny sdkVersion);
@@ -419,6 +421,17 @@ Future<dynamic> handleWebMethodCall(MethodCall call) async {
       break;
     case 'surveyAction':
       // not supported on Web
+      break;
+    case 'displaySurvey':
+      final surveyId = args['surveyId'] as String;
+      try {
+        posthog?.displaySurvey(
+          stringToJSAny(surveyId),
+          mapToJSAny({'displayType': 'popover'}),
+        );
+      } catch (e) {
+        printIfDebug('Exception on displaySurvey: $e');
+      }
       break;
     case 'captureException':
       final properties = safeMapConversion(args['properties']);

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -283,6 +283,14 @@ void main() {
       ]);
     });
 
+    test('displaySurvey sends the surveyId over the method channel', () async {
+      await posthogFlutterIO.displaySurvey('survey-123');
+
+      final call = log.firstWhere((c) => c.method == 'displaySurvey');
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      expect(args, {'surveyId': 'survey-123'});
+    });
+
     test('setGroupPropertiesForFlags sends groupType and properties', () async {
       await posthogFlutterIO.setGroupPropertiesForFlags(
         'organization',

--- a/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
+++ b/posthog_flutter/test/posthog_flutter_platform_interface_fake.dart
@@ -187,6 +187,14 @@ class PosthogFlutterPlatformFake extends PosthogFlutterPlatformInterface {
     });
   }
 
+  // Call tracking for displaySurvey
+  final List<String> displaySurveyCalls = [];
+
+  @override
+  Future<void> displaySurvey(String surveyId) async {
+    displaySurveyCalls.add(surveyId);
+  }
+
   @override
   Future<Object?> getFeatureFlag({required String key}) async {
     return featureFlagValues[key];

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -156,6 +156,37 @@ void main() {
     });
   });
 
+  // Guards the web wiring: PosthogFlutterWeb must override displaySurvey so
+  // the call actually reaches posthog-js. Without the override it falls through
+  // to the platform interface and throws UnimplementedError on web.
+  group('PosthogFlutterWeb displaySurvey', () {
+    String? capturedSurveyId;
+    JSAny? capturedOptions;
+
+    setUp(() {
+      capturedSurveyId = null;
+      capturedOptions = null;
+
+      final fake = JSObject();
+      fake.setProperty(
+        'displaySurvey'.toJS,
+        ((JSString surveyId, JSAny? options) {
+          capturedSurveyId = surveyId.toDart;
+          capturedOptions = options;
+        }).toJS,
+      );
+      globalContext.setProperty('posthog'.toJS, fake);
+    });
+
+    test('override forwards the survey ID and popover options to posthog-js',
+        () async {
+      await PosthogFlutterWeb().displaySurvey('survey-123');
+
+      expect(capturedSurveyId, 'survey-123');
+      expect(capturedOptions.dartify(), {'displayType': 'popover'});
+    });
+  });
+
   // captureException must route through posthog-js's captureException (not the
   // generic capture) so it attaches required metadata and any buffered
   // $exception_steps. The Dart-built payload is passed as additionalProperties,

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -680,6 +680,22 @@ void main() {
     });
   });
 
+  group('Posthog displaySurvey', () {
+    late PosthogFlutterPlatformFake fake;
+
+    setUp(() async {
+      fake = PosthogFlutterPlatformFake();
+      PosthogFlutterPlatformInterface.instance = fake;
+      await Posthog().close();
+    });
+
+    test('forwards the survey ID to the platform interface', () async {
+      await Posthog().displaySurvey('survey-123');
+
+      expect(fake.displaySurveyCalls, ['survey-123']);
+    });
+  });
+
   group('PostHogExceptionStepsConfig', () {
     test('toMap serializes the native defaults', () {
       final config = PostHogConfig('test_project_token');


### PR DESCRIPTION
## :bulb: Motivation and Context

Closes #225

The web SDK exposes `posthog.displaySurvey()` to display a survey on demand (see [implementing custom surveys](https://posthog.com/docs/surveys/implementing-custom-surveys)), but the Flutter SDK has no way to trigger a survey manually — surveys only appear when the automatic display conditions are met, and API-type surveys can't be shown at all. This adds:

```dart
await Posthog().displaySurvey('survey-id');
```

- **Android / iOS:** the call goes over the method channel to the new native `displaySurvey` APIs (PostHog/posthog-android#643, PostHog/posthog-ios#730). The native SDK looks the survey up, bypasses display conditions (targeting flags, event triggers, seen/wait-period checks), and renders it back through the existing Flutter survey bottom sheet — events (`survey shown`/`sent`/`dismissed`) and seen-state work exactly as for auto-displayed surveys.
- **Web:** calls the JS SDK's `displaySurvey(surveyId, {displayType: 'popover'})` directly.
- No-op (with a log) when the survey isn't found or another survey is already being displayed.

> ⚠️ **Depends on unreleased native SDKs.** The native dependency minimums are bumped to posthog-android `3.56.0` and posthog-ios `3.67.0`, which don't exist yet — Android/iOS CI jobs will fail until PostHog/posthog-android#643 and PostHog/posthog-ios#730 are merged and released. Keeping this as a draft until then.

## :green_heart: How did you test it?

- Added tests: `Posthog().displaySurvey` forwarding to the platform interface (`posthog_test.dart`) and the method-channel payload (`posthog_flutter_io_test.dart`). `flutter test` passes locally (224 tests).
- `flutter analyze` and `dart format` are clean; the public API snapshot was regenerated with `scripts/check-api-dart.sh --update`; ktlint and swiftformat pass on the changed plugin files.
- The native plugin code paths (Kotlin/Swift) compile only against the unreleased native SDKs, so they're validated by inspection + the native PRs' own tests until the releases land.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) from a request to bring the JS SDK's `displaySurvey` to the Flutter SDK. Since Flutter delegates survey eligibility/state to the native SDKs and only renders in Dart, the API was implemented natively first (sibling PRs above) and this PR wires Dart → method channel → native. Scoped v1 to a single `surveyId` parameter (no `ignoreConditions`/`initialResponses` options); Web passes `displayType: 'popover'` since inline rendering has no Flutter equivalent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
