### PR TITLE
fix(web): don't compile the isolate error handler into wasm builds

### DIFF
--- a/.changeset/wasm-isolate-error-capture.md
+++ b/.changeset/wasm-isolate-error-capture.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+Flutter web (WebAssembly): enabling `captureIsolateErrors` no longer crashes the app at startup. The isolate error handler was selected with a `dart.library.html` conditional import, which is false under dart2wasm, so wasm builds compiled the `dart:isolate` implementation and threw `Unsupported operation: RawReceivePort` before `runApp` — a white screen. The import now keys on `dart.library.js_interop` (true for both JS and wasm web builds), and the setup guard also skips isolate wiring on web explicitly. JS web builds and mobile/desktop are unaffected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,13 @@ jobs:
         working-directory: ./posthog_flutter
         run: flutter test --platform chrome test/posthog_flutter_web_handler_test.dart test/posthog_widget_web_test.dart
 
+      # dart2js resolves the isolate-handler conditional import differently;
+      # only a wasm compile exercises the dart2wasm selection this test guards.
+      - name: Test (web, wasm)
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        working-directory: ./posthog_flutter
+        run: flutter test --platform chrome --wasm test/posthog_isolate_error_handler_web_test.dart
+
   publish-dry-run:
     needs: detect-markdown-only
     name: Pub publish dry run

--- a/posthog_flutter/lib/src/error_tracking/posthog_error_tracking_autocapture_integration.dart
+++ b/posthog_flutter/lib/src/error_tracking/posthog_error_tracking_autocapture_integration.dart
@@ -9,7 +9,7 @@ import 'package:posthog_flutter/src/util/platform_io_stub.dart'
     if (dart.library.io) 'package:posthog_flutter/src/util/platform_io_real.dart';
 
 import 'isolate_handler_io.dart'
-    if (dart.library.html) 'isolate_handler_web.dart';
+    if (dart.library.js_interop) 'isolate_handler_web.dart';
 import 'package:posthog_flutter/src/util/logging.dart';
 
 import '../posthog_flutter_platform_interface.dart';
@@ -210,8 +210,9 @@ class PostHogErrorTrackingAutoCaptureIntegration {
     }
 
     // https://docs.flutter.dev/perf/isolates#web-platforms-and-compute
-    // web has no isolates support
-    if (!isSupportedPlatform()) {
+    // web has no isolates support, and isSupportedPlatform() returns true
+    // there (its web stub reports kIsWeb), so check kIsWeb explicitly
+    if (kIsWeb || !isSupportedPlatform()) {
       return;
     }
 

--- a/posthog_flutter/test/posthog_isolate_error_handler_web_test.dart
+++ b/posthog_flutter/test/posthog_isolate_error_handler_web_test.dart
@@ -1,0 +1,25 @@
+// Only meaningful under `flutter test --platform chrome --wasm`: dart2js
+// selects the no-op web isolate handler regardless, so it passes either way.
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/error_tracking/posthog_error_tracking_autocapture_integration.dart';
+import 'package:posthog_flutter/src/posthog_config.dart';
+
+import 'posthog_flutter_platform_interface_fake.dart';
+
+void main() {
+  tearDown(PostHogErrorTrackingAutoCaptureIntegration.uninstall);
+
+  test('install with captureIsolateErrors does not throw on web', () {
+    final config = PostHogErrorTrackingConfig()..captureIsolateErrors = true;
+
+    final integration = PostHogErrorTrackingAutoCaptureIntegration.install(
+      config: config,
+      posthog: PosthogFlutterPlatformFake(),
+    );
+
+    expect(integration, isNotNull);
+  });
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Any Flutter app built with `flutter build web --wasm` that enables `captureIsolateErrors` white-screens at startup: `runApp` never executes. Found during live skwasm testing of the web canvas masking work, but the bug is pre-existing on `main` and independent of it.

The chain:

1. `posthog_error_tracking_autocapture_integration.dart` selected the isolate handler with `if (dart.library.html)`. That library only exists under dart2js — under dart2wasm it is **false**, so wasm web builds compile the `dart:isolate` implementation (`isolate_handler_io.dart`) instead of the web no-op.
2. The `isSupportedPlatform()` guard in `_setupIsolateErrorHandler` doesn't save you: on web the non-`dart:io` stub of `isSupportedPlatform()` returns `kIsWeb` — i.e. `true` — so the setup proceeds.
3. `RawReceivePort(...)` throws `Unsupported operation: RawReceivePort` inside `Posthog().setup()`, before `runApp` — white screen.

JS builds were never affected because `dart.library.html` is true there, which masked the bug.

## :hammer: What changed

- The conditional import now keys on `dart.library.js_interop` (true under both dart2js and dart2wasm), matching the convention already used by `origin.dart`, `chunk_ids.dart`, and `utils/isolate_utils.dart`. VM platforms keep the default `isolate_handler_io.dart`; JS and wasm web both get the no-op `isolate_handler_web.dart`.
- Defense in depth: `_setupIsolateErrorHandler` now checks `kIsWeb ||` before `!isSupportedPlatform()`, so even if the io handler is ever again compiled into a web target, the setup bails before touching `dart:isolate`. Behavior-preserving everywhere: on VM `kIsWeb` is false (unchanged), and on JS web the previous code path only reached a no-op anyway.
- Changeset added (patch bump).

This was the only `dart.library.html` conditional import left in the repo (`origin.dart` and `chunk_ids.dart` already use `js_interop`), so no other site has the same hazard.

Not changed: `_setupPlatformErrorHandler` has the same inverted-looking guard (its comment says "skip on web" but the web stub returns true, so it registers `PlatformDispatcher.onError` on web). That path is harmless — the setter works on web — and changing it would alter existing JS-web behavior, so it's left out of this fix.

## :green_heart: How did you test it?

**Repro before the fix** (example app, `captureIsolateErrors: true` — already the example default): built with `flutter build web --wasm`, served with COOP `same-origin` / COEP `require-corp`, opened in Chrome (skwasm active — `skwasm.wasm` fetched, `crossOriginIsolated: true`). Result: white screen, `flt-scene` never populated, no `$screen` event, and this `$exception` captured via a `posthog.on('eventCaptured')` hook:

```
value:     "Unsupported operation: RawReceivePort"
mechanism: { type: "runZonedGuarded", handled: false }
stack:     main.dart.wasm (all frames)
```

**After the fix**, same build/serve/browser: the app boots and renders the full example UI, `$screen` is captured, and no `$exception` events fire. A plain `flutter build web` (dart2js) build was also booted in Chrome as a regression check — renders normally.

Standard suites, all green:

- `flutter test` — 237 passing
- `flutter test --platform chrome test/posthog_flutter_web_handler_test.dart test/posthog_widget_web_test.dart` — 11 passing
- `flutter analyze` — no issues
- `make checkFormatDart` — 0 changed

**Regression test**: the crash is a compile-time target-selection issue that neither the VM suite nor the dart2js chrome suite can observe — on VM `kIsWeb` is false and on dart2js the no-op handler is selected either way. But `flutter test --platform chrome --wasm` does compile-select it, so this PR adds `test/posthog_isolate_error_handler_web_test.dart` plus a one-file "Test (web, wasm)" CI step. Verified in both directions: the test passes on this branch and fails against `main`'s handler selection with exactly `Unsupported operation: RawReceivePort`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Changeset file added (`.changeset/wasm-isolate-error-capture.md`, patch)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The bug was observed empirically on a skwasm build during canvas-masking live-testing; the agent confirmed the failure chain (conditional import → inverted web stub guard → `RawReceivePort` throw), reproduced it in Chrome before the fix, and verified the fix on both wasm and JS builds. The guard fix deliberately adds `kIsWeb ||` at the one broken call site rather than flipping the `isSupportedPlatform()` web stub itself, because that stub is shared with `posthog_flutter_io.dart` and flipping its return value on web would have a much larger blast radius than this fix needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

