### PR TITLE
fix(release): opt private package into changesets v3 versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
## Problem

The `@changesets/cli` 2.31.1 → 3.0.0 bump in #544 silently broke releases. `posthog_flutter/package.json` is `"private": true` (it only exists to track the SDK version for changesets), and v3 no longer versions private packages unless you opt in. So `pnpm changeset version` became a no-op: the version stays put, the changeset files stay in place, and it prints its usual success line and exits 0.

That cascades quietly through `publish.yml`. `Apply changesets and update version` re-reads the unchanged `5.36.6`, `Sync version to all platform files` writes identical values, `Check for version bump changes` finds an empty `git status --porcelain`, and `Commit version bump`, `Tag and push` and everything downstream get skipped. The run reports success because every step genuinely succeeded, so nothing signals that no release came out of it.

Two releases have gone out this way since the bump landed on 2026-08-20:

- [32378136563](https://github.com/PostHog/posthog-flutter/actions/runs/32378136563), the native-screen cover fix (#543)
- [32398074230](https://github.com/PostHog/posthog-flutter/actions/runs/32398074230), `captureNativeCrashes` for Android NDK crashes (#539)

Both changesets are still sitting in `.changeset/` and the SDK is still on `5.36.6`.

The same bug hit posthog-ios (PostHog/posthog-ios#778) and posthog-go.

## Changes

Sets `privatePackages: { "version": true, "tag": false }` in `.changeset/config.json` to restore the v2 behaviour. `tag: false` because the release workflow creates the git tag itself, nothing here calls `changeset tag`.

## How did you test it?

Ran `changeset version` on CLI 3.0.0 against a copy of this branch's `.changeset/`, `pnpm-workspace.yaml` and `posthog_flutter/package.json`:

| config | result |
| --- | --- |
| without this fix | stays on `5.36.6`, both changesets untouched, exits 0 |
| with this fix | bumps to `5.37.0`, both changesets consumed, `CHANGELOG.md` written |

No changeset on this PR, it's a release-config fix with nothing user-facing for the changelog. `publish.yml` filters on `.changeset/*.md`, so touching `config.json` won't kick off a release on merge. Once this lands, the next approved release picks up both queued changesets as `5.37.0`.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
