### PR TITLE
fix(android): require posthog-android 3.60.7 for the manual session replay fix

### DIFF
--- a/.changeset/android-floor-3-60-7.md
+++ b/.changeset/android-floor-3-60-7.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+Require posthog-android 3.60.7 or newer. Versions 3.43.2 through 3.60.4 stopped a manually started session replay (`sessionReplay: false` plus `startSessionRecording()`) as soon as it started, and 3.60.5/3.60.6 still lost it permanently after the session was cleared on a long background. Projects with a Gradle lockfile or cached dependency resolution could stay pinned to an affected version; the raised floor guarantees the fixed SDK.

--- a/.changeset/android-floor-3-60-7.md
+++ b/.changeset/android-floor-3-60-7.md
@@ -2,4 +2,4 @@
 "posthog_flutter": patch
 ---
 
-Require posthog-android 3.60.7 or newer. Versions 3.43.2 through 3.60.4 stopped a manually started session replay (`sessionReplay: false` plus `startSessionRecording()`) as soon as it started, and 3.60.5/3.60.6 still lost it permanently after the session was cleared on a long background. Projects with a Gradle lockfile or cached dependency resolution could stay pinned to an affected version; the raised floor guarantees the fixed SDK.
+Fix session replay started with `startSessionRecording()` capturing nothing on Android by requiring posthog-android 3.60.7 or newer.

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,7 +64,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.posthog:posthog-android:[3.60.0,4.0.0)'
+        implementation 'com.posthog:posthog-android:[3.60.7,4.0.0)'
     }
 
     testOptions {


### PR DESCRIPTION
Raises the posthog-android floor from 3.60.0 to 3.60.7.

3.43.2 through 3.60.4 stopped a manually started session replay (`sessionReplay: false` plus `startSessionRecording()`) as soon as it started. 3.60.5 and 3.60.6 fixed that but still lost the recording permanently once the session was cleared on a long background. 3.60.7 has both fixes (PostHog/posthog-android#722, PostHog/posthog-android#725).

The range already allowed 3.60.7, but a lockfile or cached resolution can hold a project on an affected version — the raised floor guarantees the fixed SDK.

Verified locally: `com.posthog:posthog-android:[3.60.7,4.0.0) -> 3.60.7`, example app builds.