### PR TITLE
feat(error-tracking): expose captureNativeCrashes for Android NDK crashes

### DIFF
--- a/.changeset/native-crash-config.md
+++ b/.changeset/native-crash-config.md
@@ -2,4 +2,4 @@
 'posthog_flutter': minor
 ---
 
-Add `errorTrackingConfig.captureNativeCrashes` to capture native C/C++ (NDK) crashes on Android. Requires Android 12 (API 31) and `captureNativeExceptions`; crashes are captured on the next app launch and symbolicated against `.so` debug symbols uploaded with the PostHog Gradle plugin.
+Add `errorTrackingConfig.captureNativeCrashes` to capture native C/C++ (NDK) crashes on Android. Requires Android 12 (API 31) and exception autocapture enabled in the project's error tracking settings; crashes are captured on the next app launch and symbolicated against `.so` debug symbols uploaded with the PostHog Gradle plugin.

--- a/.changeset/native-crash-config.md
+++ b/.changeset/native-crash-config.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': minor
+---
+
+Add `errorTrackingConfig.captureNativeCrashes` to capture native C/C++ (NDK) crashes on Android. Requires Android 12 (API 31) and `captureNativeExceptions`; crashes are captured on the next app launch and symbolicated against `.so` debug symbols uploaded with the PostHog Gradle plugin.

--- a/api/posthog_flutter.api.json
+++ b/api/posthog_flutter.api.json
@@ -2908,6 +2908,17 @@
                         "isReadable": true,
                         "isStatic": false,
                         "isWriteable": true,
+                        "name": "captureNativeCrashes",
+                        "relativePath": "lib/src/posthog_config.dart",
+                        "typeName": "bool"
+                    },
+                    {
+                        "entryPoints": [],
+                        "isDeprecated": false,
+                        "isExperimental": false,
+                        "isReadable": true,
+                        "isStatic": false,
+                        "isWriteable": true,
                         "name": "captureIsolateErrors",
                         "relativePath": "lib/src/posthog_config.dart",
                         "typeName": "bool"

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,7 +64,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.posthog:posthog-android:[3.58.0,4.0.0)'
+        implementation 'com.posthog:posthog-android:[3.59.0,4.0.0)'
     }
 
     testOptions {

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,7 +64,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.posthog:posthog-android:[3.59.0,4.0.0)'
+        implementation 'com.posthog:posthog-android:[3.60.0,4.0.0)'
     }
 
     testOptions {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -633,6 +633,9 @@ class PosthogFlutterPlugin :
                     errorConfig.getIfNotNull<Boolean>("captureNativeExceptions") {
                         errorTrackingConfig.autoCapture = it
                     }
+                    errorConfig.getIfNotNull<Boolean>("captureNativeCrashes") {
+                        errorTrackingConfig.captureNativeCrashes = it
+                    }
                     errorConfig.getIfNotNull<List<String>>("inAppIncludes") { includes ->
                         errorTrackingConfig.inAppIncludes.addAll(includes)
                     }

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -904,7 +904,8 @@ class PostHogErrorTrackingConfig {
   ///
   /// **Android:**
   ///
-  /// Captures Java/Kotlin exceptions only (no native C/C++ crashes).
+  /// Captures Java/Kotlin exceptions. For native C/C++ (NDK) crashes, also
+  /// enable [captureNativeCrashes].
   ///
   /// Stacktrace demangling for minified builds is supported by installing
   /// the PostHog Gradle plugin to upload ProGuard/R8 mappings.
@@ -912,6 +913,28 @@ class PostHogErrorTrackingConfig {
   ///
   /// Default: false
   var captureNativeExceptions = false;
+
+  /// Enable automatic capture of native C/C++ (NDK) crashes on Android.
+  ///
+  /// Requires Android 12 (API 31) or later. A native crash kills the process
+  /// immediately, so the crash is captured on the next app launch from the
+  /// records the OS kept, as an `$exception` event with raw native stack
+  /// frames. [captureNativeExceptions] must also be enabled.
+  ///
+  /// For symbolicated stack traces, upload the app's `.so` debug symbols with
+  /// the PostHog Gradle plugin.
+  /// See: https://posthog.com/docs/error-tracking/upload-mappings/android
+  ///
+  /// Because the event is sent from the next launch, properties like
+  /// `$app_version` reflect the app at capture time, not at crash time.
+  ///
+  /// **Note:**
+  /// - Apple platforms: Not applicable (native crash capture is part of
+  ///   [captureNativeExceptions])
+  /// - Flutter web: Not supported
+  ///
+  /// Default: false
+  var captureNativeCrashes = false;
 
   /// Enable automatic capture of isolate errors.
   ///
@@ -944,6 +967,7 @@ class PostHogErrorTrackingConfig {
       'captureSilentFlutterErrors': captureSilentFlutterErrors,
       'capturePlatformDispatcherErrors': capturePlatformDispatcherErrors,
       'captureNativeExceptions': captureNativeExceptions,
+      'captureNativeCrashes': captureNativeCrashes,
       'captureIsolateErrors': captureIsolateErrors,
       'exceptionSteps': exceptionSteps.toMap(),
     };

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -919,7 +919,8 @@ class PostHogErrorTrackingConfig {
   /// Requires Android 12 (API 31) or later. A native crash kills the process
   /// immediately, so the crash is captured on the next app launch from the
   /// records the OS kept, as an `$exception` event with raw native stack
-  /// frames. [captureNativeExceptions] must also be enabled.
+  /// frames. Exception autocapture must also be enabled in the project's
+  /// error tracking settings.
   ///
   /// For symbolicated stack traces, upload the app's `.so` debug symbols with
   /// the PostHog Gradle plugin.

--- a/posthog_flutter/test/event_shape_snapshot_test.dart
+++ b/posthog_flutter/test/event_shape_snapshot_test.dart
@@ -60,7 +60,8 @@ void main() {
       ..sampleRate = 0.25;
     config.errorTrackingConfig
       ..inAppIncludes.add('package:snapshot_app')
-      ..captureFlutterErrors = true;
+      ..captureFlutterErrors = true
+      ..captureNativeCrashes = true;
     config.logsConfig
       ..serviceName = 'checkout-app'
       ..serviceVersion = '1.2.3'

--- a/posthog_flutter/test/snapshots/setup_request.json
+++ b/posthog_flutter/test/snapshots/setup_request.json
@@ -42,6 +42,7 @@
         "captureSilentFlutterErrors": false,
         "capturePlatformDispatcherErrors": false,
         "captureNativeExceptions": false,
+        "captureNativeCrashes": true,
         "captureIsolateErrors": false,
         "exceptionSteps": {
           "enabled": true,


### PR DESCRIPTION
## Problem

posthog-android now captures native C/C++ (NDK) crashes via `errorTrackingConfig.captureNativeCrashes` (PostHog/posthog-android#659), but Flutter apps had no way to enable it.

## Changes

- New `errorTrackingConfig.captureNativeCrashes` on the Dart config (default `false`), forwarded over the platform channel.
- Android plugin sets it on `PostHogAndroidConfig.errorTrackingConfig`; the native SDK registers the crash scanner from there. iOS/macOS and web ignore the key (native crash capture on Apple platforms is already part of `captureNativeExceptions`).
- posthog-android version floor bumped to `[3.60.0,4.0.0)`.
- Dart API snapshot + setup-request shape snapshot updated; changeset added (minor).

## Status

No longer blocked: posthog-android 3.60.0 (the release containing PostHog/posthog-android#659) is published on Maven Central and matches the version floor.

## Tests

- `flutter test` 273/273 green (setup-request snapshot pins the new key end to end).
- `dart format`, `dart analyze`, ktlint, Dart API snapshot check all clean.
- Example APK compiled against a locally published posthog-android build of the #659 branch to verify the Kotlin wiring.


