### PR TITLE
feat: expose iOS rage click configuration

### DIFF
--- a/.changeset/fuzzy-rage-clicks-config.md
+++ b/.changeset/fuzzy-rage-clicks-config.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": minor
+---
+
+Expose iOS and Mac Catalyst rage-click autocapture settings through `PostHogConfig.rageClickConfig`. Apps can disable `$rageclick` capture or configure its distance, timeout, and tap-count thresholds.

--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -2279,6 +2279,17 @@
                         "isReadable": true,
                         "isStatic": false,
                         "isWriteable": true,
+                        "name": "rageClickConfig",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "PostHogRageClickConfig"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
                         "name": "debug",
                         "relativePath": "lib/src/posthog_config.dart",
                         "typeName": "bool"
@@ -2443,6 +2454,93 @@
                 "isRequired": false,
                 "isSealed": false,
                 "name": "PostHogConfig",
+                "relativePath": "lib/src/posthog_config.dart",
+                "superTypeNames": [
+                    "Object"
+                ],
+                "typeParameterNames": []
+            },
+            {
+                "entryPoints": [
+                    "posthog_flutter.dart"
+                ],
+                "executableDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "toMap",
+                        "parameters": [],
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "returnTypeName": "Map<String, Object>",
+                        "type": "method",
+                        "typeParameterNames": []
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isStatic": false,
+                        "name": "new",
+                        "parameters": [],
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "returnTypeName": "PostHogRageClickConfig",
+                        "type": "constructor",
+                        "typeParameterNames": []
+                    }
+                ],
+                "fieldDeclarations": [
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "enabled",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "bool"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "thresholdPoints",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "double"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "timeoutInterval",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "Duration"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
+                        "name": "minimumTapCount",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "int"
+                    }
+                ],
+                "isDeprecated": false,
+                "isExperimental": false,
+                "isRequired": false,
+                "isSealed": false,
+                "name": "PostHogRageClickConfig",
                 "relativePath": "lib/src/posthog_config.dart",
                 "superTypeNames": [
                     "Object"

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -211,6 +211,21 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             }
         }
         #if os(iOS)
+            if let rageClickConfigMap = posthogConfig["rageClickConfig"] as? [String: Any] {
+                if let enabled = rageClickConfigMap["enabled"] as? Bool {
+                    config.rageClickConfig.enabled = enabled
+                }
+                if let thresholdPoints = rageClickConfigMap["thresholdPoints"] as? NSNumber {
+                    config.rageClickConfig.thresholdPoints = CGFloat(thresholdPoints.doubleValue)
+                }
+                if let timeoutInterval = rageClickConfigMap["timeoutInterval"] as? NSNumber {
+                    config.rageClickConfig.timeoutInterval = timeoutInterval.doubleValue
+                }
+                if let minimumTapCount = rageClickConfigMap["minimumTapCount"] as? NSNumber {
+                    config.rageClickConfig.minimumTapCount = minimumTapCount.intValue
+                }
+            }
+
             // configure session replay
             if let sessionReplay = posthogConfig["sessionReplay"] as? Bool {
                 config.sessionReplay = sessionReplay

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -144,6 +144,11 @@ class PostHogConfig {
   /// events where supported by the platform. Defaults to `true`.
   var captureApplicationLifecycleEvents = true;
 
+  /// Configuration for rage-click autocapture on iOS and Mac Catalyst.
+  ///
+  /// Rage-click autocapture is not currently supported on other platforms.
+  var rageClickConfig = PostHogRageClickConfig();
+
   /// Whether the SDK emits verbose debug logs.
   ///
   /// Defaults to `false`.
@@ -385,6 +390,7 @@ class PostHogConfig {
       'sendFeatureFlagEvents': sendFeatureFlagEvents,
       'preloadFeatureFlags': preloadFeatureFlags,
       'captureApplicationLifecycleEvents': captureApplicationLifecycleEvents,
+      'rageClickConfig': rageClickConfig.toMap(),
       'debug': debug,
       'optOut': optOut,
       'surveys': surveys,
@@ -619,6 +625,46 @@ class PostHogLogsConfig {
   /// set, say, 500ms. Floor at 1s, the smallest value the native API can honor.
   static int _wholeSeconds(Duration duration) =>
       duration.inSeconds < 1 ? 1 : duration.inSeconds;
+}
+
+/// Configuration for rage-click autocapture on iOS and Mac Catalyst.
+///
+/// Assign an instance to [PostHogConfig.rageClickConfig] before calling
+/// `Posthog().setup(config)`. Other platforms ignore this configuration.
+class PostHogRageClickConfig {
+  /// Creates a rage-click configuration using the native defaults.
+  PostHogRageClickConfig();
+
+  /// Whether rapid repeated taps are captured as `$rageclick` events.
+  ///
+  /// Defaults to `true`.
+  var enabled = true;
+
+  /// Maximum Manhattan distance, in logical points, between consecutive taps.
+  ///
+  /// Defaults to `30`.
+  var thresholdPoints = 30.0;
+
+  /// Maximum time between consecutive taps in the same sequence.
+  ///
+  /// Defaults to one second.
+  var timeoutInterval = const Duration(seconds: 1);
+
+  /// Number of consecutive taps required to capture a rage click.
+  ///
+  /// Defaults to `3`.
+  var minimumTapCount = 3;
+
+  /// Converts this rage-click configuration to a platform-channel map.
+  Map<String, Object> toMap() {
+    return {
+      'enabled': enabled,
+      'thresholdPoints': thresholdPoints,
+      'timeoutInterval':
+          timeoutInterval.inMicroseconds / Duration.microsecondsPerSecond,
+      'minimumTapCount': minimumTapCount,
+    };
+  }
 }
 
 /// Configuration for mobile session replay capture and masking.

--- a/posthog_flutter/test/posthog_test.dart
+++ b/posthog_flutter/test/posthog_test.dart
@@ -181,6 +181,36 @@ void main() {
       expect(config.toMap()['host'], equals('https://us.i.posthog.com'));
     });
 
+    test('serializes the default rage-click configuration', () {
+      final config = PostHogConfig('test_project_token');
+
+      expect(config.rageClickConfig.toMap(), {
+        'enabled': true,
+        'thresholdPoints': 30.0,
+        'timeoutInterval': 1.0,
+        'minimumTapCount': 3,
+      });
+      expect(
+        config.toMap()['rageClickConfig'],
+        config.rageClickConfig.toMap(),
+      );
+    });
+
+    test('serializes overridden rage-click configuration', () {
+      final config = PostHogConfig('test_project_token')
+        ..rageClickConfig.enabled = false
+        ..rageClickConfig.thresholdPoints = 12.5
+        ..rageClickConfig.timeoutInterval = const Duration(milliseconds: 500)
+        ..rageClickConfig.minimumTapCount = 5;
+
+      expect(config.rageClickConfig.toMap(), {
+        'enabled': false,
+        'thresholdPoints': 12.5,
+        'timeoutInterval': 0.5,
+        'minimumTapCount': 5,
+      });
+    });
+
     test('session replay masks all platform views by default', () {
       final config = PostHogConfig('test_project_token');
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Flutter applications could not configure the rage-click detector provided by `posthog-ios`, including disabling it when the captured signal is not useful. This exposes the native configuration through `PostHogConfig`.

Closes #517.

The new `PostHogRageClickConfig` mirrors the four native iOS settings: `enabled`, `thresholdPoints`, `timeoutInterval`, and `minimumTapCount`. The Darwin bridge applies them on iOS and Mac Catalyst. Other platforms ignore the configuration because they do not currently implement rage-click detection.

## :green_heart: How did you test it?

- Added Dart tests for default and overridden configuration serialization.
- Ran the full Flutter test suite (267 tests).
- Ran Dart analysis, Dart/Swift formatting checks, and the public API snapshot check.
- Built the example application for the iOS simulator and macOS debug targets.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and checked with its read-only reviewer agent. The API mirrors `posthog-ios` rather than introducing Flutter-specific semantics, and the native bridge is intentionally limited to Apple platforms because `posthog-android` does not implement rage-click detection.
