### PR TITLE
test: include rage click config in setup snapshot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "pub"
-    cooldown:
-      default-days: 7
-    directory: "/"
-    schedule:
-      interval: weekly
-    groups:
-      pub-dependencies:
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    cooldown:
-      default-days: 7
-    directory: "/"
-    schedule:
-      interval: weekly
-    groups:
-      release-tooling:
-        patterns:
-          - "*"
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7
     directory: "/"
     schedule:
       interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"
     groups:
       codeql-action:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,31 @@
 version: 2
 updates:
+  - package-ecosystem: "pub"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
     groups:
       codeql-action:
         patterns:

--- a/posthog_flutter/test/snapshots/setup_request.json
+++ b/posthog_flutter/test/snapshots/setup_request.json
@@ -12,6 +12,12 @@
       "sendFeatureFlagEvents": false,
       "preloadFeatureFlags": false,
       "captureApplicationLifecycleEvents": false,
+      "rageClickConfig": {
+        "enabled": true,
+        "thresholdPoints": 30.0,
+        "timeoutInterval": 1.0,
+        "minimumTapCount": 3
+      },
       "debug": false,
       "optOut": false,
       "surveys": true,


### PR DESCRIPTION
## :bulb: Motivation and Context

The setup request snapshot does not include the default `rageClickConfig` fields added on `main`. The test job fails because the serialized setup request now contains these fields.

## :green_heart: How did you test it?

- Ran `flutter test test/event_shape_snapshot_test.dart`. All 3 tests passed.
- Ran the full `posthog_flutter` test suite. All 270 tests passed.
- Ran `git diff --check`.
- Ran autoreview against `origin/main` at `7aebc53`. It reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi agent updated the explicit setup request fixture with the default rage click configuration. The earlier Dependabot configuration change was reverted because it belongs to another pull request.
