### PR TITLE
fix(surveys): show surveys above nested navigators

### DIFF
--- a/.changeset/nested-surveys-float.md
+++ b/.changeset/nested-surveys-float.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Show surveys above nested navigator shell chrome and dismiss them through the root navigator.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:posthog_flutter_example/error_example.dart';
 import 'exception_steps_screen.dart';
 import 'masking_tests_screen.dart';
 import 'platform_views_screen.dart';
+import 'survey_nested_navigator_screen.dart';
 
 const kMaskAllPlatformViews = true;
 
@@ -150,6 +151,25 @@ class InitialScreenState extends State<InitialScreen> {
                   child: const PostHogMaskWidget(
                     child: Text('Go to Second Route'),
                   ),
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.red,
+                    foregroundColor: Colors.white,
+                  ),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const SurveyNestedNavigatorScreen(),
+                        settings: const RouteSettings(
+                          name: 'survey_nested_navigator',
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Nested Navigator Survey'),
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(

--- a/example/lib/survey_nested_navigator_screen.dart
+++ b/example/lib/survey_nested_navigator_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+// This screen invokes the bridge directly to show a deterministic local survey.
+// ignore: implementation_imports
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+
+class SurveyNestedNavigatorScreen extends StatelessWidget {
+  const SurveyNestedNavigatorScreen({super.key});
+
+  static const _survey = <String, dynamic>{
+    'id': 'nested-navigator-test',
+    'name': 'Nested navigator test',
+    'questions': [
+      {
+        'id': 'feedback',
+        'type': 'open',
+        'question': 'Does this survey appear above the red shell?',
+        'isOptional': false,
+        'buttonText': 'Submit',
+      },
+    ],
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          Positioned.fill(
+            child: Navigator(
+              observers: [PosthogObserver()],
+              onGenerateRoute: (_) => MaterialPageRoute<void>(
+                settings: const RouteSettings(name: 'survey_nested_branch'),
+                builder: (_) => Scaffold(
+                  appBar: AppBar(title: const Text('Nested navigator survey')),
+                  body: Center(
+                    child: ElevatedButton(
+                      onPressed: () => PosthogFlutterPlatformInterface.instance
+                          .showSurvey(_survey),
+                      child: const Text('Show test survey'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Container(
+              height: 120,
+              width: double.infinity,
+              color: Colors.red,
+              alignment: Alignment.center,
+              child: const Text(
+                'Persistent shell chrome',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/posthog_flutter/lib/src/surveys/survey_service.dart
+++ b/posthog_flutter/lib/src/surveys/survey_service.dart
@@ -75,15 +75,22 @@ class SurveyService {
         isDismissible: false,
         builder: (context) {
           final route = ModalRoute.of(context);
-          _currentSurveyRoute = route;
-          if (_dismissSurveyWhenReady && route != null) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (_currentSurveyRoute == route) {
-                _dismissSurveyRoute(route);
-              }
-            });
+          if (_programmaticDismissal == programmaticDismissal &&
+              !_isDismissingSurvey) {
+            _currentSurveyRoute = route;
+            if (_dismissSurveyWhenReady && route != null) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (_currentSurveyRoute == route &&
+                    _programmaticDismissal == programmaticDismissal) {
+                  _dismissSurveyRoute(route, programmaticDismissal);
+                }
+              });
+            }
           }
           return _buildSurveyWidget(survey, onShown, onResponse, (survey) {
+            if (_programmaticDismissal != programmaticDismissal) {
+              return;
+            }
             _isDismissingSurvey = true;
             _currentSurveyRoute = null;
             onClosed(survey);
@@ -95,11 +102,11 @@ class SurveyService {
     } catch (e) {
       printIfDebug('[PostHog] Error showing survey: $e');
     } finally {
-      _isShowingSurvey = false;
-      _isDismissingSurvey = false;
-      _dismissSurveyWhenReady = false;
-      _currentSurveyRoute = null;
       if (_programmaticDismissal == programmaticDismissal) {
+        _isShowingSurvey = false;
+        _isDismissingSurvey = false;
+        _dismissSurveyWhenReady = false;
+        _currentSurveyRoute = null;
         _programmaticDismissal = null;
       }
     }
@@ -121,15 +128,20 @@ class SurveyService {
     );
   }
 
-  void _dismissSurveyRoute(Route<dynamic> route) {
-    if (_isDismissingSurvey || _currentSurveyRoute != route) {
+  void _dismissSurveyRoute(
+    Route<dynamic> route,
+    Completer<void> programmaticDismissal,
+  ) {
+    if (_isDismissingSurvey ||
+        _currentSurveyRoute != route ||
+        _programmaticDismissal != programmaticDismissal) {
       return;
     }
 
     _isDismissingSurvey = true;
     _dismissSurveyWhenReady = false;
     _currentSurveyRoute = null;
-    _programmaticDismissal?.complete();
+    programmaticDismissal.complete();
     route.navigator?.removeRoute(route);
   }
 
@@ -144,6 +156,6 @@ class SurveyService {
       _dismissSurveyWhenReady = true;
       return;
     }
-    _dismissSurveyRoute(route);
+    _dismissSurveyRoute(route, _programmaticDismissal!);
   }
 }

--- a/posthog_flutter/lib/src/surveys/survey_service.dart
+++ b/posthog_flutter/lib/src/surveys/survey_service.dart
@@ -64,6 +64,7 @@ class SurveyService {
     try {
       await showModalBottomSheet(
         context: context,
+        useRootNavigator: true,
         isScrollControlled: true,
         isDismissible: false,
         builder: (context) =>
@@ -101,7 +102,7 @@ class SurveyService {
     final context = _currentSurveyContext;
     if (_isShowingSurvey && context != null) {
       // Use the stored context to properly dismiss the bottom sheet
-      Navigator.of(context).pop();
+      Navigator.of(context, rootNavigator: true).pop();
       _currentSurveyContext = null;
     }
     _isShowingSurvey = false;

--- a/posthog_flutter/lib/src/surveys/survey_service.dart
+++ b/posthog_flutter/lib/src/surveys/survey_service.dart
@@ -19,6 +19,7 @@ class SurveyService {
   SurveyService._internal();
 
   bool _isShowingSurvey = false;
+  bool _dismissSurveyWhenReady = false;
   Route<dynamic>? _currentSurveyRoute;
 
   /// Shows a survey using the PosthogObserver context
@@ -67,18 +68,23 @@ class SurveyService {
         isScrollControlled: true,
         isDismissible: false,
         builder: (context) {
-          _currentSurveyRoute = ModalRoute.of(context);
-          return _buildSurveyWidget(survey, onShown, onResponse, (s) {
-            _isShowingSurvey = false;
-            _currentSurveyRoute = null;
-            onClosed(s);
-          });
+          final route = ModalRoute.of(context);
+          _currentSurveyRoute = route;
+          if (_dismissSurveyWhenReady && route != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (_currentSurveyRoute == route) {
+                route.navigator?.removeRoute(route);
+              }
+            });
+          }
+          return _buildSurveyWidget(survey, onShown, onResponse, onClosed);
         },
       );
     } catch (e) {
       printIfDebug('[PostHog] Error showing survey: $e');
     } finally {
       _isShowingSurvey = false;
+      _dismissSurveyWhenReady = false;
       _currentSurveyRoute = null;
     }
   }
@@ -101,11 +107,15 @@ class SurveyService {
 
   /// Hides any active survey
   void hideSurvey() {
-    final route = _currentSurveyRoute;
-    if (_isShowingSurvey && route != null) {
-      route.navigator?.removeRoute(route);
-      _currentSurveyRoute = null;
+    if (!_isShowingSurvey) {
+      return;
     }
-    _isShowingSurvey = false;
+
+    final route = _currentSurveyRoute;
+    if (route == null) {
+      _dismissSurveyWhenReady = true;
+      return;
+    }
+    route.navigator?.removeRoute(route);
   }
 }

--- a/posthog_flutter/lib/src/surveys/survey_service.dart
+++ b/posthog_flutter/lib/src/surveys/survey_service.dart
@@ -19,7 +19,7 @@ class SurveyService {
   SurveyService._internal();
 
   bool _isShowingSurvey = false;
-  BuildContext? _currentSurveyContext;
+  Route<dynamic>? _currentSurveyRoute;
 
   /// Shows a survey using the PosthogObserver context
   Future<void> showSurvey(
@@ -60,24 +60,26 @@ class SurveyService {
     BuildContext context,
   ) async {
     _isShowingSurvey = true;
-    _currentSurveyContext = context;
     try {
       await showModalBottomSheet(
         context: context,
         useRootNavigator: true,
         isScrollControlled: true,
         isDismissible: false,
-        builder: (context) =>
-            _buildSurveyWidget(survey, onShown, onResponse, (s) {
-          _isShowingSurvey = false;
-          _currentSurveyContext = null;
-          onClosed(s);
-        }),
+        builder: (context) {
+          _currentSurveyRoute = ModalRoute.of(context);
+          return _buildSurveyWidget(survey, onShown, onResponse, (s) {
+            _isShowingSurvey = false;
+            _currentSurveyRoute = null;
+            onClosed(s);
+          });
+        },
       );
     } catch (e) {
       printIfDebug('[PostHog] Error showing survey: $e');
+    } finally {
       _isShowingSurvey = false;
-      _currentSurveyContext = null;
+      _currentSurveyRoute = null;
     }
   }
 
@@ -99,11 +101,10 @@ class SurveyService {
 
   /// Hides any active survey
   void hideSurvey() {
-    final context = _currentSurveyContext;
-    if (_isShowingSurvey && context != null) {
-      // Use the stored context to properly dismiss the bottom sheet
-      Navigator.of(context, rootNavigator: true).pop();
-      _currentSurveyContext = null;
+    final route = _currentSurveyRoute;
+    if (_isShowingSurvey && route != null) {
+      route.navigator?.removeRoute(route);
+      _currentSurveyRoute = null;
     }
     _isShowingSurvey = false;
   }

--- a/posthog_flutter/lib/src/surveys/survey_service.dart
+++ b/posthog_flutter/lib/src/surveys/survey_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../util/logging.dart';
@@ -19,8 +21,10 @@ class SurveyService {
   SurveyService._internal();
 
   bool _isShowingSurvey = false;
+  bool _isDismissingSurvey = false;
   bool _dismissSurveyWhenReady = false;
   Route<dynamic>? _currentSurveyRoute;
+  Completer<void>? _programmaticDismissal;
 
   /// Shows a survey using the PosthogObserver context
   Future<void> showSurvey(
@@ -61,8 +65,10 @@ class SurveyService {
     BuildContext context,
   ) async {
     _isShowingSurvey = true;
+    final programmaticDismissal = Completer<void>();
+    _programmaticDismissal = programmaticDismissal;
     try {
-      await showModalBottomSheet(
+      final modalDismissal = showModalBottomSheet<void>(
         context: context,
         useRootNavigator: true,
         isScrollControlled: true,
@@ -73,19 +79,29 @@ class SurveyService {
           if (_dismissSurveyWhenReady && route != null) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
               if (_currentSurveyRoute == route) {
-                route.navigator?.removeRoute(route);
+                _dismissSurveyRoute(route);
               }
             });
           }
-          return _buildSurveyWidget(survey, onShown, onResponse, onClosed);
+          return _buildSurveyWidget(survey, onShown, onResponse, (survey) {
+            _isDismissingSurvey = true;
+            _currentSurveyRoute = null;
+            onClosed(survey);
+          });
         },
       );
+      // removeRoute did not complete a route's future before Flutter 3.32.
+      await Future.any([modalDismissal, programmaticDismissal.future]);
     } catch (e) {
       printIfDebug('[PostHog] Error showing survey: $e');
     } finally {
       _isShowingSurvey = false;
+      _isDismissingSurvey = false;
       _dismissSurveyWhenReady = false;
       _currentSurveyRoute = null;
+      if (_programmaticDismissal == programmaticDismissal) {
+        _programmaticDismissal = null;
+      }
     }
   }
 
@@ -105,9 +121,21 @@ class SurveyService {
     );
   }
 
+  void _dismissSurveyRoute(Route<dynamic> route) {
+    if (_isDismissingSurvey || _currentSurveyRoute != route) {
+      return;
+    }
+
+    _isDismissingSurvey = true;
+    _dismissSurveyWhenReady = false;
+    _currentSurveyRoute = null;
+    _programmaticDismissal?.complete();
+    route.navigator?.removeRoute(route);
+  }
+
   /// Hides any active survey
   void hideSurvey() {
-    if (!_isShowingSurvey) {
+    if (!_isShowingSurvey || _isDismissingSurvey) {
       return;
     }
 
@@ -116,6 +144,6 @@ class SurveyService {
       _dismissSurveyWhenReady = true;
       return;
     }
-    route.navigator?.removeRoute(route);
+    _dismissSurveyRoute(route);
   }
 }

--- a/posthog_flutter/test/surveys_test.dart
+++ b/posthog_flutter/test/surveys_test.dart
@@ -102,6 +102,34 @@ void main() {
     await immediatelyHiddenSurvey;
 
     expect(find.byType(SurveyBottomSheet), findsNothing);
+
+    final userClosedSurvey = SurveyService().showSurvey(
+      PostHogDisplaySurvey.fromDict(surveyWithLinkQuestion(link: '')),
+      (_) {},
+      (_, __, ___) => throw UnimplementedError(),
+      (_) {},
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.close));
+    await userClosedSurvey;
+
+    final nextSurvey = SurveyService().showSurvey(
+      PostHogDisplaySurvey.fromDict(surveyWithLinkQuestion(link: '')),
+      (_) {},
+      (_, __, ___) => throw UnimplementedError(),
+      (_) {},
+    );
+    await tester.pump();
+
+    SurveyService().hideSurvey();
+    await tester.pumpAndSettle();
+    await nextSurvey;
+
+    expect(
+      find.byType(SurveyBottomSheet, skipOffstage: false),
+      findsNothing,
+    );
   });
 
   group('PostHogDisplaySurvey.fromDict link question', () {

--- a/posthog_flutter/test/surveys_test.dart
+++ b/posthog_flutter/test/surveys_test.dart
@@ -111,7 +111,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.close));
+    await tester.tap(find.byType(IconButton));
     await userClosedSurvey;
 
     final nextSurvey = SurveyService().showSurvey(

--- a/posthog_flutter/test/surveys_test.dart
+++ b/posthog_flutter/test/surveys_test.dart
@@ -88,6 +88,18 @@ void main() {
     await tester.pumpAndSettle();
     await pushedRoute;
     expect(find.text('Nested route'), findsOneWidget);
+
+    final immediatelyHiddenSurvey = SurveyService().showSurvey(
+      PostHogDisplaySurvey.fromDict(surveyWithLinkQuestion(link: '')),
+      (_) {},
+      (_, __, ___) => throw UnimplementedError(),
+      (_) {},
+    );
+    SurveyService().hideSurvey();
+    await tester.pumpAndSettle();
+    await immediatelyHiddenSurvey;
+
+    expect(find.byType(SurveyBottomSheet), findsNothing);
   });
 
   group('PostHogDisplaySurvey.fromDict link question', () {

--- a/posthog_flutter/test/surveys_test.dart
+++ b/posthog_flutter/test/surveys_test.dart
@@ -1,6 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/posthog_observer.dart';
 import 'package:posthog_flutter/src/surveys/models/posthog_display_link_question.dart';
 import 'package:posthog_flutter/src/surveys/models/posthog_display_survey.dart';
+import 'package:posthog_flutter/src/surveys/survey_service.dart';
+import 'package:posthog_flutter/src/surveys/widgets/survey_bottom_sheet.dart';
 
 void main() {
   // Builds a minimal survey dict (as forwarded by the native method channel)
@@ -29,6 +33,50 @@ void main() {
     final survey = PostHogDisplaySurvey.fromDict(dict);
     return survey.questions.first as PostHogDisplayLinkQuestion;
   }
+
+  testWidgets('shows and hides surveys using the root navigator', (
+    tester,
+  ) async {
+    addTearDown(() {
+      SurveyService().hideSurvey();
+      PosthogObserver.clearCurrentContext();
+    });
+
+    final rootNavigatorKey = GlobalKey<NavigatorState>();
+    final nestedNavigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: rootNavigatorKey,
+        home: Navigator(
+          key: nestedNavigatorKey,
+          observers: [PosthogObserver()],
+          onGenerateRoute: (_) => MaterialPageRoute<void>(
+            builder: (_) => const Scaffold(body: Text('Nested route')),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final showSurvey = SurveyService().showSurvey(
+      PostHogDisplaySurvey.fromDict(surveyWithLinkQuestion(link: '')),
+      (_) {},
+      (_, __, ___) => throw UnimplementedError(),
+      (_) {},
+    );
+    await tester.pumpAndSettle();
+
+    final surveyContext = tester.element(find.byType(SurveyBottomSheet));
+    expect(Navigator.of(surveyContext), same(rootNavigatorKey.currentState));
+
+    SurveyService().hideSurvey();
+    await tester.pumpAndSettle();
+    await showSurvey;
+
+    expect(find.byType(SurveyBottomSheet), findsNothing);
+    expect(find.text('Nested route'), findsOneWidget);
+  });
 
   group('PostHogDisplaySurvey.fromDict link question', () {
     // (description, native link payload, expected parsed link)

--- a/posthog_flutter/test/surveys_test.dart
+++ b/posthog_flutter/test/surveys_test.dart
@@ -78,6 +78,7 @@ void main() {
     await tester.pumpAndSettle();
 
     SurveyService().hideSurvey();
+    SurveyService().hideSurvey();
     await tester.pumpAndSettle();
     await showSurvey;
 
@@ -95,6 +96,7 @@ void main() {
       (_, __, ___) => throw UnimplementedError(),
       (_) {},
     );
+    SurveyService().hideSurvey();
     SurveyService().hideSurvey();
     await tester.pumpAndSettle();
     await immediatelyHiddenSurvey;

--- a/posthog_flutter/test/surveys_test.dart
+++ b/posthog_flutter/test/surveys_test.dart
@@ -70,11 +70,23 @@ void main() {
     final surveyContext = tester.element(find.byType(SurveyBottomSheet));
     expect(Navigator.of(surveyContext), same(rootNavigatorKey.currentState));
 
+    final pushedRoute = rootNavigatorKey.currentState!.push<void>(
+      MaterialPageRoute(
+        builder: (_) => const Scaffold(body: Text('New root route')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
     SurveyService().hideSurvey();
     await tester.pumpAndSettle();
     await showSurvey;
 
-    expect(find.byType(SurveyBottomSheet), findsNothing);
+    expect(find.text('New root route'), findsOneWidget);
+    expect(find.byType(SurveyBottomSheet, skipOffstage: false), findsNothing);
+
+    rootNavigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    await pushedRoute;
     expect(find.text('Nested route'), findsOneWidget);
   });
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #534.

Surveys currently use the nearest navigator. In apps with nested navigators, this can place the survey below shell UI such as a persistent tab bar and block its controls.

This change presents surveys through the root navigator. It stores the exact survey route for programmatic dismissal, so `hideSurvey()` does not pop an unrelated application route. It also preserves dismissal requests made before the bottom sheet finishes building. Repeated dismissal requests are idempotent, and programmatic dismissal completes correctly on Flutter versions before 3.32.

The example app now includes a deterministic nested-navigator screen. It paints persistent shell UI above the nested navigator and can show a local test survey without remote survey configuration.

## :green_heart: How did you test it?

- Ran `dart analyze .`.
- Ran `flutter test -r expanded test/surveys_test.dart`.
- Ran the full Flutter test suite with 271 tests passing.
- Added a widget test with nested and root navigators. The test checks root placement, repeated dismissal while another root route is on top, and repeated dismissal before the bottom sheet builds.
- Built and ran the example on an iPhone 17 simulator with iOS 26.4 using XcodeBuildMCP.
- Used AXe to open the nested-navigator example and show the local survey. The shell occupies y=754-874 and the Submit button occupies y=776-824. AXe reported Submit as the hit target at y=800, confirming that the survey is above the shell.
- Ran `pnpm exec changeset status`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented and tested the fix in a dedicated worktree. Review found dismissal edge cases involving another root route, calls before the sheet builder, repeated calls, and Flutter versions where route removal does not complete the route future. These findings were accepted, covered where reproducible by widget tests, and fixed. The final autoreview reported no actionable findings.
