### PR TITLE
fix(replay): mask every element that matched a masking rule

### DIFF
--- a/.changeset/mask-nested-elements.md
+++ b/.changeset/mask-nested-elements.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+Session replay: masks every element that matched a masking rule, at any depth. The rect collector only walked two levels of the matched-element tree and dropped any node that had more than one matched child, so with `maskAllTexts`/`maskAllImages` enabled a `PostHogMaskWidget` wrapping several masked children lost its own mask rect and anything it wrapped but did not match on its own (an image, an avatar, decoration) stayed visible in the recording.

--- a/.changeset/mask-nested-elements.md
+++ b/.changeset/mask-nested-elements.md
@@ -2,4 +2,4 @@
 "posthog_flutter": patch
 ---
 
-Session replay: masks every element that matched a masking rule, at any depth. The rect collector only walked two levels of the matched-element tree and dropped any node that had more than one matched child, so with `maskAllTexts`/`maskAllImages` enabled a `PostHogMaskWidget` wrapping several masked children lost its own mask rect and anything it wrapped but did not match on its own (an image, an avatar, decoration) stayed visible in the recording.
+Session replay: masks every element that matched a masking rule, at any depth. The rect collector only walked two levels of the matched-element tree and dropped any node that had more than one matched child, so with `maskAllTexts`/`maskAllImages` enabled a `PostHogMaskWidget` wrapping several masked children lost its own mask rect, and whatever it wrapped that matched no rule on its own (a decorated container, a chart, a custom-painted avatar) stayed visible in the recording. More of the screen is masked as a result: a `PostHogMaskWidget` now covers its whole subtree, as documented, instead of only the children that matched.

--- a/example/lib/masking_tests_screen.dart
+++ b/example/lib/masking_tests_screen.dart
@@ -252,6 +252,43 @@ class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
                 const _MaskedPasswordField(),
               ),
 
+              // Test 15: PostHogMaskWidget around several masked children.
+              // The avatar is not masked on its own when maskAllImages is off,
+              // so it is only covered if the wrapper itself is masked.
+              _buildTestSection(
+                'Test 15: PostHogMaskWidget with multiple children',
+                PostHogMaskWidget(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Flexible(
+                        child: Text(
+                          'Jane Doe',
+                          style: TextStyle(fontSize: 14, color: Colors.black),
+                        ),
+                      ),
+                      Image.network(
+                        'https://picsum.photos/60/60',
+                        width: 48,
+                        height: 48,
+                        fit: BoxFit.cover,
+                        errorBuilder: (ctx, err, stack) => Container(
+                          width: 48,
+                          height: 48,
+                          color: Colors.amber,
+                        ),
+                      ),
+                      const Flexible(
+                        child: Text(
+                          'Balance: 1234',
+                          style: TextStyle(fontSize: 14, color: Colors.black),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
               const SizedBox(height: 40),
             ],
           ),

--- a/example/lib/masking_tests_screen.dart
+++ b/example/lib/masking_tests_screen.dart
@@ -60,15 +60,15 @@ class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
                   text: const TextSpan(
                     style: TextStyle(fontSize: 16, color: Colors.black),
                     children: [
-                      TextSpan(text: 'This is '),
+                      TextSpan(text: 'This RichText is masked '),
                       TextSpan(
-                        text: 'sensitive data',
+                        text: 'when maskAllTexts',
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
                           color: Colors.red,
                         ),
                       ),
-                      TextSpan(text: ' that should be masked.'),
+                      TextSpan(text: ' is enabled'),
                     ],
                   ),
                 ),
@@ -78,7 +78,7 @@ class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
               _buildTestSection(
                 'Test 3: SelectableText',
                 const SelectableText(
-                  'This SelectableText should also be masked',
+                  'This SelectableText is masked when maskAllTexts is enabled',
                   style: TextStyle(fontSize: 14, color: Colors.blue),
                 ),
               ),
@@ -253,10 +253,10 @@ class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
               ),
 
               // Test 15: PostHogMaskWidget around several masked children.
-              // The avatar is not masked on its own when maskAllImages is off,
-              // so it is only covered if the wrapper itself is masked.
+              // The amber box matches no masking rule on its own, so it is
+              // covered only if the wrapper contributes its own rect.
               _buildTestSection(
-                'Test 15: PostHogMaskWidget with multiple children',
+                'Test 15: PostHogMaskWidget with multiple children (needs maskAllTexts or maskAllImages)',
                 PostHogMaskWidget(
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -267,17 +267,7 @@ class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
                           style: TextStyle(fontSize: 14, color: Colors.black),
                         ),
                       ),
-                      Image.network(
-                        'https://picsum.photos/60/60',
-                        width: 48,
-                        height: 48,
-                        fit: BoxFit.cover,
-                        errorBuilder: (ctx, err, stack) => Container(
-                          width: 48,
-                          height: 48,
-                          color: Colors.amber,
-                        ),
-                      ),
+                      Container(width: 48, height: 48, color: Colors.amber),
                       const Flexible(
                         child: Text(
                           'Balance: 1234',

--- a/posthog_flutter/lib/src/replay/element_parsers/element_data.dart
+++ b/posthog_flutter/lib/src/replay/element_parsers/element_data.dart
@@ -29,22 +29,15 @@ class ElementData {
     return elements;
   }
 
-  List<ElementData> extractRects({bool isRoot = true}) {
-    List<ElementData> rects = [];
+  /// Every node below the root is an element that already matched a masking
+  /// rule, so the whole subtree is collected — a match can sit at any depth
+  /// (a `SelectableText` puts its `RenderParagraph` several levels down).
+  List<ElementData> extractRects() {
+    final rects = <ElementData>[];
 
-    if (children != null) {
-      for (var child in children ?? []) {
-        if (child.children == null) {
-          rects.add(child);
-          continue;
-        } else if ((child.children?.length ?? 0) > 1) {
-          for (var grandChild in child.children ?? []) {
-            rects.add(grandChild);
-          }
-        } else {
-          rects.add(child);
-        }
-      }
+    for (final child in children ?? const <ElementData>[]) {
+      rects.add(child);
+      rects.addAll(child.extractRects());
     }
     return rects;
   }

--- a/posthog_flutter/lib/src/replay/element_parsers/element_data.dart
+++ b/posthog_flutter/lib/src/replay/element_parsers/element_data.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_dynamic_calls
-
 import 'package:flutter/material.dart';
 import 'package:posthog_flutter/src/replay/mask/posthog_mask_widget.dart';
 
@@ -31,7 +29,8 @@ class ElementData {
 
   /// Every node below the root is an element that already matched a masking
   /// rule, so the whole subtree is collected — a match can sit at any depth
-  /// (a `SelectableText` puts its `RenderParagraph` several levels down).
+  /// (a `ListTile` title nests `AnimatedDefaultTextStyle` → `DefaultTextStyle`
+  /// → `Text` → `RichText`).
   List<ElementData> extractRects() {
     final rects = <ElementData>[];
 

--- a/posthog_flutter/lib/src/replay/mask/posthog_mask_controller.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_mask_controller.dart
@@ -36,11 +36,6 @@ class PostHogMaskController {
 
   /// Extracts a flattened list of [ElementData] objects for every element in
   /// the widget tree that matched a masking rule, at any depth.
-  ///
-  /// **Returns:**
-  ///   - `List<ElementData>`: A list of [ElementData] objects representing the
-  ///     elements to mask.
-  ///
   List<ElementData>? getCurrentWidgetsElements() {
     final context = containerKey.currentContext;
 

--- a/posthog_flutter/lib/src/replay/mask/posthog_mask_controller.dart
+++ b/posthog_flutter/lib/src/replay/mask/posthog_mask_controller.dart
@@ -34,18 +34,12 @@ class PostHogMaskController {
     Posthog().config?.sessionReplayConfig,
   );
 
-  /// Extracts a flattened list of [ElementData] objects representing the
-  /// renderable elements in the widget tree.
-  ///
-  /// This method traverses the tree of [ElementData] objects and returns a
-  /// list of elements that have no children or only one child.
-  ///
-  /// The method is designed to extract the elements that are directly
-  /// renderable on the screen.
+  /// Extracts a flattened list of [ElementData] objects for every element in
+  /// the widget tree that matched a masking rule, at any depth.
   ///
   /// **Returns:**
   ///   - `List<ElementData>`: A list of [ElementData] objects representing the
-  ///     renderable elements.
+  ///     elements to mask.
   ///
   List<ElementData>? getCurrentWidgetsElements() {
     final context = containerKey.currentContext;

--- a/posthog_flutter/test/element_data_test.dart
+++ b/posthog_flutter/test/element_data_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:posthog_flutter/src/replay/element_parsers/element_data.dart';
+import 'package:posthog_flutter/src/replay/mask/posthog_mask_controller.dart';
+
+ElementData _node(String type, {List<ElementData>? children, Widget? widget}) {
+  return ElementData(
+    rect: const Rect.fromLTWH(0, 0, 10, 10),
+    type: type,
+    children: children,
+    widget: widget,
+  );
+}
+
+List<String> _types(List<ElementData> elements) =>
+    elements.map((e) => e.type).toList();
+
+/// Mask rects are local paint bounds plus a transform to the capture
+/// container, which is what the native SDK paints with.
+Rect _resolved(ElementData element) => MatrixUtils.transformRect(
+    element.transform ?? Matrix4.identity(), element.rect);
+
+bool _covers(List<ElementData> elements, Rect target) {
+  const epsilon = 1.0;
+  return elements.any((element) {
+    final rect = _resolved(element);
+    return rect.left <= target.left + epsilon &&
+        rect.top <= target.top + epsilon &&
+        rect.right >= target.right - epsilon &&
+        rect.bottom >= target.bottom - epsilon;
+  });
+}
+
+Future<void> _pumpMaskedApp(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    PostHogWidget(
+      child: MaterialApp(
+        home: Scaffold(body: Center(child: child)),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ElementData.extractRects', () {
+    test('returns every descendant of a deeply nested tree', () {
+      final root = _node('Root', children: [
+        _node('a', children: [
+          _node('b', children: [
+            _node('c', children: [_node('d')]),
+          ]),
+        ]),
+      ]);
+
+      expect(_types(root.extractRects()), ['a', 'b', 'c', 'd']);
+    });
+
+    test('returns direct children when the tree is flat', () {
+      final root = _node('Root', children: [_node('a'), _node('b')]);
+
+      expect(_types(root.extractRects()), ['a', 'b']);
+    });
+
+    test('keeps a node that has several children alongside the children', () {
+      // The parent matched a masking rule too, and its rect is the only one
+      // covering the gaps between the children.
+      final root = _node('Root', children: [
+        _node('parent', children: [_node('a'), _node('b')]),
+      ]);
+
+      expect(_types(root.extractRects()), ['parent', 'a', 'b']);
+    });
+
+    test('returns nothing for a childless root', () {
+      expect(_node('Root').extractRects(), isEmpty);
+    });
+  });
+
+  group('ElementData.extractMaskWidgetRects', () {
+    test('collects mask widgets and obscured fields at any depth', () {
+      final root = _node('Root', children: [
+        _node('Padding', children: [
+          _node('PostHogMaskWidget',
+              widget: const PostHogMaskWidget(child: SizedBox()),
+              children: [
+                _node('TextField',
+                    widget: const TextField(obscureText: true),
+                    children: [
+                      _node('Text', widget: const Text('visible')),
+                    ]),
+              ]),
+        ]),
+      ]);
+
+      expect(_types(root.extractMaskWidgetRects()),
+          ['PostHogMaskWidget', 'TextField']);
+    });
+
+    test('ignores fields that are not obscured', () {
+      final root = _node('Root', children: [
+        _node('TextField', widget: const TextField(obscureText: false)),
+      ]);
+
+      expect(root.extractMaskWidgetRects(), isEmpty);
+    });
+  });
+
+  group('masking a real widget tree', () {
+    testWidgets('masks the whole PostHogMaskWidget, not just its text children',
+        (tester) async {
+      // The avatar matches no masking rule of its own, so it is only covered
+      // if the wrapper contributes its own rect.
+      await _pumpMaskedApp(
+        tester,
+        PostHogMaskWidget(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Jane Doe'),
+              Container(
+                key: const Key('avatar'),
+                width: 48,
+                height: 48,
+                color: Colors.amber,
+              ),
+              const Text('Balance: 1234'),
+            ],
+          ),
+        ),
+      );
+
+      final elements =
+          PostHogMaskController.instance.getCurrentWidgetsElements()!;
+
+      expect(_covers(elements, tester.getRect(find.byKey(const Key('avatar')))),
+          isTrue);
+    });
+
+    testWidgets('masks a RichText', (tester) async {
+      await _pumpMaskedApp(
+        tester,
+        RichText(
+          text: const TextSpan(
+            style: TextStyle(fontSize: 16, color: Colors.black),
+            children: [
+              TextSpan(text: 'This is '),
+              TextSpan(text: 'sensitive data'),
+            ],
+          ),
+        ),
+      );
+
+      final elements =
+          PostHogMaskController.instance.getCurrentWidgetsElements()!;
+
+      expect(_covers(elements, tester.getRect(find.byType(RichText))), isTrue);
+    });
+
+    testWidgets('masks a SelectableText', (tester) async {
+      await _pumpMaskedApp(
+        tester,
+        const SelectableText('This SelectableText should also be masked'),
+      );
+
+      final elements =
+          PostHogMaskController.instance.getCurrentWidgetsElements()!;
+
+      expect(_covers(elements, tester.getRect(find.byType(SelectableText))),
+          isTrue);
+    });
+
+    testWidgets('still masks a plain Text', (tester) async {
+      await _pumpMaskedApp(tester, const Text('plain text'));
+
+      final elements =
+          PostHogMaskController.instance.getCurrentWidgetsElements()!;
+
+      expect(_covers(elements, tester.getRect(find.byType(Text))), isTrue);
+    });
+
+    testWidgets('still masks a TextField', (tester) async {
+      await _pumpMaskedApp(tester, const TextField());
+
+      final elements =
+          PostHogMaskController.instance.getCurrentWidgetsElements()!;
+
+      expect(
+          _covers(elements, tester.getRect(find.byType(EditableText))), isTrue);
+    });
+  });
+}

--- a/posthog_flutter/test/element_data_test.dart
+++ b/posthog_flutter/test/element_data_test.dart
@@ -17,18 +17,17 @@ List<String> _types(List<ElementData> elements) =>
     elements.map((e) => e.type).toList();
 
 /// Mask rects are local paint bounds plus a transform to the capture
-/// container, which is what the native SDK paints with.
+/// container, which is what ImageMaskPainter draws with.
 Rect _resolved(ElementData element) => MatrixUtils.transformRect(
     element.transform ?? Matrix4.identity(), element.rect);
 
 bool _covers(List<ElementData> elements, Rect target) {
-  const epsilon = 1.0;
   return elements.any((element) {
     final rect = _resolved(element);
-    return rect.left <= target.left + epsilon &&
-        rect.top <= target.top + epsilon &&
-        rect.right >= target.right - epsilon &&
-        rect.bottom >= target.bottom - epsilon;
+    return rect.left <= target.left &&
+        rect.top <= target.top &&
+        rect.right >= target.right &&
+        rect.bottom >= target.bottom;
   });
 }
 
@@ -64,8 +63,6 @@ void main() {
     });
 
     test('keeps a node that has several children alongside the children', () {
-      // The parent matched a masking rule too, and its rect is the only one
-      // covering the gaps between the children.
       final root = _node('Root', children: [
         _node('parent', children: [_node('a'), _node('b')]),
       ]);
@@ -188,6 +185,33 @@ void main() {
 
       expect(
           _covers(elements, tester.getRect(find.byType(EditableText))), isTrue);
+    });
+
+    testWidgets('does not mask a sibling that matched no rule', (tester) async {
+      await _pumpMaskedApp(
+        tester,
+        SizedBox(
+          width: 400,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('secret'),
+              Container(
+                key: const Key('plain'),
+                width: 48,
+                height: 48,
+                color: Colors.amber,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final elements =
+          PostHogMaskController.instance.getCurrentWidgetsElements()!;
+      final plain = tester.getRect(find.byKey(const Key('plain')));
+
+      expect(elements.any((e) => _resolved(e).overlaps(plain)), isFalse);
     });
   });
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

`ElementData.extractRects()` — the function that produces the list of rects the replay capturer paints black over each screenshot — was not recursive. It walked the root's direct children, and grandchildren only when a child had more than one child (dropping the child itself in that branch). Anything else was silently discarded.

Two consequences, both in shipped code:

1. **A `PostHogMaskWidget` that wraps more than one masked child loses its own mask rect.** Its matched children (the texts) are still masked, but anything the wrapper covers that does not match a masking rule on its own — an image while `maskAllImages` is off, an avatar, a decoration, the space between children — is recorded in the clear, despite the developer explicitly asking for that subtree to be masked.
2. **Matches nested more than one level deep are dropped**, so masking depended on where in the widget tree an element happened to land.

Point 1 is the one that actually leaks today. It bites specifically when `maskAllTexts` or `maskAllImages` is enabled, because in that branch `screenshot_capturer.dart` draws *only* the `extractRects()` list — the separate `getPostHogWidgetWrapperElements()` list is drawn only in the `else` branch, when both flags are off. So with `maskAllTexts: true` there is no second path that recovers the dropped wrapper.

Every node below the root of this tree already matched a masking rule (`widget_elements_decipher.dart` only attaches nodes that a parser accepted), so no node may be discarded. The fix collects the whole subtree.

This affects **shipped iOS and Android** session replay. The masks are painted into the screenshot on the Dart side by `ImageMaskPainter`, so both platforms use the same code path and both leaked. The same function is what the in-progress web canvas mask provider calls, so it is fixed there too.

### Cost

Collecting the full subtree emits more rects, including exact duplicates — a `Text` element and the `RichText` below it resolve to the same `RenderParagraph`, so they produce an identical rect. Measured on the example app's masking screen: 39 rects before, 76 after, of which 38 are unique. These are `canvas.drawRect` calls of the same black rect on a Dart-side picture (nothing extra crosses the method channel), the output image is pixel-identical, and capture is throttled — so this is left un-deduplicated rather than adding a hash set to the per-frame path.

## :green_heart: How did you test it?

**Unit tests** (`posthog_flutter/test/element_data_test.dart`, new). Tree-shape tests for `extractRects` (deep nesting, flat trees, a node with several children, empty root), regression tests for `extractMaskWidgetRects`, plus widget-level tests that pump a real tree under `PostHogWidget` and assert against `PostHogMaskController.getCurrentWidgetsElements()` — the `PostHogMaskWidget`-with-multiple-children case, `RichText`, `SelectableText`, `Text`, `TextField`. Three of them fail on `main` and pass with the fix. Full suite: 234 passing, `flutter analyze` clean, `dart format --set-exit-if-changed` clean.

**iOS simulator (iPhone 17 Pro, iOS 26.4) and Android emulator (API 37)**, example app with `maskAllTexts: true`, before and after the fix, comparing the actual masked frames the SDK produces. On both platforms, before the fix: the `PostHogMaskWidget` around a row of `Text` / unmasked widget / `Text` masks only the two texts, and **the widget between them is fully visible in the recording**; the `PostHogMaskWidget` around the password field leaves its background and border uncovered. After the fix both wrappers are covered end to end on both platforms. (The simulator runs used a network image in that slot; the committed example uses a plain coloured box instead, so the screen has no network dependency — same masking behaviour, since neither matches a rule while `maskAllImages` is off.)

Checked for over-masking in the same runs: with `maskAllImages: false`, the standalone images in tests 6–8 stay unmasked, and rotated/scaled text masks still track their transforms. Texts, `RichText`, `SelectableText`, and text fields were already masked before the fix on mobile — that part was not a regression, and this change does not alter it.

Example app: added test 15 to the masking screen, a `PostHogMaskWidget` wrapping several masked children with an unmasked widget between them, which is the shape that leaked. Tests 2 and 3 now state the config their labels depend on, matching test 1 — both are masked only when `maskAllTexts` is on, so the old unconditional wording read like a bug under the example's committed defaults.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The starting hypothesis was that `RichText` and `SelectableText` are never masked on mobile; that turned out to be wrong — both sit at the root of the matched-element tree in practice and were already masked. Dumping the real tree from the example app is what located the actual failure: the dropped `PostHogMaskWidget` wrapper. The example screen's test 15 and the widget-level test were written to reproduce that specific shape rather than the original hypothesis.

An earlier draft kept the "drop a node with more than one child" branch and only added recursion. That was discarded — with every node in the tree being a confirmed masking match, there is no rule that justifies dropping one, and keeping the branch left the wrapper leak in place. De-duplicating the resulting rects was considered and rejected on the measurement above.

Two adjacent pre-existing bugs were found and deliberately left alone:

- `PostHogMaskController.parsers` is `late final`, built once from the startup config, so changing `maskAllTexts` / `maskAllImages` at runtime never registers or unregisters the parsers.
- `element_object_parser.dart` masks `element.widget is Text` with no `maskAllTexts` check, so `maskAllImages: true` with `maskAllTexts: false` still masks all text.

Also noted, not fixed: `screenshot_capturer.dart` calls `getPostHogWidgetWrapperElements()` unconditionally and then `getCurrentWidgetsElements()`, parsing the whole render tree twice per captured frame, and discards the first result whenever `maskAllTexts` or `maskAllImages` is on.
