### PR TITLE
test: snapshot event and request shapes

### DIFF
--- a/posthog_flutter/test/event_shape_snapshot_test.dart
+++ b/posthog_flutter/test/event_shape_snapshot_test.dart
@@ -1,0 +1,270 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:posthog_flutter/src/posthog_flutter_io.dart';
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+const _updateSnapshots = bool.fromEnvironment('UPDATE_EVENT_SHAPE_SNAPSHOTS');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('posthog_flutter');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  final calls = <MethodCall>[];
+
+  setUp(() async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+    PosthogFlutterPlatformInterface.instance = PosthogFlutterIO();
+    await Posthog().close();
+    calls.clear();
+  });
+
+  tearDown(() async {
+    await Posthog().close();
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('snapshots the Flutter-owned setup request parameters', () async {
+    final config = PostHogConfig('snapshot_project_token')
+      ..host = 'https://eu.i.posthog.com'
+      ..flushAt = 12
+      ..maxQueueSize = 800
+      ..maxBatchSize = 25
+      ..flushInterval = const Duration(seconds: 15)
+      ..sendFeatureFlagEvents = false
+      ..preloadFeatureFlags = false
+      ..captureApplicationLifecycleEvents = false
+      ..personProfiles = PostHogPersonProfiles.always
+      ..sessionReplay = true
+      ..capturePushNotificationSubscriptions = false
+      ..capturePushNotificationOpened = false
+      ..bootstrap = const PostHogBootstrapConfig(
+        distinctId: 'snapshot-user',
+        isIdentifiedId: true,
+        featureFlags: {'checkout': 'variant-a'},
+        featureFlagPayloads: {
+          'checkout': {'color': 'blue'},
+        },
+      );
+    config.sessionReplayConfig
+      ..maskAllImages = false
+      ..sampleRate = 0.25;
+    config.errorTrackingConfig
+      ..inAppIncludes.add('package:snapshot_app')
+      ..captureFlutterErrors = true;
+    config.logsConfig
+      ..serviceName = 'checkout-app'
+      ..serviceVersion = '1.2.3'
+      ..environment = 'test'
+      ..resourceAttributes = {'region': 'eu'}
+      ..flushAt = 10;
+
+    await Posthog().setup(config);
+
+    await _expectSnapshot('setup_request.json', calls);
+  });
+
+  test('snapshots event and identity channel shapes', () async {
+    final config = PostHogConfig(
+      'snapshot_project_token',
+      beforeSend: [
+        (event) {
+          event.properties = {
+            ...?event.properties,
+            'snapshot_before_send': 'event',
+          };
+          return event;
+        },
+      ],
+    );
+    await Posthog().setup(config);
+    calls.clear();
+
+    await Posthog().screen(
+      screenName: 'Checkout',
+      properties: {
+        'cart_size': 3,
+        'route': {'source': 'email', 'coupon': null},
+      },
+    );
+    await Posthog().capture(
+      eventName: 'order completed',
+      properties: {
+        'order_id': 'ord_123',
+        'total': 42.5,
+        'items': [
+          {'sku': 'sku_1', 'quantity': 2, 'note': null},
+        ],
+        'placed_at': DateTime.utc(2024, 3, 1, 12, 30),
+        r'$set': {'plan': 'legacy', 'legacy_only': true},
+        r'$set_once': {'first_checkout_at': '2024-03-01'},
+      },
+      userProperties: {'plan': 'pro', 'email_verified': true},
+      userPropertiesSetOnce: {'signup_source': 'invite'},
+    );
+    await Posthog().identify(
+      userId: 'user_123',
+      userProperties: {
+        'email': 'person@example.com',
+        'profile': {'role': 'admin', 'nickname': null},
+      },
+      userPropertiesSetOnce: {'created_at': DateTime.utc(2024, 1, 1)},
+    );
+    await Posthog().setPersonProperties(
+      userPropertiesToSet: {'plan': 'enterprise'},
+      userPropertiesToSetOnce: {'first_team': 'growth'},
+    );
+    await Posthog().alias(alias: 'legacy_user_456');
+    await Posthog().group(
+      groupType: 'company',
+      groupKey: 'posthog',
+      groupProperties: {'industry': 'analytics', 'employees': 100},
+    );
+    await Posthog().setPersonPropertiesForFlags({
+      'plan': 'enterprise',
+      'seats': 25,
+    }, reloadFeatureFlags: false);
+    await Posthog().setGroupPropertiesForFlags(
+        'company',
+        {
+          'region': 'eu',
+          'employees': 100,
+        },
+        reloadFeatureFlags: false);
+
+    await _expectSnapshot('event_channel_shapes.json', calls);
+  });
+
+  test('snapshots applicable Flutter-built special event parameters', () async {
+    final config = PostHogConfig(
+      'snapshot_project_token',
+      beforeSend: [
+        (event) {
+          event.properties = {
+            ...?event.properties,
+            'snapshot_before_send': 'event',
+          };
+          return event;
+        },
+      ],
+    );
+    config.logsConfig.beforeSend = [
+      (record) {
+        record.attributes = {
+          ...?record.attributes,
+          'snapshot_before_send': 'log',
+        };
+        return record;
+      },
+    ];
+    await Posthog().setup(config);
+    calls.clear();
+
+    await Posthog().captureLog(
+      body: 'checkout completed',
+      level: PostHogLogSeverity.warn,
+      attributes: {
+        'order_id': 'ord_123',
+        'attempted_at': DateTime.utc(2024, 3, 1, 12, 30),
+      },
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      traceFlags: 0,
+    );
+    await Posthog().captureException(
+      error: StateError('checkout failed'),
+      stackTrace: Chain.parse(
+        '#0      CheckoutService.submit '
+        '(package:snapshot_app/checkout.dart:42:7)\n'
+        '#1      main (package:snapshot_app/main.dart:10:3)',
+      ),
+      properties: {
+        'order_id': 'ord_123',
+        'attempted_at': DateTime.utc(2024, 3, 1, 12, 30),
+      },
+    );
+    await Posthog().captureRunZonedGuardedError(
+      error: ArgumentError('zoned checkout failure'),
+      stackTrace: Chain.parse(
+        '#0      CheckoutZone.run '
+        '(package:snapshot_app/zone.dart:21:5)\n'
+        '#1      main (package:snapshot_app/main.dart:12:3)',
+      ),
+      properties: {'zone': 'checkout'},
+    );
+    await Posthog().addExceptionStep(
+      'User tapped Checkout',
+      properties: {'screen': 'cart', 'item_count': 3},
+    );
+    await Posthog().capturePushNotificationOpened(
+      title: 'Order ready',
+      subtitle: 'Pickup available',
+      body: 'Tap to view order ord_123',
+      payload: {
+        'posthog': {'campaign_id': 'campaign_123', 'delivery': null},
+      },
+      action: 'view_order',
+    );
+
+    final normalizedCalls = calls.map((call) {
+      if (call.method != 'captureException') {
+        return call;
+      }
+
+      final arguments = Map<String, Object?>.from(call.arguments as Map);
+      expect(arguments['timestamp'], isA<int>());
+      arguments['timestamp'] = '<timestamp-ms>';
+
+      final properties = Map<String, Object?>.from(
+        arguments['properties'] as Map,
+      );
+      final exceptionList = List<Object?>.from(
+        properties[r'$exception_list'] as List,
+      );
+      final exception = Map<String, Object?>.from(exceptionList.single! as Map);
+      expect(exception['thread_id'], isA<int>());
+      exception['thread_id'] = '<thread-id>';
+      exceptionList[0] = exception;
+      properties[r'$exception_list'] = exceptionList;
+      arguments['properties'] = properties;
+
+      return MethodCall(call.method, arguments);
+    }).toList();
+
+    await _expectSnapshot('special_event_channel_shapes.json', normalizedCalls);
+  });
+}
+
+Future<void> _expectSnapshot(String name, List<MethodCall> calls) async {
+  final snapshotFile = File('test/snapshots/$name');
+  final actual = calls
+      .map(
+        (call) => <String, Object?>{
+          'method': call.method,
+          'arguments': call.arguments,
+        },
+      )
+      .toList();
+  final formatted = const JsonEncoder.withIndent('  ').convert(actual);
+
+  if (_updateSnapshots) {
+    await snapshotFile.parent.create(recursive: true);
+    await snapshotFile.writeAsString('$formatted\n');
+  }
+
+  expect(
+    '$formatted\n',
+    await snapshotFile.readAsString(),
+    reason: 'Update this explicit fixture only after reviewing the shape diff. '
+        'Run with --dart-define=UPDATE_EVENT_SHAPE_SNAPSHOTS=true to accept it.',
+  );
+}

--- a/posthog_flutter/test/snapshots/README.md
+++ b/posthog_flutter/test/snapshots/README.md
@@ -1,0 +1,12 @@
+# Event shape snapshots
+
+These fixtures pin the latest deterministic boundary owned by the Flutter package: public Dart API calls after Flutter-side enrichment, `beforeSend` processing, property normalization, and conversion to platform-channel method arguments.
+
+The embedded Android and Apple SDKs add device, identity, session, and other system properties, then build and encode ingestion and feature-flag network requests. Flutter does not receive those final events or decoded wire requests, so their snapshots belong in the native SDK repositories. Flutter web similarly delegates final enrichment and serialization to posthog-js. These fixtures intentionally do not duplicate those downstream snapshots.
+
+To accept an intentional Flutter-owned shape change after reviewing the diff, run:
+
+```sh
+flutter test test/event_shape_snapshot_test.dart \
+  --dart-define=UPDATE_EVENT_SHAPE_SNAPSHOTS=true
+```

--- a/posthog_flutter/test/snapshots/event_channel_shapes.json
+++ b/posthog_flutter/test/snapshots/event_channel_shapes.json
@@ -1,0 +1,105 @@
+[
+  {
+    "method": "screen",
+    "arguments": {
+      "screenName": "Checkout",
+      "properties": {
+        "cart_size": 3,
+        "route": {
+          "source": "email"
+        },
+        "snapshot_before_send": "event"
+      }
+    }
+  },
+  {
+    "method": "capture",
+    "arguments": {
+      "eventName": "order completed",
+      "properties": {
+        "order_id": "ord_123",
+        "total": 42.5,
+        "items": [
+          {
+            "sku": "sku_1",
+            "quantity": 2
+          }
+        ],
+        "placed_at": "2024-03-01 12:30:00.000Z",
+        "$screen_name": "Checkout",
+        "snapshot_before_send": "event"
+      },
+      "userProperties": {
+        "plan": "pro",
+        "legacy_only": true,
+        "email_verified": true
+      },
+      "userPropertiesSetOnce": {
+        "first_checkout_at": "2024-03-01",
+        "signup_source": "invite"
+      }
+    }
+  },
+  {
+    "method": "identify",
+    "arguments": {
+      "userId": "user_123",
+      "userProperties": {
+        "email": "person@example.com",
+        "profile": {
+          "role": "admin"
+        }
+      },
+      "userPropertiesSetOnce": {
+        "created_at": "2024-01-01 00:00:00.000Z"
+      }
+    }
+  },
+  {
+    "method": "setPersonProperties",
+    "arguments": {
+      "userPropertiesToSet": {
+        "plan": "enterprise"
+      },
+      "userPropertiesToSetOnce": {
+        "first_team": "growth"
+      }
+    }
+  },
+  {
+    "method": "alias",
+    "arguments": {
+      "alias": "legacy_user_456"
+    }
+  },
+  {
+    "method": "group",
+    "arguments": {
+      "groupType": "company",
+      "groupKey": "posthog",
+      "groupProperties": {
+        "industry": "analytics",
+        "employees": 100
+      }
+    }
+  },
+  {
+    "method": "setPersonPropertiesForFlags",
+    "arguments": {
+      "userProperties": {
+        "plan": "enterprise",
+        "seats": 25
+      }
+    }
+  },
+  {
+    "method": "setGroupPropertiesForFlags",
+    "arguments": {
+      "groupType": "company",
+      "groupProperties": {
+        "region": "eu",
+        "employees": 100
+      }
+    }
+  }
+]

--- a/posthog_flutter/test/snapshots/setup_request.json
+++ b/posthog_flutter/test/snapshots/setup_request.json
@@ -1,0 +1,71 @@
+[
+  {
+    "method": "setup",
+    "arguments": {
+      "projectToken": "snapshot_project_token",
+      "apiKey": "snapshot_project_token",
+      "host": "https://eu.i.posthog.com",
+      "flushAt": 12,
+      "maxQueueSize": 800,
+      "maxBatchSize": 25,
+      "flushInterval": 15,
+      "sendFeatureFlagEvents": false,
+      "preloadFeatureFlags": false,
+      "captureApplicationLifecycleEvents": false,
+      "debug": false,
+      "optOut": false,
+      "surveys": true,
+      "personProfiles": "always",
+      "sessionReplay": true,
+      "dataMode": "any",
+      "sessionReplayConfig": {
+        "maskAllImages": false,
+        "maskAllTexts": true,
+        "throttleDelayMs": 1000,
+        "maskAllPlatformViews": true,
+        "captureNativeScreens": false,
+        "sampleRate": 0.25
+      },
+      "errorTrackingConfig": {
+        "inAppIncludes": [
+          "package:snapshot_app"
+        ],
+        "inAppExcludes": [],
+        "inAppByDefault": true,
+        "captureFlutterErrors": true,
+        "captureSilentFlutterErrors": false,
+        "capturePlatformDispatcherErrors": false,
+        "captureNativeExceptions": false,
+        "captureIsolateErrors": false,
+        "exceptionSteps": {
+          "enabled": true,
+          "maxBytes": 32768
+        }
+      },
+      "logs": {
+        "serviceName": "checkout-app",
+        "serviceVersion": "1.2.3",
+        "environment": "test",
+        "resourceAttributes": {
+          "region": "eu"
+        },
+        "flushAt": 10
+      },
+      "capturePushNotificationSubscriptions": false,
+      "capturePushNotificationOpened": false,
+      "pushIdentityProviderEnabled": false,
+      "bootstrap": {
+        "distinctId": "snapshot-user",
+        "isIdentifiedId": true,
+        "featureFlags": {
+          "checkout": "variant-a"
+        },
+        "featureFlagPayloads": {
+          "checkout": {
+            "color": "blue"
+          }
+        }
+      }
+    }
+  }
+]

--- a/posthog_flutter/test/snapshots/special_event_channel_shapes.json
+++ b/posthog_flutter/test/snapshots/special_event_channel_shapes.json
@@ -1,0 +1,138 @@
+[
+  {
+    "method": "captureLog",
+    "arguments": {
+      "body": "checkout completed",
+      "level": "warn",
+      "attributes": {
+        "order_id": "ord_123",
+        "attempted_at": "2024-03-01 12:30:00.000Z",
+        "snapshot_before_send": "log"
+      },
+      "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+      "spanId": "00f067aa0ba902b7",
+      "traceFlags": 0
+    }
+  },
+  {
+    "method": "captureException",
+    "arguments": {
+      "timestamp": "<timestamp-ms>",
+      "properties": {
+        "$exception_level": "error",
+        "$exception_list": [
+          {
+            "type": "StateError",
+            "mechanism": {
+              "handled": true,
+              "synthetic": false,
+              "type": "generic"
+            },
+            "value": "Bad state: checkout failed",
+            "stacktrace": {
+              "frames": [
+                {
+                  "platform": "dart",
+                  "abs_path": "package:snapshot_app/main.dart",
+                  "in_app": true,
+                  "package": "snapshot_app",
+                  "function": "main",
+                  "filename": "main.dart",
+                  "lineno": 10,
+                  "colno": 3
+                },
+                {
+                  "platform": "dart",
+                  "abs_path": "package:snapshot_app/checkout.dart",
+                  "in_app": true,
+                  "package": "snapshot_app",
+                  "function": "CheckoutService.submit",
+                  "filename": "checkout.dart",
+                  "lineno": 42,
+                  "colno": 7
+                }
+              ],
+              "type": "raw"
+            },
+            "thread_id": "<thread-id>"
+          }
+        ],
+        "order_id": "ord_123",
+        "attempted_at": "2024-03-01 12:30:00.000Z",
+        "snapshot_before_send": "event"
+      }
+    }
+  },
+  {
+    "method": "captureException",
+    "arguments": {
+      "timestamp": "<timestamp-ms>",
+      "properties": {
+        "$exception_level": "error",
+        "$exception_list": [
+          {
+            "type": "ArgumentError",
+            "mechanism": {
+              "handled": false,
+              "synthetic": false,
+              "type": "runZonedGuarded"
+            },
+            "value": "Invalid argument(s): zoned checkout failure",
+            "stacktrace": {
+              "frames": [
+                {
+                  "platform": "dart",
+                  "abs_path": "package:snapshot_app/main.dart",
+                  "in_app": true,
+                  "package": "snapshot_app",
+                  "function": "main",
+                  "filename": "main.dart",
+                  "lineno": 12,
+                  "colno": 3
+                },
+                {
+                  "platform": "dart",
+                  "abs_path": "package:snapshot_app/zone.dart",
+                  "in_app": true,
+                  "package": "snapshot_app",
+                  "function": "CheckoutZone.run",
+                  "filename": "zone.dart",
+                  "lineno": 21,
+                  "colno": 5
+                }
+              ],
+              "type": "raw"
+            },
+            "thread_id": "<thread-id>"
+          }
+        ],
+        "zone": "checkout",
+        "snapshot_before_send": "event"
+      }
+    }
+  },
+  {
+    "method": "addExceptionStep",
+    "arguments": {
+      "message": "User tapped Checkout",
+      "properties": {
+        "screen": "cart",
+        "item_count": 3
+      }
+    }
+  },
+  {
+    "method": "capturePushNotificationOpened",
+    "arguments": {
+      "title": "Order ready",
+      "subtitle": "Pickup available",
+      "body": "Tap to view order ord_123",
+      "payload": {
+        "posthog": {
+          "campaign_id": "campaign_123"
+        }
+      },
+      "action": "view_order"
+    }
+  }
+]


### PR DESCRIPTION
## :bulb: Motivation and Context

Material changes to Flutter-owned method-channel event and setup parameters should require an explicit golden update. This brings the deterministic coverage introduced for the browser in [d0933e1](https://github.com/PostHog/posthog-js/commit/d0933e1bcb600957b82e37d72dab895ceed16e27) to the Flutter SDK's applicable boundary.

The fixtures cover setup, capture, screen, identify, person properties, alias, groups, feature-flag properties, logs, exceptions, zoned errors, and exception steps. They intentionally cover Flutter-owned channel parameters rather than native enrichment or HTTP serialization. Recording requires `--dart-define=UPDATE_EVENT_SHAPE_SNAPSHOTS=true`.

## :green_heart: How did you test it?

In an isolated package copy compatible with the locally installed Flutter SDK:

- `flutter test test/event_shape_snapshot_test.dart`
- `flutter analyze test/event_shape_snapshot_test.dart`
- `dart format --output=none --set-exit-if-changed test/event_shape_snapshot_test.dart`
- Parsed all JSON fixtures

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and built-in reviewer subagents in a local session. The method-channel boundary was chosen because native SDKs own final mobile enrichment and request serialization, while Flutter owns these dispatch parameters.
