### PR TITLE
fix(surveys): draw icons without Material Icons font

### DIFF
--- a/.changeset/calm-icons-draw.md
+++ b/.changeset/calm-icons-draw.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Draw survey close and check icons without requiring the Material Icons font.

--- a/posthog_flutter/lib/src/surveys/widgets/survey_bottom_sheet.dart
+++ b/posthog_flutter/lib/src/surveys/widgets/survey_bottom_sheet.dart
@@ -15,6 +15,7 @@ import 'open_text_question.dart';
 import 'rating_question.dart';
 import 'choice_question.dart';
 import 'confirmation_message.dart';
+import 'survey_icon.dart';
 
 /// A bottom sheet that displays a survey to the user.
 class SurveyBottomSheet extends StatefulWidget {
@@ -197,8 +198,8 @@ class _SurveyBottomSheetState extends State<SurveyBottomSheet> {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       IconButton(
-                        icon: Icon(
-                          Icons.close,
+                        icon: SurveyIcon(
+                          type: SurveyIconType.close,
                           color: widget.appearance.closeButtonColor,
                         ),
                         onPressed: () => _handleClose(),

--- a/posthog_flutter/lib/src/surveys/widgets/survey_choice_button.dart
+++ b/posthog_flutter/lib/src/surveys/widgets/survey_choice_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import '../models/survey_appearance.dart';
+import 'survey_icon.dart';
 
 class SurveyChoiceButton extends StatelessWidget {
   const SurveyChoiceButton({
@@ -91,8 +93,8 @@ class SurveyChoiceButton extends StatelessWidget {
                       ),
               ),
               if (isSelected)
-                Icon(
-                  Icons.check,
+                SurveyIcon(
+                  type: SurveyIconType.check,
                   size: 16,
                   color: appearance.choiceButtonTextColor,
                 ),

--- a/posthog_flutter/lib/src/surveys/widgets/survey_icon.dart
+++ b/posthog_flutter/lib/src/surveys/widgets/survey_icon.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+enum SurveyIconType { close, check }
+
+class SurveyIcon extends StatelessWidget {
+  const SurveyIcon({
+    super.key,
+    required this.type,
+    required this.color,
+    this.size = 24,
+  });
+
+  final SurveyIconType type;
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: size,
+      child: CustomPaint(
+        painter: SurveyIconPainter(type: type, color: color),
+      ),
+    );
+  }
+}
+
+class SurveyIconPainter extends CustomPainter {
+  const SurveyIconPainter({required this.type, required this.color});
+
+  final SurveyIconType type;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = size.shortestSide * 0.1
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    switch (type) {
+      case SurveyIconType.close:
+        canvas
+          ..drawLine(
+            Offset(size.width * 0.25, size.height * 0.25),
+            Offset(size.width * 0.75, size.height * 0.75),
+            paint,
+          )
+          ..drawLine(
+            Offset(size.width * 0.75, size.height * 0.25),
+            Offset(size.width * 0.25, size.height * 0.75),
+            paint,
+          );
+      case SurveyIconType.check:
+        final path = Path()
+          ..moveTo(size.width * 0.2, size.height * 0.52)
+          ..lineTo(size.width * 0.42, size.height * 0.72)
+          ..lineTo(size.width * 0.8, size.height * 0.3);
+        canvas.drawPath(path, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(SurveyIconPainter oldDelegate) {
+    return oldDelegate.type != type || oldDelegate.color != color;
+  }
+}

--- a/posthog_flutter/lib/src/surveys/widgets/survey_icon.dart
+++ b/posthog_flutter/lib/src/surveys/widgets/survey_icon.dart
@@ -33,33 +33,46 @@ class SurveyIconPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = size.shortestSide * 0.1
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
-
+    // These paths match the canonical Material Icons 24px SVGs.
+    // https://github.com/google/material-design-icons/tree/master/src/navigation
+    final path = Path();
     switch (type) {
       case SurveyIconType.close:
-        canvas
-          ..drawLine(
-            Offset(size.width * 0.25, size.height * 0.25),
-            Offset(size.width * 0.75, size.height * 0.75),
-            paint,
-          )
-          ..drawLine(
-            Offset(size.width * 0.75, size.height * 0.25),
-            Offset(size.width * 0.25, size.height * 0.75),
-            paint,
-          );
+        path
+          ..moveTo(19, 6.41)
+          ..lineTo(17.59, 5)
+          ..lineTo(12, 10.59)
+          ..lineTo(6.41, 5)
+          ..lineTo(5, 6.41)
+          ..lineTo(10.59, 12)
+          ..lineTo(5, 17.59)
+          ..lineTo(6.41, 19)
+          ..lineTo(12, 13.41)
+          ..lineTo(17.59, 19)
+          ..lineTo(19, 17.59)
+          ..lineTo(13.41, 12)
+          ..close();
       case SurveyIconType.check:
-        final path = Path()
-          ..moveTo(size.width * 0.2, size.height * 0.52)
-          ..lineTo(size.width * 0.42, size.height * 0.72)
-          ..lineTo(size.width * 0.8, size.height * 0.3);
-        canvas.drawPath(path, paint);
+        path
+          ..moveTo(9, 16.17)
+          ..lineTo(4.83, 12)
+          ..lineTo(3.41, 13.41)
+          ..lineTo(9, 19)
+          ..lineTo(21, 7)
+          ..lineTo(19.59, 5.59)
+          ..close();
     }
+
+    canvas
+      ..save()
+      ..scale(size.width / 24, size.height / 24)
+      ..drawPath(
+        path,
+        Paint()
+          ..color = color
+          ..style = PaintingStyle.fill,
+      )
+      ..restore();
   }
 
   @override

--- a/posthog_flutter/test/survey_icons_test.dart
+++ b/posthog_flutter/test/survey_icons_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/surveys/models/posthog_display_survey.dart';
+import 'package:posthog_flutter/src/surveys/models/survey_appearance.dart';
+import 'package:posthog_flutter/src/surveys/models/survey_callbacks.dart';
+import 'package:posthog_flutter/src/surveys/widgets/survey_bottom_sheet.dart';
+import 'package:posthog_flutter/src/surveys/widgets/survey_choice_button.dart';
+import 'package:posthog_flutter/src/surveys/widgets/survey_icon.dart';
+
+void main() {
+  testWidgets('selected choices draw the check without a font glyph', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: Colors.white,
+        builder: (_, __) => Center(
+          child: SizedBox(
+            width: 300,
+            child: SurveyChoiceButton(
+              label: 'Selected choice',
+              isSelected: true,
+              onTap: () {},
+              appearance: SurveyAppearance.defaultAppearance,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Icon), findsNothing);
+    expect(
+      tester.widget<SurveyIcon>(find.byType(SurveyIcon)).type,
+      SurveyIconType.check,
+    );
+    expect(
+      tester
+          .widget<CustomPaint>(
+            find.descendant(
+              of: find.byType(SurveyIcon),
+              matching: find.byType(CustomPaint),
+            ),
+          )
+          .painter,
+      isA<SurveyIconPainter>(),
+    );
+  });
+
+  testWidgets('survey sheet draws the close icon without a font glyph', (
+    tester,
+  ) async {
+    final survey = PostHogDisplaySurvey.fromDict({
+      'id': 'survey-1',
+      'name': 'Test survey',
+      'questions': [
+        {
+          'type': 'link',
+          'question': 'Welcome',
+          'isOptional': false,
+          'link': '',
+        },
+      ],
+    });
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: Colors.white,
+        builder: (_, __) => Material(
+          child: SurveyBottomSheet(
+            survey: survey,
+            onShown: (_) {},
+            onResponse: (_, __, ___) async => const PostHogSurveyNextQuestion(
+              questionIndex: 0,
+              isSurveyCompleted: true,
+            ),
+            onClosed: (_) {},
+            appearance: SurveyAppearance.defaultAppearance,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Icon), findsNothing);
+    expect(
+      tester.widget<SurveyIcon>(find.byType(SurveyIcon)).type,
+      SurveyIconType.close,
+    );
+  });
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Apps that use `WidgetsApp` or do not set `uses-material-design: true` do not bundle the Material Icons font. Survey close and check icons then render as missing-glyph boxes.

This change draws both icons with `CustomPainter` using the canonical Material Icons 24px path coordinates. It keeps the existing geometry, sizes, and colors without requiring a font asset. Fixes #536.

## :green_heart: How did you test it?

- `flutter analyze`
- `flutter test -r expanded`
- Widget tests render the close and check icons under `WidgetsApp` without a Material Icons font.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using `openai-codex/gpt-5.6-sol` and checked with Pi autoreview. The implementation copies the canonical Apache-2.0 Material Icons path geometry into one custom painter instead of adding a bundled font asset.
