### PR TITLE
fix: Drop events when beforeSend callbacks throw

### DIFF
--- a/.changeset/calm-hooks-close.md
+++ b/.changeset/calm-hooks-close.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Drop events when a before-send callback throws.

--- a/posthog_flutter/lib/src/posthog_flutter_io.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_io.dart
@@ -64,8 +64,10 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
         if (result == null) return null;
         event = result;
       } catch (e) {
-        // Skip a throwing callback; continue with the pre-callback event.
-        printIfDebug('[PostHog] beforeSend callback threw exception: $e');
+        printIfDebug(
+          '[PostHog] Warning: beforeSend callback threw an exception; dropping event: $e',
+        );
+        return null;
       }
     }
     return event;

--- a/posthog_flutter/test/posthog_flutter_io_test.dart
+++ b/posthog_flutter/test/posthog_flutter_io_test.dart
@@ -461,26 +461,40 @@ void main() {
       expect(args['eventName'], 'keep me');
     });
 
-    test('beforeSend exception returns original event', () async {
+    test('beforeSend exception drops event and stops the chain', () async {
+      final callOrder = <String>[];
+
       testConfig = PostHogConfig(
         'test_project_token',
         beforeSend: [
           (event) {
+            callOrder.add('transform');
+            event.event = 'transformed_event';
+            return event;
+          },
+          (event) {
+            callOrder.add('throw');
             throw Exception('Hey I errored out');
+          },
+          (event) {
+            callOrder.add('sentinel');
+            return event;
           },
         ],
       );
       await posthogFlutterIO.setup(testConfig);
+      log.clear();
 
-      await posthogFlutterIO.capture(
-        eventName: 'test_event',
-        properties: {'key': 'value'},
+      await expectLater(
+        posthogFlutterIO.capture(
+          eventName: 'test_event',
+          properties: {'key': 'value'},
+        ),
+        completes,
       );
 
-      final captureCall = log.firstWhere((c) => c.method == 'capture');
-      final args = Map<String, dynamic>.from(captureCall.arguments as Map);
-      expect(args['eventName'], 'test_event');
-      expect(args['properties'], {'key': 'value'});
+      expect(callOrder, ['transform', 'throw']);
+      expect(log, isEmpty);
     });
 
     test('multiple beforeSend callbacks are applied in order', () async {
@@ -491,8 +505,12 @@ void main() {
         beforeSend: [
           (event) {
             callOrder.add(1);
-            event.event = '${event.event}_first';
-            return event;
+            return PostHogEvent(
+              event: '${event.event}_first',
+              properties: event.properties,
+              userProperties: event.userProperties,
+              userPropertiesSetOnce: event.userPropertiesSetOnce,
+            );
           },
           (event) {
             callOrder.add(2);
@@ -732,27 +750,28 @@ void main() {
       expect(callOrder, ['sync1', 'async1', 'sync2']);
     });
 
-    test('async beforeSend exception returns original event', () async {
+    test('async beforeSend exception drops event without throwing', () async {
       testConfig = PostHogConfig(
         'test_project_token',
         beforeSend: [
           (event) async {
-            await Future.delayed(const Duration(milliseconds: 100));
+            await Future<void>.delayed(Duration.zero);
             throw Exception('Async error');
           },
         ],
       );
       await posthogFlutterIO.setup(testConfig);
+      log.clear();
 
-      await posthogFlutterIO.capture(
-        eventName: 'test_event',
-        properties: {'key': 'value'},
+      await expectLater(
+        posthogFlutterIO.capture(
+          eventName: 'test_event',
+          properties: {'key': 'value'},
+        ),
+        completes,
       );
 
-      final captureCall = log.firstWhere((c) => c.method == 'capture');
-      final args = Map<String, dynamic>.from(captureCall.arguments as Map);
-      expect(args['eventName'], 'test_event');
-      expect(args['properties'], {'key': 'value'});
+      expect(log, isEmpty);
     });
 
     test(


### PR DESCRIPTION
## :bulb: Motivation and Context

A throwing `beforeSend` callback was logged and skipped, which allowed the original or previously modified event to continue through the remaining callbacks and reach the native capture queue. This conflicts with the fail-closed hook contract and can send an event that the callback did not approve.

This change logs the callback exception, stops the callback chain, and drops the event. Each successful callback still passes its returned event to the next callback.

## :green_heart: How did you test it?

- `make checkFormatDart`
- `make analyzeDart`
- `make checkApiDart`
- `make test`
- `pnpm changeset status`

The tests cover synchronous and asynchronous callback exceptions, stopping later callbacks, preventing method-channel capture, and passing a replacement event through the callback chain.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi coding agent inspected the existing implementation and tests, strengthened chain propagation coverage, ran the repository validation commands, and ran the isolated autoreview helper. The implementation returns `null` immediately after a callback throws so the event cannot continue to the platform channel.
