### PR TITLE
chore: update changed shared workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
     name: Notify Slack - Approval Needed
     needs: check-changesets
     if: needs.check-changesets.outputs.has-changesets == 'true'
-    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
+    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
       slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}


### PR DESCRIPTION
## :bulb: Motivation and Context

The shared `notify-approval-needed.yml` workflow has changed since the commit pinned here. The older pins for `semantic-pr-title.yml` and `detect-markdown-only.yml` remain unchanged because those workflow files are byte-for-byte identical at the current shared-workflow commit.

This updates only the shared workflow whose content changed.

## :green_heart: How did you test it?

- Compared each referenced workflow blob with `PostHog/.github@5ba5d24966f2c416ca792654638e4ce6f19f545b`.
- Ran `git diff --check`.
- Ran `actionlint`. It reports the same pre-existing ShellCheck findings on the base branch.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's worker agent audited the reusable workflow references and made the pin-only edit. Each referenced workflow was compared by Git blob content, so older pins were retained when their workflow files had not changed. This PR requires human review and is assigned to the directing user.
