### PR TITLE
fix: exclude privacy manifest from CocoaPods sources

### DIFF
--- a/.changeset/clean-swift-packages.md
+++ b/.changeset/clean-swift-packages.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Limit CocoaPods source compilation to Swift files when packaging the Darwin plugin.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,11 @@ jobs:
 
       - name: Enable Swift Package Manager
         if: ${{ needs.detect-markdown-only.outputs.markdown_only != 'true' && (matrix.package_manager == 'spm') }}
-        run: flutter config --enable-swift-package-manager # flutter config --no-enable-swift-package-manager
+        run: flutter config --enable-swift-package-manager
+
+      - name: Disable Swift Package Manager
+        if: ${{ needs.detect-markdown-only.outputs.markdown_only != 'true' && (matrix.package_manager == 'cocoapods') }}
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Install dependencies
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -15,7 +15,7 @@ Postog flutter plugin
   s.source           = { :path => '.' }
   s.social_media_url = 'https://twitter.com/PostHog'
 
-  s.source_files = 'posthog_flutter/Sources/posthog_flutter/**/*'
+  s.source_files = 'posthog_flutter/Sources/posthog_flutter/**/*.swift'
   s.resource_bundles = { "PostHogFlutter" => "posthog_flutter/Sources/posthog_flutter/PrivacyInfo.xcprivacy" }
   
   s.ios.dependency 'Flutter'


### PR DESCRIPTION
## :bulb: Motivation and Context

Flutter 3.44 enables Swift Package Manager by default. The CocoaPods rows in the Apple build matrix did not disable it, so those jobs no longer guaranteed that the plugin's CocoaPods integration was tested.

The podspec also included every file under the Swift source directory in `source_files`. This caused CocoaPods to treat `PrivacyInfo.xcprivacy` as a source file and report that Xcode had no rule to process it.

## :green_heart: How did you test it?

- Ran `pod lib lint posthog_flutter/darwin/posthog_flutter.podspec --configuration=Debug --skip-tests --use-modular-headers --use-libraries --allow-warnings`.
- Ran the same CocoaPods lint without `--use-libraries`.
- Parsed the workflow YAML.
- Ran `swift package dump-package` for the plugin package.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi reviewed Flutter's current Swift Package Manager guidance and the plugin's Darwin packaging. It updated the CocoaPods source glob and made each CI matrix row explicitly select its package manager. Pi autoreview found no actionable issues in the final branch diff.
