### PR TITLE
fix: clean up CI warnings

### DIFF
--- a/.changeset/calm-builds-pass.md
+++ b/.changeset/calm-builds-pass.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Clean up Android and macOS build warnings.

--- a/.changeset/calm-builds-pass.md
+++ b/.changeset/calm-builds-pass.md
@@ -2,4 +2,4 @@
 'posthog_flutter': patch
 ---
 
-Clean up Android and macOS build warnings.
+Clean up Android build warnings.

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@eea2a62aa490b1bfa2e2b3488fc0042b89cfa5ed # main @ 2026-07-27
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -345,7 +345,6 @@
 		};
 		33CC111E2044C6BF0003C045 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		};
 		33CC111E2044C6BF0003C045 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PostHogDisplaySurveyExt.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PostHogDisplaySurveyExt.kt
@@ -24,7 +24,7 @@ fun PostHogDisplaySurvey.toMap(): Map<String, Any?> {
                         )
 
                     questionMap["questionDescription"] = question.questionDescription
-                    questionMap["questionDescriptionContentType"] = question.questionDescriptionContentType?.value
+                    questionMap["questionDescriptionContentType"] = question.questionDescriptionContentType.value
                     questionMap["buttonText"] = question.buttonText
 
                     // Add question type-specific properties

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -1402,7 +1402,7 @@ class PosthogFlutterPlugin :
     ) {
         try {
             val featureFlagKey: String = call.argument("key")!!
-            val flag = PostHog.getFeatureFlagPayload(featureFlagKey)
+            val flag = PostHog.getFeatureFlagResult(featureFlagKey, sendFeatureFlagEvent = false)?.payload
             result.success(flag)
         } catch (e: Throwable) {
             result.error("PosthogFlutterException", e.localizedMessage, null)
@@ -1737,12 +1737,14 @@ class PosthogFlutterPlugin :
         result: Result,
     ) {
         try {
+            @Suppress("UNCHECKED_CAST")
             val arguments =
                 call.arguments as? Map<String, Any> ?: run {
                     result.error("INVALID_ARGUMENTS", "Invalid arguments for captureException", null)
                     return
                 }
 
+            @Suppress("UNCHECKED_CAST")
             val properties = arguments["properties"] as? Map<String, Any>
             val timestampMs = arguments["timestamp"] as? Long
 
@@ -1867,6 +1869,7 @@ class PosthogFlutterPlugin :
         call: MethodCall,
         result: Result,
     ) {
+        @Suppress("UNCHECKED_CAST")
         val args = call.arguments as? Map<String, Any>
         val type = args?.get("type") as? String
 


### PR DESCRIPTION
## :bulb: Motivation and Context

A full CI-log audit of #503 found several non-blocking warnings and two issues in the SDK compliance wrapper: its pinned actions still targeted Node 20, and the configured concurrency was not always forwarded to the harness.

The same audit found avoidable warnings in the Android bridge.

## :hammer: What changed

- Updated the pinned `posthog-sdk-test-harness` reusable workflow to a revision that uses Node 24 actions and always forwards the configured concurrency.
- Replaced Android's deprecated `getFeatureFlagPayload` call with the equivalent `getFeatureFlagResult(..., sendFeatureFlagEvent = false)?.payload` path, preserving the existing no-event behavior.
- Removed an unnecessary Kotlin safe call and narrowly suppressed unavoidable generic-map cast warnings at Flutter method-channel boundaries.
- Added a patch changeset.

## :green_heart: How did you test it?

- `make checkFormatKotlin`
- `flutter build apk`
- `./gradlew :posthog_flutter:testDebugUnitTest` on JDK 17 — 15 passing
- Verified the targeted Android source warnings are absent from the resulting logs
- Bundle-driven autoreview — clean, with no P0/P1 findings

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi audited the CI logs, implemented the targeted warning fixes in a dedicated worktree, and ran the Android build plus Android unit tests. The unchecked method-channel casts remain behavior-preserving and use narrow suppressions after review identified that replacing them with generic accessors would change malformed-input handling. A bundle-driven autoreview completed cleanly.
