### PR TITLE
ci: bound the test job runtime so a hung browser fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
       # Browser-only tests (`@TestOn('browser')`) are skipped by the VM run above.
       - name: Test (web)
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        timeout-minutes: 5
         working-directory: ./posthog_flutter
         run: flutter test --platform chrome test/posthog_flutter_web_handler_test.dart test/posthog_widget_web_test.dart test/web_canvas_mask_provider_test.dart
 
@@ -174,6 +175,7 @@ jobs:
       # only a wasm compile exercises the dart2wasm selection this test guards.
       - name: Test (web, wasm)
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        timeout-minutes: 5
         working-directory: ./posthog_flutter
         run: flutter test --platform chrome --wasm test/posthog_isolate_error_handler_web_test.dart
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
   test:
     needs: detect-markdown-only
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'


### PR DESCRIPTION
The `test` job's web steps launch Chrome and wait for it to hand off to the test runner. When that handshake never completes, the step blocks having produced no output — and there is no `timeout-minutes` anywhere in `.github/workflows/`, so the only backstop is GitHub's 360-minute default.

That happened on [run 32192152104](https://github.com/PostHog/posthog-flutter/actions/runs/32192152104):

| Step | Result | Duration |
|---|---|---|
| `Test` (`flutter test`, VM) | success | **31 s** |
| `Test (web)` (`flutter test --platform chrome`) | cancelled at the ceiling | **5 h 59 m** |
| `Test (web, wasm)` | skipped | — |

The web step emitted no test result at all before hanging — not even for files the PR under test did not touch — and teardown logged orphaned `chrome` and `chrome_crashpad_handler` processes. Re-running the identical commit passed in minutes, so it was browser startup on the hosted runner, not the code.

**Value chosen from data:** the `test` job takes **1–2 minutes** on `main` (12 of the 13 most recent completed runs; the 13th is the cancelled one). 15 minutes is ~7× the worst normal case, so a cold cache or a slow runner will not trip it.

### What this does and does not do

- **Does:** turns a six-hour hang into a 15-minute red check. Saves ~6 billable runner-hours per occurrence, frees the concurrency slot, and makes the failure obvious rather than looking like a stuck PR for a workday.
- **Does not:** prevent the flake. Recovery is still a manual re-run, which is what worked here.

Deliberately not adding a retry wrapper: retrying on *any* non-zero exit would also mask genuine test failures and double their runtime. Bounding the hang is the honest fix; if this recurs often enough to warrant automatic recovery, that is worth doing separately with a condition narrower than "the step failed".

Scoped to the `test` job — it is the only one with browser-based steps, and the only one that has hung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNawXpsiq9d6qHiRqXqDiE