### PR TITLE
feat(error-tracking): report the injected release id on flutter web

### DIFF
--- a/.changeset/web-injected-release-id.md
+++ b/.changeset/web-injected-release-id.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": minor
+---
+
+Report the release id `posthog-cli sourcemap inject --release-mode=event` writes into a Flutter web bundle as `$release_id` on `$exception` events, so PostHog resolves the release per event instead of joining through the uploaded symbol set. The SDK reads the injected global itself, so the release lands whatever posthog-js version the page loaded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         timeout-minutes: 5
         working-directory: ./posthog_flutter
-        run: flutter test --platform chrome test/posthog_flutter_web_handler_test.dart test/posthog_widget_web_test.dart test/web_canvas_mask_provider_test.dart
+        run: flutter test --platform chrome test/posthog_flutter_web_handler_test.dart test/posthog_widget_web_test.dart test/web_canvas_mask_provider_test.dart test/dart_exception_processor_web_test.dart
 
       # dart2js resolves the isolate-handler conditional import differently;
       # only a wasm compile exercises the dart2wasm selection this test guards.

--- a/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
+++ b/posthog_flutter/lib/src/error_tracking/dart_exception_processor.dart
@@ -11,6 +11,7 @@ import 'utils/isolate_utils.dart' as isolate_utils;
 import 'posthog_exception.dart';
 import 'origin.dart';
 import 'chunk_ids.dart';
+import 'release_id.dart';
 
 typedef ChunkIdMapType = Map<String, String>;
 
@@ -118,10 +119,16 @@ class DartExceptionProcessor {
       inAppByDefault: inAppByDefault,
     );
 
+    // The release id posthog-cli injected into the chunk. posthog-js reads the
+    // same global from 1.409.0 on, but the page picks its own posthog-js, so
+    // reading it here keeps the release on the event whatever version loaded.
+    final releaseId = getPosthogReleaseId();
+
     // Final result, merging system properties with user properties (user properties take precedence)
     final result = <String, dynamic>{
       '\$exception_level': 'error', // Never crashes, so always error
       '\$exception_list': exceptionList,
+      if (releaseId != null) '\$release_id': releaseId,
       if (properties != null) ...properties,
     };
 

--- a/posthog_flutter/lib/src/error_tracking/release_id.dart
+++ b/posthog_flutter/lib/src/error_tracking/release_id.dart
@@ -1,0 +1,1 @@
+export 'release_id_io.dart' if (dart.library.js_interop) 'release_id_web.dart';

--- a/posthog_flutter/lib/src/error_tracking/release_id_io.dart
+++ b/posthog_flutter/lib/src/error_tracking/release_id_io.dart
@@ -1,0 +1,6 @@
+/// No chunk carries a release id outside the web build, so there is nothing to
+/// read. Apple and Android exceptions resolve their release from the app
+/// metadata the native SDK reports.
+String? getPosthogReleaseId() {
+  return null;
+}

--- a/posthog_flutter/lib/src/error_tracking/release_id_web.dart
+++ b/posthog_flutter/lib/src/error_tracking/release_id_web.dart
@@ -1,0 +1,21 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+@JS('globalThis')
+external JSObject get globalThis;
+
+/// Reads the release id `posthog-cli sourcemap inject --release-mode=event`
+/// writes into each chunk.
+///
+/// The CLI prepends a snippet that sets `globalThis._posthogReleaseId` to the
+/// release row's id, first write wins, so the first loaded chunk pins the
+/// release for the runtime. Returns null when nothing was injected or the value
+/// is not a non-empty string.
+String? getPosthogReleaseId() {
+  final releaseIdJS = globalThis['_posthogReleaseId'];
+  final releaseId = releaseIdJS?.dartify();
+  if (releaseId is! String || releaseId.isEmpty) {
+    return null;
+  }
+  return releaseId;
+}

--- a/posthog_flutter/test/dart_exception_processor_web_test.dart
+++ b/posthog_flutter/test/dart_exception_processor_web_test.dart
@@ -1,0 +1,53 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/src/error_tracking/dart_exception_processor.dart';
+
+@JS('globalThis')
+external JSObject get globalThis;
+
+void setReleaseId(JSAny? value) {
+  if (value == null) {
+    globalThis.delete('_posthogReleaseId'.toJS);
+    return;
+  }
+  globalThis['_posthogReleaseId'] = value;
+}
+
+Map<String, dynamic> process() {
+  return DartExceptionProcessor.processException(
+    error: StateError('boom'),
+    stackTrace: StackTrace.current,
+  );
+}
+
+void main() {
+  group('DartExceptionProcessor release id', () {
+    tearDown(() => setReleaseId(null));
+
+    test('reports the release id posthog-cli injected into the chunk', () {
+      setReleaseId('01a047ca-108d-0000-7487-e086f76d4aaf'.toJS);
+
+      expect(process()[r'$release_id'], '01a047ca-108d-0000-7487-e086f76d4aaf');
+    });
+
+    // An absent or malformed global has to leave the property off entirely. An
+    // empty or non-string value reaches the server as a release that resolves
+    // to nothing, which is worse than no release at all.
+    for (final (description, value) in <(String, JSAny?)>[
+      ('nothing is injected', null),
+      ('the global is an empty string', ''.toJS),
+      ('the global is not a string', 42.toJS),
+    ]) {
+      test('omits the release id when $description', () {
+        setReleaseId(value);
+
+        expect(process().containsKey(r'$release_id'), isFalse);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

A Flutter web app that uploads its sourcemaps with `posthog-cli sourcemap inject --release-mode=event` gets a release id written into `main.dart.js`. Nothing in the Dart SDK read it. The release still reached the event, because on web the plugin hands the exception to posthog-js and posthog-js reads the same global — but only posthog-js 1.409.0 and later. The page picks its own posthog-js, so an app on an older one silently loses the release its build injected.

This reads the global in Dart, next to the chunk ids the SDK already reads there.

- `release_id.dart`, `release_id_web.dart` and `release_id_io.dart` mirror the existing `chunk_ids.dart` trio. The io stub returns null: no chunk carries a release id outside the web build, and Apple and Android exceptions resolve their release from the app metadata the native SDK reports.
- `DartExceptionProcessor.processException` puts it on the payload as `$release_id`, before user properties, so a caller can still override it.
- An absent, empty or non-string global leaves the property off. A malformed value reaches the server as a release that resolves to nothing, which is worse than sending no release.

Nothing changes for an app that does not run `--release-mode=event`, and nothing changes on Apple or Android.

## :green_heart: How did you test it?

Two example apps in `error-tracking-examples`, the same Flutter web app twice, differing only in the release mode their upload runs in. Each was run twice: a first release, then the same code again under a new version. Both built against this branch through a path dependency, and both reported into a local PostHog.

All four exceptions symbolicated the full Dart call chain and resolved a release.

### Flutter web (legacy)

#### First release

<details>
<summary>posthog-cli, flutter-web-legacy@5.0.0</summary>

```
WARN posthog_cli::api::releases: release flutter-web-legacy@5.0.0 not found
INFO posthog_cli::api::releases: Release flutter-web-legacy@5.0.0 created successfully! 01a047ec-a14d-0000-0040-a7619a2252d6
INFO posthog_cli::sourcemaps::inject: injecting selection: ["build/web"]
INFO posthog_cli::sourcemaps::source_pairs: found 1 pairs
INFO posthog_cli::sourcemaps::inject: injecting done
INFO posthog_cli::sourcemaps::plain::upload: Found 1 chunks to upload
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/9f3fd20628e0212fc976621e6ce8f2c71d60d4be/2026/08/b7ed7628-4096-45f5-a0d3-7de40d04e922.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/e411631564d0c46bd7175f6826ee5cd9bef72285/2026/08/56d5a60a-e291-4db8-aed3-6e41e32abc6a.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/212510f2d2b1ef3129d3ad2f28d2132fa5fdb278/2026/08/9c41af45-1aa1-40f8-8478-98a91907d77b.png) |

The app page reads `injected $release_id: none`, which is what legacy mode looks like. The release on the event came from the symbol set the upload bound to it.

#### Second release, same code

<details>
<summary>posthog-cli, flutter-web-legacy@6.0.0</summary>

```
WARN posthog_cli::api::releases: release flutter-web-legacy@6.0.0 not found
INFO posthog_cli::api::releases: Release flutter-web-legacy@6.0.0 created successfully! 01a047ee-5f8d-0000-4e44-b784779574a6
INFO posthog_cli::sourcemaps::inject: injecting selection: ["build/web"]
INFO posthog_cli::sourcemaps::source_pairs: found 1 pairs
INFO posthog_cli::sourcemaps::inject: injecting done
INFO posthog_cli::sourcemaps::plain::upload: Found 1 chunks to upload
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

Legacy mints a fresh random chunk id on every build, so an unchanged 2.4 MB sourcemap uploads again as a second symbol set.

### Flutter web (event mode)

#### First release

<details>
<summary>posthog-cli, flutter-web-releaseless@5.0.0</summary>

```
WARN posthog_cli::api::releases: release flutter-web-releaseless@5.0.0 not found
INFO posthog_cli::api::releases: Release flutter-web-releaseless@5.0.0 created successfully! 01a047f1-da22-0000-d921-a557644b1768
INFO posthog_cli::sourcemaps::inject: injecting selection: ["build/web"]
INFO posthog_cli::sourcemaps::source_pairs: found 1 pairs
INFO posthog_cli::sourcemaps::inject: injecting done
INFO posthog_cli::sourcemaps::plain::upload: Found 1 chunks to upload
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

| Release is associated | App the SDK reported |
| --- | --- |
| ![release](https://raw.githubusercontent.com/PostHog/pr-assets/d1a0eae128ceb2702c6ee62e721377a7b0d1ecf6/2026/08/2541deca-ac12-4172-b5bd-c9212e86079b.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/dc4f3fc2015846ae89e148ad0ef5de4371f52f31/2026/08/bc2ca4ac-6f37-43e6-86bd-f05ff8668a0b.png) |

The app page prints the id it read out of the chunk, and the event carries the same one.

#### Second release, same code

<details>
<summary>posthog-cli, flutter-web-releaseless@6.0.0</summary>

```
WARN posthog_cli::api::releases: release flutter-web-releaseless@6.0.0 not found
INFO posthog_cli::api::releases: Release flutter-web-releaseless@6.0.0 created successfully! 01a047f4-ee05-0000-8df6-3d3592b4255c
INFO posthog_cli::sourcemaps::inject: injecting selection: ["build/web"]
INFO posthog_cli::sourcemaps::source_pairs: found 1 pairs
INFO posthog_cli::sourcemaps::inject: injecting done
INFO posthog_cli::sourcemaps::plain::upload: Found 1 chunks to upload
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (1 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
```

</details>

`1 skipped (1 already present)` is the case the two examples exist to contrast. The chunk id comes from the content, so the sourcemap is unchanged and the stored symbol set is reused. The new release's id goes into `main.dart.js`, and the exception reports `flutter-web-releaseless@6.0.0` off that one symbol set.

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/3e2ce0bb7a9b330d5180de4a8a60714e7c907d39/2026/08/1af344b0-8120-4bd3-9ed0-22cfa0fc78ef.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/970e7ac3d94d0345c0bfb4eff0c2bba629254f7b/2026/08/0bf4cf18-2c73-40c1-96d0-97f0a24bdf1c.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/f710990a669587e69dc52f48129b8754d96c9ca6/2026/08/f0cabeff-87ea-4073-ba20-2316ab1dbb74.png) |

Both variants and all four releases land on one issue, each event carrying its own:

![releases](https://raw.githubusercontent.com/PostHog/pr-assets/9e80cf4a7b25a154e93a2bdf697379901b37317d/2026/08/75bed64f-c087-4a5e-92d9-b80e2dc35256.png)

### Deferred loading

`flutter build web` emits one sourcemapped chunk. An app that uses deferred loading gets one more per deferred library. A third build with `import 'heavy.dart' deferred as heavy` produced `main.dart.js` and `main.dart.js_1.part.js`, the CLI found and injected both, and every frame carried its own chunk id:

```
fn=aa6.$0     file=main.dart.js             chunk=43e34280-56ef-5e2f-9462-42a959136196
fn=Object.aEI file=main.dart.js_1.part.js   chunk=5ddac51e-6b0a-5fc5-bec4-6a09ac09c349
fn=Object.h   file=main.dart.js             chunk=43e34280-56ef-5e2f-9462-42a959136196
```

Both frames symbolicated, and the event resolved one release for the whole stack.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

Docs are unticked on purpose: `--release-mode` is not documented on posthog.com for any platform yet, so a Flutter-only page would be the first. Happy to write it in a follow-up once the general docs land.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. Skills invoked: `posthog-repos`, `asd-ste100`, `writing-pr-descriptions`.

The task started as "add event release mode support for Flutter", on the assumption the SDK needed the same work the other SDKs got. It did not. Reading `posthog_flutter` on `main` showed the web handler already routes through posthog-js's `captureException`, and running it end to end confirmed the release reaches the event today. The change that survived is the narrower one: read the global in Dart so the release does not depend on which posthog-js the page loaded.

Rejected along the way: reading the release id in the web method-channel handler instead of the processor, which would have missed the fallback path the handler keeps for old posthog-js builds.

The two example apps live in `PostHog/error-tracking-examples` on `main`, as `flutter-web-legacy` and `flutter-web-releaseless`.
