### PR TITLE
fix(replay): keep the native-screen cover across a session boundary

### DIFF
--- a/.changeset/occlusion-survives-replay-restart.md
+++ b/.changeset/occlusion-survives-replay-restart.md
@@ -2,4 +2,4 @@
 "posthog_flutter": patch
 ---
 
-Fix session replay losing the native-screen cover when the session changes while one is up. `reset()`, or a `close()`/`setup()` pair, briefly turns replay off, and the occlusion detector read that as the episode ending — so the Flutter app was recorded from underneath the native screen, and the same screen was then detected again as a new episode. The detector now keeps the episode while the app is still covered.
+Fix session replay recording the Flutter UI from underneath a native screen when the session changes — `reset()`, or a `close()`/`setup()` pair — while that screen is up.

--- a/.changeset/occlusion-survives-replay-restart.md
+++ b/.changeset/occlusion-survives-replay-restart.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+Fix session replay losing the native-screen cover when a session boundary lands during one. `reset()`, or a `close()`/`setup()` pair, turns replay off for around a second; the occlusion detector read that as the episode ending, so Flutter capture resumed while the native screen was still on top and the same cover was then re-detected as a new episode

--- a/.changeset/occlusion-survives-replay-restart.md
+++ b/.changeset/occlusion-survives-replay-restart.md
@@ -2,4 +2,4 @@
 "posthog_flutter": patch
 ---
 
-Fix session replay losing the native-screen cover when a session boundary lands during one. `reset()`, or a `close()`/`setup()` pair, turns replay off for around a second; the occlusion detector read that as the episode ending, so Flutter capture resumed while the native screen was still on top and the same cover was then re-detected as a new episode
+Fix session replay losing the native-screen cover when the session changes while one is up. `reset()`, or a `close()`/`setup()` pair, briefly turns replay off, and the occlusion detector read that as the episode ending — so the Flutter app was recorded from underneath the native screen, and the same screen was then detected again as a new episode. The detector now keeps the episode while the app is still covered.

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -985,31 +985,29 @@ class PosthogFlutterPlugin :
     // Null activity (config-change detach) fails open — the captured Flutter tree
     // has no native pixels. Known limitation: a host recreation mid-episode never
     // re-fires onActivityResumed, ending the episode early.
-    private fun isFlutterCovered(): Boolean = activity != null && isHostActivityStopped && otherResumedCount > 0
+    private fun isFlutterOccluded(): Boolean = activity != null && isHostActivityStopped && otherResumedCount > 0
 
     @OptIn(PostHogInternalReplayApi::class)
     private fun occlusionTick() {
         if (!isSessionReplayActive()) {
             if (isOccluded || bridgeEnabled) {
-                // A session boundary — reset(), or a close()/setup() pair — turns
-                // replay off until its flags reload lands. Ending the episode
-                // there lifts Dart's capture suppression while a native screen is
-                // still on top, and the tick after re-detects that same cover as a
-                // fresh episode. Hold for as long as the cover is up: nothing is
-                // captured while replay is off, so the hold costs no frames, and
-                // the cover going away is what ends the episode either way.
-                if (isFlutterCovered()) {
+                // Replay reads inactive across a session boundary — reset(), or a
+                // close()/setup() pair — until its flags reload lands, and that is
+                // not the episode ending. Ending here would lift Dart's capture
+                // suppression under a live native cover. Unbounded on purpose:
+                // nothing is captured while replay is off, so the hold costs no
+                // frames, and the cover going away ends the episode either way.
+                if (isFlutterOccluded()) {
                     heldWhileInactive = true
-                    // Per run of not-covered reads, matching the active path,
-                    // which clears this on every tick that keeps the episode.
+                    // Re-arms the debounce budget below for the next run of
+                    // not-occluded reads. A blip seen before the hold is not
+                    // carried across it, so it cannot signal a cover swap later.
                     notOccludedTicks = 0
                     return
                 } else if (notOccludedTicks < 1) {
                     // The same end-debounce the active path applies, because a
-                    // native→native handoff's first not-covered read can land on
-                    // either side of the boundary. Without it, a tick reading the
-                    // gap between one native screen finishing and the next
-                    // resuming ends the episode with no guard at all.
+                    // native→native handoff's first not-occluded read can land on
+                    // either side of the boundary.
                     notOccludedTicks++
                     return
                 }
@@ -1027,7 +1025,7 @@ class PosthogFlutterPlugin :
         }
         val resumedFromHold = heldWhileInactive
         heldWhileInactive = false
-        val occludedNow = isFlutterCovered()
+        val occludedNow = isFlutterOccluded()
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a
         // stale Flutter frame into the native flow.
@@ -1042,8 +1040,8 @@ class PosthogFlutterPlugin :
         // A hold that ends with the cover still up and no bridge re-handshakes
         // for the same reason: the enable was refused while replay was off (it
         // requires an active recording), so without this Dart keeps showing a
-        // placeholder it emitted for a session that has since rotated, and the
-        // new one gets nothing until the cover goes away.
+        // placeholder it emitted for an episode the SDK has since stopped
+        // recording, and nothing replaces it until the cover goes away.
         val resumedUnbridged = resumedFromHold && !bridgeEnabled
         val coverSwapped =
             occludedNow && isOccluded && (notOccludedTicks > 0 || resumedUnbridged)

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -50,9 +50,11 @@ private const val OCCLUSION_TICK_MS = 1000L
 
 // How long an occlusion episode survives while replay reads inactive. Wall time,
 // not ticks: lifecycle and window callbacks nudge extra ticks, which would burn a
-// tick budget in milliseconds. Covers a session boundary's inactive window (about
-// a second) with margin.
-private const val INACTIVE_HOLD_MS = 2000L
+// tick budget in milliseconds. A session boundary keeps replay off until the
+// flags reload lands, so the window is a network round trip, not a fixed delay —
+// this only has to outlast one attempt. It is a safety valve for a coverage
+// reading that never recovers, not the thing that ends a dismissed cover.
+private const val INACTIVE_HOLD_MS = 30_000L
 
 private const val BRIDGE_FAILURE_STRIKE_LIMIT = 3
 
@@ -940,6 +942,7 @@ class PosthogFlutterPlugin :
 
     private fun stopOcclusionDetector() {
         occlusionDetectorRunning = false
+        inactiveHoldStartedAt = 0L
         mainHandler.removeCallbacks(occlusionTicker)
         mainHandler.removeCallbacks(nudgeRunnable)
         unregisterLifecycleTracking()
@@ -984,12 +987,11 @@ class PosthogFlutterPlugin :
         if (!isSessionReplayActive()) {
             if (isOccluded || bridgeEnabled) {
                 // A session boundary — reset(), or a close()/setup() pair — turns
-                // replay off for around a second. Ending the episode there lifts
-                // Dart's capture suppression while a native screen is still on
-                // top, and the tick after re-detects that same cover as a fresh
-                // episode. Hold while still covered. Bounded, because an episode
-                // end is the only thing that releases the suppression: a recording
-                // that really did stop must still get one.
+                // replay off until its flags reload lands. Ending the episode
+                // there lifts Dart's capture suppression while a native screen is
+                // still on top, and the tick after re-detects that same cover as a
+                // fresh episode. Hold while still covered: nothing is captured
+                // while replay is off, so holding costs no frames.
                 if (isFlutterCovered()) {
                     val now = SystemClock.uptimeMillis()
                     if (inactiveHoldStartedAt == 0L) {
@@ -1021,15 +1023,6 @@ class PosthogFlutterPlugin :
         }
         val resumedFromHold = inactiveHoldStartedAt != 0L
         inactiveHoldStartedAt = 0L
-        if (resumedFromHold && bridgeEnabled) {
-            // The episode outlived a session rotation. Re-arm the per-episode
-            // bridge state so the new session's first bridged frame counts as the
-            // episode's first — resetting the decor view's snapshot state rather
-            // than leaning on the native SDK to do it on rotation — and so failure
-            // demotion can still fall back to the placeholder.
-            bridgeEpisodeStarted = false
-            bridgeFailureStrikes = 0
-        }
         val occludedNow = isFlutterCovered()
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -14,7 +14,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.SystemClock
 import android.util.Log
 import android.view.PixelCopy
 import android.view.SurfaceView
@@ -47,14 +46,6 @@ import kotlin.math.roundToInt
 
 private const val FLUTTER_VIEW_CLASS_PREFIX = "io.flutter"
 private const val OCCLUSION_TICK_MS = 1000L
-
-// How long an occlusion episode survives while replay reads inactive. Wall time,
-// not ticks: lifecycle and window callbacks nudge extra ticks, which would burn a
-// tick budget in milliseconds. A session boundary keeps replay off until the
-// flags reload lands, so the window is a network round trip, not a fixed delay —
-// this only has to outlast one attempt. It is a safety valve for a coverage
-// reading that never recovers, not the thing that ends a dismissed cover.
-private const val INACTIVE_HOLD_MS = 30_000L
 
 private const val BRIDGE_FAILURE_STRIKE_LIMIT = 3
 
@@ -866,8 +857,8 @@ class PosthogFlutterPlugin :
     // End-transition debounce: ticks reading not-occluded while an episode is active.
     private var notOccludedTicks = 0
 
-    // When the current run of inactive reads began, 0 when not holding.
-    private var inactiveHoldStartedAt = 0L
+    // Whether the episode is being held open across a run of inactive reads.
+    private var heldWhileInactive = false
 
     // Monotonic episode id, stamped into every push so Dart drops stale-episode
     // async work. Volatile: re-read on the capture executor.
@@ -942,7 +933,7 @@ class PosthogFlutterPlugin :
 
     private fun stopOcclusionDetector() {
         occlusionDetectorRunning = false
-        inactiveHoldStartedAt = 0L
+        heldWhileInactive = false
         mainHandler.removeCallbacks(occlusionTicker)
         mainHandler.removeCallbacks(nudgeRunnable)
         unregisterLifecycleTracking()
@@ -990,16 +981,15 @@ class PosthogFlutterPlugin :
                 // replay off until its flags reload lands. Ending the episode
                 // there lifts Dart's capture suppression while a native screen is
                 // still on top, and the tick after re-detects that same cover as a
-                // fresh episode. Hold while still covered: nothing is captured
-                // while replay is off, so holding costs no frames.
+                // fresh episode. Hold for as long as the cover is up: nothing is
+                // captured while replay is off, so the hold costs no frames, and
+                // the cover going away is what ends the episode either way.
                 if (isFlutterCovered()) {
-                    val now = SystemClock.uptimeMillis()
-                    if (inactiveHoldStartedAt == 0L) {
-                        inactiveHoldStartedAt = now
-                    }
-                    if (now - inactiveHoldStartedAt < INACTIVE_HOLD_MS) {
-                        return
-                    }
+                    heldWhileInactive = true
+                    // Per run of not-covered reads, matching the active path,
+                    // which clears this on every tick that keeps the episode.
+                    notOccludedTicks = 0
+                    return
                 } else if (notOccludedTicks < 1) {
                     // The same end-debounce the active path applies, because a
                     // native→native handoff's first not-covered read can land on
@@ -1018,11 +1008,11 @@ class PosthogFlutterPlugin :
                 // occluded=true push looks like unchanged state.
                 pushOcclusionEvent(occluded = false)
             }
-            inactiveHoldStartedAt = 0L
+            heldWhileInactive = false
             return
         }
-        val resumedFromHold = inactiveHoldStartedAt != 0L
-        inactiveHoldStartedAt = 0L
+        val resumedFromHold = heldWhileInactive
+        heldWhileInactive = false
         val occludedNow = isFlutterCovered()
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -48,6 +48,10 @@ import kotlin.math.roundToInt
 private const val FLUTTER_VIEW_CLASS_PREFIX = "io.flutter"
 private const val OCCLUSION_TICK_MS = 1000L
 
+// Ticks a not-occluded read must repeat before it ends an episode. Both the
+// active and the inactive path debounce, and they have to agree.
+private const val END_DEBOUNCE_TICKS = 1
+
 private const val BRIDGE_FAILURE_STRIKE_LIMIT = 3
 
 /** PosthogFlutterPlugin */
@@ -948,6 +952,7 @@ class PosthogFlutterPlugin :
     private fun stopOcclusionDetector() {
         occlusionDetectorRunning = false
         heldWhileInactive = false
+        notOccludedTicks = 0
         mainHandler.removeCallbacks(occlusionTicker)
         mainHandler.removeCallbacks(nudgeRunnable)
         unregisterLifecycleTracking()
@@ -999,12 +1004,11 @@ class PosthogFlutterPlugin :
                 // frames, and the cover going away ends the episode either way.
                 if (isFlutterOccluded()) {
                     heldWhileInactive = true
-                    // Re-arms the debounce budget below for the next run of
-                    // not-occluded reads. A blip seen before the hold is not
-                    // carried across it, so it cannot signal a cover swap later.
+                    // A blip seen before the hold is deliberately not carried
+                    // across it, so it cannot signal a cover swap later.
                     notOccludedTicks = 0
                     return
-                } else if (notOccludedTicks < 1) {
+                } else if (notOccludedTicks < END_DEBOUNCE_TICKS) {
                     // The same end-debounce the active path applies, because a
                     // native→native handoff's first not-occluded read can land on
                     // either side of the boundary.
@@ -1029,7 +1033,7 @@ class PosthogFlutterPlugin :
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a
         // stale Flutter frame into the native flow.
-        if (!occludedNow && isOccluded && notOccludedTicks < 1) {
+        if (!occludedNow && isOccluded && notOccludedTicks < END_DEBOUNCE_TICKS) {
             notOccludedTicks++
             return
         }

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -987,12 +987,10 @@ class PosthogFlutterPlugin :
                 // replay off for around a second. Ending the episode there lifts
                 // Dart's capture suppression while a native screen is still on
                 // top, and the tick after re-detects that same cover as a fresh
-                // episode. Hold while still covered — using the same debounced
-                // view of coverage the active path applies, so a native→native
-                // handoff reading not-covered cannot skip both guards at once.
-                // Bounded, because an episode end is the only thing that releases
-                // the suppression: a recording that really did stop must get one.
-                if (isFlutterCovered() || notOccludedTicks > 0) {
+                // episode. Hold while still covered. Bounded, because an episode
+                // end is the only thing that releases the suppression: a recording
+                // that really did stop must still get one.
+                if (isFlutterCovered()) {
                     val now = SystemClock.uptimeMillis()
                     if (inactiveHoldStartedAt == 0L) {
                         inactiveHoldStartedAt = now
@@ -1000,6 +998,14 @@ class PosthogFlutterPlugin :
                     if (now - inactiveHoldStartedAt < INACTIVE_HOLD_MS) {
                         return
                     }
+                } else if (notOccludedTicks < 1) {
+                    // The same end-debounce the active path applies, because a
+                    // native→native handoff's first not-covered read can land on
+                    // either side of the boundary. Without it, a tick reading the
+                    // gap between one native screen finishing and the next
+                    // resuming ends the episode with no guard at all.
+                    notOccludedTicks++
+                    return
                 }
                 isOccluded = false
                 bridgeEnabled = false
@@ -1015,6 +1021,15 @@ class PosthogFlutterPlugin :
         }
         val resumedFromHold = inactiveHoldStartedAt != 0L
         inactiveHoldStartedAt = 0L
+        if (resumedFromHold && bridgeEnabled) {
+            // The episode outlived a session rotation. Re-arm the per-episode
+            // bridge state so the new session's first bridged frame counts as the
+            // episode's first — resetting the decor view's snapshot state rather
+            // than leaning on the native SDK to do it on rotation — and so failure
+            // demotion can still fall back to the placeholder.
+            bridgeEpisodeStarted = false
+            bridgeFailureStrikes = 0
+        }
         val occludedNow = isFlutterCovered()
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -47,6 +47,10 @@ import kotlin.math.roundToInt
 private const val FLUTTER_VIEW_CLASS_PREFIX = "io.flutter"
 private const val OCCLUSION_TICK_MS = 1000L
 
+// Ticks an occlusion episode survives while replay reads inactive. Two covers a
+// session boundary, whose inactive window runs to about one tick, with margin.
+private const val INACTIVE_HOLD_TICKS = 2
+
 private const val BRIDGE_FAILURE_STRIKE_LIMIT = 3
 
 /** PosthogFlutterPlugin */
@@ -857,6 +861,9 @@ class PosthogFlutterPlugin :
     // End-transition debounce: ticks reading not-occluded while an episode is active.
     private var notOccludedTicks = 0
 
+    // Ticks an episode has been held open while replay reads inactive.
+    private var inactiveTicks = 0
+
     // Monotonic episode id, stamped into every push so Dart drops stale-episode
     // async work. Volatile: re-read on the capture executor.
     @Volatile
@@ -964,10 +971,27 @@ class PosthogFlutterPlugin :
         )
     }
 
+    // Null activity (config-change detach) fails open — the captured Flutter tree
+    // has no native pixels. Known limitation: a host recreation mid-episode never
+    // re-fires onActivityResumed, ending the episode early.
+    private fun isFlutterCovered(): Boolean = activity != null && isHostActivityStopped && otherResumedCount > 0
+
     @OptIn(PostHogInternalReplayApi::class)
     private fun occlusionTick() {
         if (!isSessionReplayActive()) {
             if (isOccluded || bridgeEnabled) {
+                // A session boundary — reset(), or a close()/setup() pair — turns
+                // replay off for around a tick. Ending the episode there lifts
+                // Dart's capture suppression while a native screen is still on
+                // top, and the tick after re-detects that same cover as a fresh
+                // episode. Hold while still covered, long enough to outlast a
+                // boundary (and a burst of them) at this tick rate. Bounded,
+                // because an episode end is the only thing that releases the
+                // suppression, so a recording that really did stop must get one.
+                if (isFlutterCovered() && inactiveTicks < INACTIVE_HOLD_TICKS) {
+                    inactiveTicks++
+                    return
+                }
                 isOccluded = false
                 bridgeEnabled = false
                 bridgeEpisodeStarted = false
@@ -977,13 +1001,11 @@ class PosthogFlutterPlugin :
                 // occluded=true push looks like unchanged state.
                 pushOcclusionEvent(occluded = false)
             }
+            inactiveTicks = 0
             return
         }
-        // Null activity (config-change detach) fails open — the captured Flutter
-        // tree has no native pixels. Known limitation: a host recreation
-        // mid-episode never re-fires onActivityResumed, ending the episode early.
-        val occludedNow =
-            activity != null && isHostActivityStopped && otherResumedCount > 0
+        inactiveTicks = 0
+        val occludedNow = isFlutterCovered()
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a
         // stale Flutter frame into the native flow.

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.util.Log
 import android.view.PixelCopy
 import android.view.SurfaceView
@@ -47,9 +48,11 @@ import kotlin.math.roundToInt
 private const val FLUTTER_VIEW_CLASS_PREFIX = "io.flutter"
 private const val OCCLUSION_TICK_MS = 1000L
 
-// Ticks an occlusion episode survives while replay reads inactive. Two covers a
-// session boundary, whose inactive window runs to about one tick, with margin.
-private const val INACTIVE_HOLD_TICKS = 2
+// How long an occlusion episode survives while replay reads inactive. Wall time,
+// not ticks: lifecycle and window callbacks nudge extra ticks, which would burn a
+// tick budget in milliseconds. Covers a session boundary's inactive window (about
+// a second) with margin.
+private const val INACTIVE_HOLD_MS = 2000L
 
 private const val BRIDGE_FAILURE_STRIKE_LIMIT = 3
 
@@ -861,8 +864,8 @@ class PosthogFlutterPlugin :
     // End-transition debounce: ticks reading not-occluded while an episode is active.
     private var notOccludedTicks = 0
 
-    // Ticks an episode has been held open while replay reads inactive.
-    private var inactiveTicks = 0
+    // When the current run of inactive reads began, 0 when not holding.
+    private var inactiveHoldStartedAt = 0L
 
     // Monotonic episode id, stamped into every push so Dart drops stale-episode
     // async work. Volatile: re-read on the capture executor.
@@ -981,16 +984,22 @@ class PosthogFlutterPlugin :
         if (!isSessionReplayActive()) {
             if (isOccluded || bridgeEnabled) {
                 // A session boundary — reset(), or a close()/setup() pair — turns
-                // replay off for around a tick. Ending the episode there lifts
+                // replay off for around a second. Ending the episode there lifts
                 // Dart's capture suppression while a native screen is still on
                 // top, and the tick after re-detects that same cover as a fresh
-                // episode. Hold while still covered, long enough to outlast a
-                // boundary (and a burst of them) at this tick rate. Bounded,
-                // because an episode end is the only thing that releases the
-                // suppression, so a recording that really did stop must get one.
-                if (isFlutterCovered() && inactiveTicks < INACTIVE_HOLD_TICKS) {
-                    inactiveTicks++
-                    return
+                // episode. Hold while still covered — using the same debounced
+                // view of coverage the active path applies, so a native→native
+                // handoff reading not-covered cannot skip both guards at once.
+                // Bounded, because an episode end is the only thing that releases
+                // the suppression: a recording that really did stop must get one.
+                if (isFlutterCovered() || notOccludedTicks > 0) {
+                    val now = SystemClock.uptimeMillis()
+                    if (inactiveHoldStartedAt == 0L) {
+                        inactiveHoldStartedAt = now
+                    }
+                    if (now - inactiveHoldStartedAt < INACTIVE_HOLD_MS) {
+                        return
+                    }
                 }
                 isOccluded = false
                 bridgeEnabled = false
@@ -1001,10 +1010,11 @@ class PosthogFlutterPlugin :
                 // occluded=true push looks like unchanged state.
                 pushOcclusionEvent(occluded = false)
             }
-            inactiveTicks = 0
+            inactiveHoldStartedAt = 0L
             return
         }
-        inactiveTicks = 0
+        val resumedFromHold = inactiveHoldStartedAt != 0L
+        inactiveHoldStartedAt = 0L
         val occludedNow = isFlutterCovered()
         // Debounce END only: a native→native handoff (A pauses before B resumes)
         // briefly reads not-occluded; ending the episode there would flash a
@@ -1016,7 +1026,15 @@ class PosthogFlutterPlugin :
         // Occluded again after a blip = the cover was swapped. The old cover's
         // bridge grant must not carry over; re-handshake under a new episode
         // id. No end event, so Dart's suppression never lapses.
-        val coverSwapped = occludedNow && isOccluded && notOccludedTicks > 0
+        //
+        // A hold that ends with the cover still up and no bridge re-handshakes
+        // for the same reason: the enable was refused while replay was off (it
+        // requires an active recording), so without this Dart keeps showing a
+        // placeholder it emitted for a session that has since rotated, and the
+        // new one gets nothing until the cover goes away.
+        val resumedUnbridged = resumedFromHold && !bridgeEnabled
+        val coverSwapped =
+            occludedNow && isOccluded && (notOccludedTicks > 0 || resumedUnbridged)
         notOccludedTicks = 0
         if (occludedNow != isOccluded) {
             val previousOccluded = isOccluded

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -28,17 +28,19 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         private var bridgeEpisodeStarted = false
         // End-transition debounce: ticks reading not-occluded while an episode is active.
         private var notOccludedTicks = 0
-        // Ticks an episode has been held open while replay reads inactive.
-        private var inactiveTicks = 0
+        // When the current run of inactive reads began, nil when not holding.
+        private var inactiveHoldStartedAt: TimeInterval?
         // Monotonic episode id, stamped into every push so Dart drops stale-episode work.
         private var occlusionEpisode = 0
         // Failed captures before the episode's first delivered frame; at the limit it
         // falls back (bridgeFailed). After first delivery, failures never demote.
         private var bridgeFailureStrikes = 0
         private static let bridgeFailureStrikeLimit = 3
-        // Ticks an episode survives while replay reads inactive. Two covers a
-        // session boundary, whose inactive window runs to about one tick.
-        private static let inactiveHoldTicks = 2
+        // How long an episode survives while replay reads inactive. Wall time, not
+        // ticks: window notifications nudge extra ticks, which would burn a tick
+        // budget in milliseconds. Covers a session boundary's inactive window
+        // (about a second) with margin.
+        private static let inactiveHoldSeconds: TimeInterval = 2
     #endif
 
     private static var instance: PosthogFlutterPlugin?
@@ -891,17 +893,22 @@ extension PosthogFlutterPlugin {
             guard PostHogSDK.shared.isSessionReplayActive() else {
                 if isOccluded || bridgeEnabled {
                     // A session boundary — reset(), or a close()/setup() pair —
-                    // turns replay off for around a tick. Ending the episode there
-                    // would lift Dart's capture suppression while a native screen
-                    // is still on top, and the tick after re-detects that same
-                    // cover as a fresh episode. Hold while still covered, long
-                    // enough to outlast a boundary (and a burst of them) at this
-                    // tick rate. Bounded, because an episode end is the only thing
-                    // that releases the suppression, so a recording that really
-                    // did stop must still get one.
-                    if Self.isFlutterOccluded(), inactiveTicks < Self.inactiveHoldTicks {
-                        inactiveTicks += 1
-                        return
+                    // turns replay off for around a second. Ending the episode
+                    // there would lift Dart's capture suppression while a native
+                    // screen is still on top, and the tick after re-detects that
+                    // same cover as a fresh episode. Hold while still covered —
+                    // using the same debounced view of coverage the active path
+                    // applies, so a native→native handoff reading not-covered
+                    // cannot skip both guards at once. Bounded, because an episode
+                    // end is the only thing that releases the suppression: a
+                    // recording that really did stop must still get one.
+                    if Self.isFlutterOccluded() || notOccludedTicks > 0 {
+                        let now = ProcessInfo.processInfo.systemUptime
+                        let startedAt = inactiveHoldStartedAt ?? now
+                        inactiveHoldStartedAt = startedAt
+                        if now - startedAt < Self.inactiveHoldSeconds {
+                            return
+                        }
                     }
                     isOccluded = false
                     bridgeEnabled = false
@@ -911,10 +918,11 @@ extension PosthogFlutterPlugin {
                     // occluded=true push looks like unchanged state.
                     pushOcclusionEvent(occluded: false)
                 }
-                inactiveTicks = 0
+                inactiveHoldStartedAt = nil
                 return
             }
-            inactiveTicks = 0
+            let resumedFromHold = inactiveHoldStartedAt != nil
+            inactiveHoldStartedAt = nil
             let occluded = Self.isFlutterOccluded()
             // Debounce END only: a native→native handoff briefly reads
             // not-occluded; ending the episode there would flash a stale frame.
@@ -925,7 +933,14 @@ extension PosthogFlutterPlugin {
             // Occluded again after a blip = the cover was swapped. The old
             // cover's bridge grant must not carry over; re-handshake under a
             // new episode id. No end event, so Dart's suppression never lapses.
-            let coverSwapped = occluded && isOccluded && notOccludedTicks > 0
+            //
+            // A hold that ends with the cover still up and no bridge re-handshakes
+            // for the same reason: the enable was refused while replay was off (it
+            // requires an active recording), so without this Dart keeps showing a
+            // placeholder it emitted for a session that has since rotated, and the
+            // new one gets nothing until the cover goes away.
+            let resumedUnbridged = resumedFromHold && !bridgeEnabled
+            let coverSwapped = occluded && isOccluded && (notOccludedTicks > 0 || resumedUnbridged)
             notOccludedTicks = 0
             if occluded != isOccluded {
                 isOccluded = occluded

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -38,9 +38,12 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         private static let bridgeFailureStrikeLimit = 3
         // How long an episode survives while replay reads inactive. Wall time, not
         // ticks: window notifications nudge extra ticks, which would burn a tick
-        // budget in milliseconds. Covers a session boundary's inactive window
-        // (about a second) with margin.
-        private static let inactiveHoldSeconds: TimeInterval = 2
+        // budget in milliseconds. A session boundary keeps replay off until the
+        // flags reload lands, so the window is a network round trip, not a fixed
+        // delay — this only has to outlast one attempt. It is a safety valve for a
+        // coverage reading that never recovers, not the thing that ends a
+        // dismissed cover.
+        private static let inactiveHoldSeconds: TimeInterval = 30
     #endif
 
     private static var instance: PosthogFlutterPlugin?
@@ -843,6 +846,7 @@ extension PosthogFlutterPlugin {
         }
 
         func stopOcclusionDetector() {
+            inactiveHoldStartedAt = nil
             occlusionTimer?.invalidate()
             occlusionTimer = nil
             NotificationCenter.default.removeObserver(self, name: UIWindow.didBecomeVisibleNotification, object: nil)
@@ -893,13 +897,12 @@ extension PosthogFlutterPlugin {
             guard PostHogSDK.shared.isSessionReplayActive() else {
                 if isOccluded || bridgeEnabled {
                     // A session boundary — reset(), or a close()/setup() pair —
-                    // turns replay off for around a second. Ending the episode
-                    // there would lift Dart's capture suppression while a native
-                    // screen is still on top, and the tick after re-detects that
-                    // same cover as a fresh episode. Hold while still covered.
-                    // Bounded, because an episode end is the only thing that
-                    // releases the suppression: a recording that really did stop
-                    // must still get one.
+                    // turns replay off until its flags reload lands. Ending the
+                    // episode there would lift Dart's capture suppression while a
+                    // native screen is still on top, and the tick after re-detects
+                    // that same cover as a fresh episode. Hold while still
+                    // covered: nothing is captured while replay is off, so holding
+                    // costs no frames.
                     if Self.isFlutterOccluded() {
                         let now = ProcessInfo.processInfo.systemUptime
                         let startedAt = inactiveHoldStartedAt ?? now
@@ -929,14 +932,6 @@ extension PosthogFlutterPlugin {
             }
             let resumedFromHold = inactiveHoldStartedAt != nil
             inactiveHoldStartedAt = nil
-            if resumedFromHold, bridgeEnabled {
-                // The episode outlived a session rotation. Re-arm the per-episode
-                // bridge state so the new session's first bridged frame counts as
-                // the episode's first, and so failure demotion can still fall back
-                // to the placeholder.
-                bridgeEpisodeStarted = false
-                bridgeFailureStrikes = 0
-            }
             let occluded = Self.isFlutterOccluded()
             // Debounce END only: a native→native handoff briefly reads
             // not-occluded; ending the episode there would flash a stale frame.

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -36,6 +36,9 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         // falls back (bridgeFailed). After first delivery, failures never demote.
         private var bridgeFailureStrikes = 0
         private static let bridgeFailureStrikeLimit = 3
+        // Ticks a not-occluded read must repeat before it ends an episode. Both
+        // the active and the inactive path debounce, and they have to agree.
+        private static let endDebounceTicks = 1
     #endif
 
     private static var instance: PosthogFlutterPlugin?
@@ -841,6 +844,7 @@ extension PosthogFlutterPlugin {
 
         func stopOcclusionDetector() {
             heldWhileInactive = false
+            notOccludedTicks = 0
             occlusionTimer?.invalidate()
             occlusionTimer = nil
             NotificationCenter.default.removeObserver(self, name: UIWindow.didBecomeVisibleNotification, object: nil)
@@ -899,12 +903,11 @@ extension PosthogFlutterPlugin {
                     // either way.
                     if Self.isFlutterOccluded() {
                         heldWhileInactive = true
-                        // Re-arms the debounce budget below for the next run of
-                        // not-occluded reads. A blip seen before the hold is not
-                        // carried across it, so it cannot signal a cover swap later.
+                        // A blip seen before the hold is deliberately not carried
+                        // across it, so it cannot signal a cover swap later.
                         notOccludedTicks = 0
                         return
-                    } else if notOccludedTicks < 1 {
+                    } else if notOccludedTicks < Self.endDebounceTicks {
                         // The same end-debounce the active path applies, because a
                         // native→native handoff's first not-occluded read can land
                         // on either side of the boundary.
@@ -927,7 +930,7 @@ extension PosthogFlutterPlugin {
             let occluded = Self.isFlutterOccluded()
             // Debounce END only: a native→native handoff briefly reads
             // not-occluded; ending the episode there would flash a stale frame.
-            if !occluded, isOccluded, notOccludedTicks < 1 {
+            if !occluded, isOccluded, notOccludedTicks < Self.endDebounceTicks {
                 notOccludedTicks += 1
                 return
             }

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -890,26 +890,24 @@ extension PosthogFlutterPlugin {
             }
             guard PostHogSDK.shared.isSessionReplayActive() else {
                 if isOccluded || bridgeEnabled {
-                    // A session boundary — reset(), or a close()/setup() pair —
-                    // turns replay off until its flags reload lands. Ending the
-                    // episode there would lift Dart's capture suppression while a
-                    // native screen is still on top, and the tick after re-detects
-                    // that same cover as a fresh episode. Hold for as long as the
-                    // cover is up: nothing is captured while replay is off, so the
-                    // hold costs no frames, and the cover going away is what ends
-                    // the episode either way.
+                    // Replay reads inactive across a session boundary — reset(),
+                    // or a close()/setup() pair — until its flags reload lands, and
+                    // that is not the episode ending. Ending here would lift Dart's
+                    // capture suppression under a live native cover. Unbounded on
+                    // purpose: nothing is captured while replay is off, so the hold
+                    // costs no frames, and the cover going away ends the episode
+                    // either way.
                     if Self.isFlutterOccluded() {
                         heldWhileInactive = true
-                        // Per run of not-occluded reads, matching the active path,
-                        // which clears this on every tick that keeps the episode.
+                        // Re-arms the debounce budget below for the next run of
+                        // not-occluded reads. A blip seen before the hold is not
+                        // carried across it, so it cannot signal a cover swap later.
                         notOccludedTicks = 0
                         return
                     } else if notOccludedTicks < 1 {
                         // The same end-debounce the active path applies, because a
                         // native→native handoff's first not-occluded read can land
-                        // on either side of the boundary. Without it, a tick
-                        // reading the gap between one native screen dismissing and
-                        // the next presenting ends the episode with no guard.
+                        // on either side of the boundary.
                         notOccludedTicks += 1
                         return
                     }
@@ -940,8 +938,8 @@ extension PosthogFlutterPlugin {
             // A hold that ends with the cover still up and no bridge re-handshakes
             // for the same reason: the enable was refused while replay was off (it
             // requires an active recording), so without this Dart keeps showing a
-            // placeholder it emitted for a session that has since rotated, and the
-            // new one gets nothing until the cover goes away.
+            // placeholder it emitted for an episode the SDK has since stopped
+            // recording, and nothing replaces it until the cover goes away.
             let resumedUnbridged = resumedFromHold && !bridgeEnabled
             let coverSwapped = occluded && isOccluded && (notOccludedTicks > 0 || resumedUnbridged)
             notOccludedTicks = 0

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -28,22 +28,14 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         private var bridgeEpisodeStarted = false
         // End-transition debounce: ticks reading not-occluded while an episode is active.
         private var notOccludedTicks = 0
-        // When the current run of inactive reads began, nil when not holding.
-        private var inactiveHoldStartedAt: TimeInterval?
+        // Whether the episode is being held open across a run of inactive reads.
+        private var heldWhileInactive = false
         // Monotonic episode id, stamped into every push so Dart drops stale-episode work.
         private var occlusionEpisode = 0
         // Failed captures before the episode's first delivered frame; at the limit it
         // falls back (bridgeFailed). After first delivery, failures never demote.
         private var bridgeFailureStrikes = 0
         private static let bridgeFailureStrikeLimit = 3
-        // How long an episode survives while replay reads inactive. Wall time, not
-        // ticks: window notifications nudge extra ticks, which would burn a tick
-        // budget in milliseconds. A session boundary keeps replay off until the
-        // flags reload lands, so the window is a network round trip, not a fixed
-        // delay — this only has to outlast one attempt. It is a safety valve for a
-        // coverage reading that never recovers, not the thing that ends a
-        // dismissed cover.
-        private static let inactiveHoldSeconds: TimeInterval = 30
     #endif
 
     private static var instance: PosthogFlutterPlugin?
@@ -846,7 +838,7 @@ extension PosthogFlutterPlugin {
         }
 
         func stopOcclusionDetector() {
-            inactiveHoldStartedAt = nil
+            heldWhileInactive = false
             occlusionTimer?.invalidate()
             occlusionTimer = nil
             NotificationCenter.default.removeObserver(self, name: UIWindow.didBecomeVisibleNotification, object: nil)
@@ -900,16 +892,16 @@ extension PosthogFlutterPlugin {
                     // turns replay off until its flags reload lands. Ending the
                     // episode there would lift Dart's capture suppression while a
                     // native screen is still on top, and the tick after re-detects
-                    // that same cover as a fresh episode. Hold while still
-                    // covered: nothing is captured while replay is off, so holding
-                    // costs no frames.
+                    // that same cover as a fresh episode. Hold for as long as the
+                    // cover is up: nothing is captured while replay is off, so the
+                    // hold costs no frames, and the cover going away is what ends
+                    // the episode either way.
                     if Self.isFlutterOccluded() {
-                        let now = ProcessInfo.processInfo.systemUptime
-                        let startedAt = inactiveHoldStartedAt ?? now
-                        inactiveHoldStartedAt = startedAt
-                        if now - startedAt < Self.inactiveHoldSeconds {
-                            return
-                        }
+                        heldWhileInactive = true
+                        // Per run of not-occluded reads, matching the active path,
+                        // which clears this on every tick that keeps the episode.
+                        notOccludedTicks = 0
+                        return
                     } else if notOccludedTicks < 1 {
                         // The same end-debounce the active path applies, because a
                         // native→native handoff's first not-occluded read can land
@@ -927,11 +919,11 @@ extension PosthogFlutterPlugin {
                     // occluded=true push looks like unchanged state.
                     pushOcclusionEvent(occluded: false)
                 }
-                inactiveHoldStartedAt = nil
+                heldWhileInactive = false
                 return
             }
-            let resumedFromHold = inactiveHoldStartedAt != nil
-            inactiveHoldStartedAt = nil
+            let resumedFromHold = heldWhileInactive
+            heldWhileInactive = false
             let occluded = Self.isFlutterOccluded()
             // Debounce END only: a native→native handoff briefly reads
             // not-occluded; ending the episode there would flash a stale frame.

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -896,19 +896,25 @@ extension PosthogFlutterPlugin {
                     // turns replay off for around a second. Ending the episode
                     // there would lift Dart's capture suppression while a native
                     // screen is still on top, and the tick after re-detects that
-                    // same cover as a fresh episode. Hold while still covered —
-                    // using the same debounced view of coverage the active path
-                    // applies, so a native→native handoff reading not-covered
-                    // cannot skip both guards at once. Bounded, because an episode
-                    // end is the only thing that releases the suppression: a
-                    // recording that really did stop must still get one.
-                    if Self.isFlutterOccluded() || notOccludedTicks > 0 {
+                    // same cover as a fresh episode. Hold while still covered.
+                    // Bounded, because an episode end is the only thing that
+                    // releases the suppression: a recording that really did stop
+                    // must still get one.
+                    if Self.isFlutterOccluded() {
                         let now = ProcessInfo.processInfo.systemUptime
                         let startedAt = inactiveHoldStartedAt ?? now
                         inactiveHoldStartedAt = startedAt
                         if now - startedAt < Self.inactiveHoldSeconds {
                             return
                         }
+                    } else if notOccludedTicks < 1 {
+                        // The same end-debounce the active path applies, because a
+                        // native→native handoff's first not-occluded read can land
+                        // on either side of the boundary. Without it, a tick
+                        // reading the gap between one native screen dismissing and
+                        // the next presenting ends the episode with no guard.
+                        notOccludedTicks += 1
+                        return
                     }
                     isOccluded = false
                     bridgeEnabled = false
@@ -923,6 +929,14 @@ extension PosthogFlutterPlugin {
             }
             let resumedFromHold = inactiveHoldStartedAt != nil
             inactiveHoldStartedAt = nil
+            if resumedFromHold, bridgeEnabled {
+                // The episode outlived a session rotation. Re-arm the per-episode
+                // bridge state so the new session's first bridged frame counts as
+                // the episode's first, and so failure demotion can still fall back
+                // to the placeholder.
+                bridgeEpisodeStarted = false
+                bridgeFailureStrikes = 0
+            }
             let occluded = Self.isFlutterOccluded()
             // Debounce END only: a native→native handoff briefly reads
             // not-occluded; ending the episode there would flash a stale frame.

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -28,12 +28,17 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         private var bridgeEpisodeStarted = false
         // End-transition debounce: ticks reading not-occluded while an episode is active.
         private var notOccludedTicks = 0
+        // Ticks an episode has been held open while replay reads inactive.
+        private var inactiveTicks = 0
         // Monotonic episode id, stamped into every push so Dart drops stale-episode work.
         private var occlusionEpisode = 0
         // Failed captures before the episode's first delivered frame; at the limit it
         // falls back (bridgeFailed). After first delivery, failures never demote.
         private var bridgeFailureStrikes = 0
         private static let bridgeFailureStrikeLimit = 3
+        // Ticks an episode survives while replay reads inactive. Two covers a
+        // session boundary, whose inactive window runs to about one tick.
+        private static let inactiveHoldTicks = 2
     #endif
 
     private static var instance: PosthogFlutterPlugin?
@@ -885,6 +890,19 @@ extension PosthogFlutterPlugin {
             }
             guard PostHogSDK.shared.isSessionReplayActive() else {
                 if isOccluded || bridgeEnabled {
+                    // A session boundary — reset(), or a close()/setup() pair —
+                    // turns replay off for around a tick. Ending the episode there
+                    // would lift Dart's capture suppression while a native screen
+                    // is still on top, and the tick after re-detects that same
+                    // cover as a fresh episode. Hold while still covered, long
+                    // enough to outlast a boundary (and a burst of them) at this
+                    // tick rate. Bounded, because an episode end is the only thing
+                    // that releases the suppression, so a recording that really
+                    // did stop must still get one.
+                    if Self.isFlutterOccluded(), inactiveTicks < Self.inactiveHoldTicks {
+                        inactiveTicks += 1
+                        return
+                    }
                     isOccluded = false
                     bridgeEnabled = false
                     bridgeEpisodeStarted = false
@@ -893,8 +911,10 @@ extension PosthogFlutterPlugin {
                     // occluded=true push looks like unchanged state.
                     pushOcclusionEvent(occluded: false)
                 }
+                inactiveTicks = 0
                 return
             }
+            inactiveTicks = 0
             let occluded = Self.isFlutterOccluded()
             // Debounce END only: a native→native handoff briefly reads
             // not-occluded; ending the episode there would flash a stale frame.


### PR DESCRIPTION
## :bulb: Motivation and Context

**A session boundary landing under a native screen drops the cover.** `reset()`, or a `close()`/`setup()` pair, turns session replay off for around a second. The occlusion detector polls once a second and reads that as "recording stopped", so a tick landing inside that window ends the episode **while the native screen is still on top**:

- Dart lifts its capture suppression, resumes Flutter capture, and forces a sample — recording the Flutter tree from underneath a native screen the user is actually looking at.
- The next tick re-detects the same, unchanged cover as a **new episode**, re-handshaking the bridge for a cover that never went away.

Found while device-testing #510, and pre-existing on `main` — the branch that surfaced it is Dart-only, and this path (`PosthogFlutterPlugin.kt:968`, `PosthogFlutterPlugin.swift:888` on `main`) is untouched by it. Independent of #510 and mergeable in either order.

## :hammer: How

Hold the episode while the app is **still covered**, instead of ending it the moment replay reads inactive. Three constraints shaped it, all from review:

- **Hold for as long as the cover is up** — not on a timer. An elapsed bound can only fire while replay is inactive, i.e. while nothing is being recorded, so ending the episode there buys nothing and reopens the very window this closes: Dart lifts suppression, replay returns before the next tick re-detects the cover, and a frame of the hidden Flutter UI can ship. A bound also cannot self-heal a coverage reading that never recovers, because a stuck reading only shows up while replay is *active*, where this branch never runs — true on `main` too.
- **Coverage drives the ending, not time.** A dismissed cover ends its episode through the not-covered debounce within a tick, whatever replay is doing; detector teardown ends it explicitly.
- **Debounce the inactive branch too, per run.** A native→native handoff transiently reads not-covered and that first read can land on either side of the boundary, so the inactive branch applies the same increment-and-return the active path does — and clears the counter while covered, so a second handoff in the same episode is guarded too, not just the first.
- **Re-handshake on resume.** `enableNativeBridge` acceptance requires an active recording, so a boundary landing while Dart's enable is in flight refuses it. A hold that ends with the cover still up and no bridge re-handshakes under a new episode, reusing the cover-swap path, so there is still no end event and suppression never lapses.

The hold is a boolean: no constant, no timestamp, no elapsed arithmetic.

## :green_heart: How did you test it?

**Device runs on Android (Pixel 9, API 37) and iOS (26.4 simulator)**, with a temporary hook that forces the replay-inactive window and refuses a handshake mid-flight (removed before commit). Marks bracket each cover so log ordering says whether an episode ended *under* it or *at its dismissal*.

| Scenario | Result, both platforms |
|---|---|
| Boundary lands mid-cover, bridge already granted | Episode intact, ends at dismissal |
| Boundary refused mid-handshake | Placeholder episode, then a **fresh bridged episode while the cover is still up** |
| Cover dismissed 2 s into a 12 s outage | Episode ends promptly at dismissal |
| 40 s outage, cover stays up throughout | **No end at 15 s or 31 s**; the episode ends only when the cover dismisses |

The re-handshake is mutation-tested on device: deleting it leaves that episode a placeholder for the entire cover.

**Known limit, unchanged by this PR:** a native→native handoff slower than one tick still ends the episode, on `main` and here alike — the pre-existing bound of the one-tick handoff debounce.

**No unit test:** the behaviour lives in a private main-thread poll driven by the SDK's replay-active flag and private activity-lifecycle counters, with no existing Kotlin/Swift coverage of `occlusionTick`. Reaching it would mean widening that state purely for the test; the device runs above are the evidence.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. — see **No unit test** above; verified on device on both platforms instead
- [x] I updated the docs if needed. — no user-facing API change
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, found while running the device verification #510's reviewer asked for. The first attempt at a repro was a single `reset()` under a cover, which read as a reproduction until brackets were added to the log — with them it was clear the episode had ended at dismissal all along, and the ordering had been ambiguous. That is what motivated the forced-window hook and the explicit `--- still covered ---` marks, so the before/after claim rests on ordering that cannot be misread.

The hold was one tick initially; it went to two after the measured inactive window turned out to run close to the 1 s tick interval, leaving no margin. A pure predicate helper with unit tests was written and then dropped — the tests asserted `a && b < n`, which tests the language rather than the behaviour.



