### PR TITLE
fix(web): handle exception capture failures

### DIFF
--- a/.changeset/soft-owls-listen.md
+++ b/.changeset/soft-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Handle posthog-js errors raised while capturing exceptions on web.

--- a/posthog_flutter/analysis_options.yaml
+++ b/posthog_flutter/analysis_options.yaml
@@ -1,7 +1,4 @@
 analyzer:
-  errors:
-    # Remove after https://github.com/PostHog/posthog-flutter/pull/532 merges.
-    unawaited_return_in_try_block: ignore
   exclude:
     - build/**
     - android/**

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -430,8 +430,8 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
       return await handleWebMethodCall(
         MethodCall('captureException', {'properties': normalizedData}),
       );
-    } on Exception catch (exception) {
-      printIfDebug('Exception in captureException: $exception');
+    } catch (error) {
+      printIfDebug('Exception in captureException: $error');
     }
   }
 

--- a/posthog_flutter/lib/posthog_flutter_web.dart
+++ b/posthog_flutter/lib/posthog_flutter_web.dart
@@ -427,7 +427,7 @@ class PosthogFlutterWeb extends PosthogFlutterPlatformInterface {
         exceptionData.cast<String, Object>(),
       );
 
-      return handleWebMethodCall(
+      return await handleWebMethodCall(
         MethodCall('captureException', {'properties': normalizedData}),
       );
     } on Exception catch (exception) {

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -156,6 +156,28 @@ void main() {
     });
   });
 
+  group('PosthogFlutterWeb captureException', () {
+    test('handles failures from posthog-js', () async {
+      void failCapture(JSAny? _, JSAny? __) {
+        throw Exception('capture failed');
+      }
+
+      void failFallbackCapture(JSAny? _, JSAny? __, JSAny? ___) {
+        throw Exception('fallback capture failed');
+      }
+
+      final fake = JSObject();
+      fake.setProperty('captureException'.toJS, failCapture.toJS);
+      fake.setProperty('capture'.toJS, failFallbackCapture.toJS);
+      globalContext.setProperty('posthog'.toJS, fake);
+
+      await expectLater(
+        PosthogFlutterWeb().captureException(error: StateError('boom')),
+        completes,
+      );
+    });
+  });
+
   // captureException must route through posthog-js's captureException (not the
   // generic capture) so it attaches required metadata and any buffered
   // $exception_steps. The Dart-built payload is passed as additionalProperties,

--- a/posthog_flutter/test/posthog_flutter_web_handler_test.dart
+++ b/posthog_flutter/test/posthog_flutter_web_handler_test.dart
@@ -157,18 +157,15 @@ void main() {
   });
 
   group('PosthogFlutterWeb captureException', () {
-    test('handles failures from posthog-js', () async {
-      void failCapture(JSAny? _, JSAny? __) {
-        throw Exception('capture failed');
-      }
-
-      void failFallbackCapture(JSAny? _, JSAny? __, JSAny? ___) {
-        throw Exception('fallback capture failed');
-      }
+    test('handles native JavaScript failures from posthog-js', () async {
+      final failWithJavaScriptError = globalContext.callMethod<JSFunction>(
+        'eval'.toJS,
+        '() => { throw new Error("capture failed"); }'.toJS,
+      );
 
       final fake = JSObject();
-      fake.setProperty('captureException'.toJS, failCapture.toJS);
-      fake.setProperty('capture'.toJS, failFallbackCapture.toJS);
+      fake.setProperty('captureException'.toJS, failWithJavaScriptError);
+      fake.setProperty('capture'.toJS, failWithJavaScriptError);
       globalContext.setProperty('posthog'.toJS, fake);
 
       await expectLater(


### PR DESCRIPTION
## :bulb: Motivation and Context

`PosthogFlutterWeb.captureException` returned the future from the web method handler without awaiting it. If both posthog-js exception capture and its fallback capture failed, the asynchronous error escaped the method's existing error handler.

This fix awaits the handler call so asynchronous failures are caught and logged by `captureException` instead of reaching the caller. The error handler now also catches native JavaScript errors, which do not necessarily implement Dart's `Exception` interface. The change removes the temporary `unawaited_return_in_try_block` analyzer suppression added by #531.

## :green_heart: How did you test it?

- `make analyzeDart`
- `cd posthog_flutter && flutter test --platform chrome test/posthog_flutter_web_handler_test.dart`
- `cd posthog_flutter && flutter pub publish --dry-run`
- `pnpm changeset status --since=origin/main`

The browser test installs posthog-js stubs that throw native JavaScript `Error` objects from both exception capture and fallback capture. It verifies that `PosthogFlutterWeb.captureException` completes normally. Dart analysis and package validation pass without suppressing the diagnostic.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi split this published-package fix out of PR #531 so it can be reviewed and released independently. After #531 merged, Pi merged `main` into this branch and removed its temporary analyzer suppression. Review feedback identified that native JavaScript errors could bypass the typed Dart exception handler, so the handler and browser test were updated. Autoreview against the updated `origin/main` reported no actionable findings.
