### PR TITLE
fix(push): capture $push_notification_opened on iOS cold start

### DIFF
--- a/.changeset/fix-ios-cold-start-push-open.md
+++ b/.changeset/fix-ios-cold-start-push-open.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Fix `$push_notification_opened` not being captured on iOS when the app is cold-launched from a notification tap.

--- a/.changeset/fix-ios-cold-start-push-open.md
+++ b/.changeset/fix-ios-cold-start-push-open.md
@@ -2,4 +2,4 @@
 'posthog_flutter': patch
 ---
 
-Fix `$push_notification_opened` not being captured on iOS when the app is cold-launched from a notification tap.
+Fix `$push_notification_opened` not being captured on iOS when the app is cold-launched from a notification tap. Requires posthog-ios 3.72.0, and your app must set `UNUserNotificationCenter.current().delegate` — without one iOS reports the tap to nobody.

--- a/.changeset/push-open-plist-opt-out-scope.md
+++ b/.changeset/push-open-plist-opt-out-scope.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Change `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED` to opt out of iOS push-open capture in every app, not only those using `com.posthog.posthog.AUTO_INIT`.

--- a/.changeset/push-open-plist-opt-out-scope.md
+++ b/.changeset/push-open-plist-opt-out-scope.md
@@ -2,4 +2,4 @@
 'posthog_flutter': patch
 ---
 
-Change `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED` to opt out of iOS push-open capture in every app, not only those using `com.posthog.posthog.AUTO_INIT`.
+Change `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED` to also suppress the new iOS cold-start prewarm in apps that do not use `com.posthog.posthog.AUTO_INIT`.

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,8 +1,19 @@
 import UIKit
 import Flutter
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+
+  // Notification taps only reach the app through a UNUserNotificationCenter delegate; without this
+  // the SDK has nothing to observe and never captures $push_notification_opened.
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    UNUserNotificationCenter.current().delegate = self
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
 
   private var ownWindow: UIWindow?
 

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -21,7 +21,7 @@ Postog flutter plugin
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
 
-  # ~> Version 3.70.0 up to, but not including, 4.0.0
+  # ~> Version 3.72.0 up to, but not including, 4.0.0
   s.dependency 'PostHog', '>= 3.72.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'

--- a/posthog_flutter/darwin/posthog_flutter.podspec
+++ b/posthog_flutter/darwin/posthog_flutter.podspec
@@ -22,7 +22,7 @@ Postog flutter plugin
   s.osx.dependency 'FlutterMacOS'
 
   # ~> Version 3.70.0 up to, but not including, 4.0.0
-  s.dependency 'PostHog', '>= 3.70.0', '< 4.0.0'
+  s.dependency 'PostHog', '>= 3.72.0', '< 4.0.0'
 
   s.ios.deployment_target = '13.0'
   # PH iOS SDK 3.0.0 requires >= 10.15

--- a/posthog_flutter/darwin/posthog_flutter/Package.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/PostHog/posthog-ios", "3.70.0" ..< "4.0.0"),
+        .package(url: "https://github.com/PostHog/posthog-ios", "3.72.0" ..< "4.0.0"),
     ],
     targets: [
         .target(

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -83,6 +83,7 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         let instance = PosthogFlutterPlugin()
         instance.channel = methodChannel
         PosthogFlutterPlugin.instance = instance
+        prewarmPushNotificationOpenCapture()
         initPlugin()
         registrar.addMethodCallDelegate(instance, channel: methodChannel)
     }
@@ -93,6 +94,21 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
 
     private let dispatchQueue = DispatchQueue(label: "com.posthog.PosthogFlutterPlugin",
                                               target: .global(qos: .utility))
+
+    /// A cold launch from a notification tap delivers the response about 150ms in, before Dart can
+    /// reach `Posthog().setup()`. Registration runs inside `didFinishLaunchingWithOptions`, early
+    /// enough for the native SDK to hold that response until setup() installs the integration.
+    ///
+    /// The Info.plist key is the only opt-out reachable this early. `setup()` releases an unwanted
+    /// prewarm afterwards, except when PostHog is already set up with push-open capture disabled and
+    /// a later `FlutterEngine` registers — that setup() has already run, so use the plist key there.
+    private static func prewarmPushNotificationOpenCapture() {
+        let capturePushNotificationOpened = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED") as? Bool ?? true
+        guard capturePushNotificationOpened else { return }
+        if #available(iOS 14.0, macOS 11.0, *) {
+            PostHogSDK.prewarmPushNotificationOpenCapture()
+        }
+    }
 
     public static func initPlugin() {
         let autoInit = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.AUTO_INIT") as? Bool ?? true

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PosthogFlutterPlugin.swift
@@ -103,11 +103,14 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
     /// prewarm afterwards, except when PostHog is already set up with push-open capture disabled and
     /// a later `FlutterEngine` registers — that setup() has already run, so use the plist key there.
     private static func prewarmPushNotificationOpenCapture() {
-        let capturePushNotificationOpened = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED") as? Bool ?? true
-        guard capturePushNotificationOpened else { return }
+        guard plistCapturePushNotificationOpened else { return }
         if #available(iOS 14.0, macOS 11.0, *) {
             PostHogSDK.prewarmPushNotificationOpenCapture()
         }
+    }
+
+    private static var plistCapturePushNotificationOpened: Bool {
+        Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED") as? Bool ?? true
     }
 
     public static func initPlugin() {
@@ -138,7 +141,6 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
         // Push flags default ON natively and setup() no-ops a second call, so a later
         // Dart-side opt-out can never reach the SDK — the plist is the only opt-out here.
         let capturePushNotificationSubscriptions = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_SUBSCRIPTIONS") as? Bool ?? true
-        let capturePushNotificationOpened = Bundle.main.object(forInfoDictionaryKey: "com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED") as? Bool ?? true
 
         setupPostHog([
             "projectToken": projectToken,
@@ -147,7 +149,7 @@ public class PosthogFlutterPlugin: NSObject, FlutterPlugin {
             "captureApplicationLifecycleEvents": captureApplicationLifecycleEvents,
             "debug": debug,
             "capturePushNotificationSubscriptions": capturePushNotificationSubscriptions,
-            "capturePushNotificationOpened": capturePushNotificationOpened,
+            "capturePushNotificationOpened": plistCapturePushNotificationOpened,
         ])
     }
 

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -251,6 +251,9 @@ class PostHogConfig {
   /// warm-start taps on Android.
   ///
   /// **Flutter web:** not supported. Defaults to `true`.
+  ///
+  /// On iOS this requires your app to set `UNUserNotificationCenter.current().delegate`.
+  /// Without one, iOS reports the tap to nobody and no open can be captured.
   bool capturePushNotificationOpened = true;
 
   /// Mints a signed identity-verification token for push subscription requests.

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -254,6 +254,10 @@ class PostHogConfig {
   ///
   /// On iOS this requires your app to set `UNUserNotificationCenter.current().delegate`.
   /// Without one, iOS reports the tap to nobody and no open can be captured.
+  ///
+  /// Setting this to `false` does not prevent the iOS cold-start prewarm, which runs before
+  /// Dart does — opt that out with the `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED`
+  /// key in `Info.plist`.
   bool capturePushNotificationOpened = true;
 
   /// Mints a signed identity-verification token for push subscription requests.


### PR DESCRIPTION
## :link: Related PRs

One fix, five PRs — three SDKs plus the docs. Each Flutter PR is gated on the native release it depends on.

| PR | What it does |
| --- | --- |
| PostHog/posthog-ios#792 | native iOS — hold a tap delivered before `setup()` |
| PostHog/posthog-android#753 | native Android — read a launch intent the SDK installed too late to see |
| **PostHog/posthog-flutter#556** | **Flutter iOS cold start · posthog-ios#792 merged, awaiting the 3.72.0 release · fixes PostHog/posthog-flutter#555** — ← this PR |
| PostHog/posthog-flutter#557 | Flutter Android cold + warm start · needs posthog-android 3.62.0 · fixes PostHog/posthog-flutter#558 |
| PostHog/posthog.com#19905 | docs for all of the above |

**Order:** PostHog/posthog-ios#792 and PostHog/posthog-android#753 merge and release first → PostHog/posthog-flutter#556 and PostHog/posthog-flutter#557 leave draft and go green on their own once the floors publish → PostHog/posthog.com#19905 last, since posthog.com deploys on merge.

## :bulb: Motivation and Context

Fixes #555 — `$push_notification_opened` is never captured on iOS. Reproduced on a simulator; two independent causes:

1. **Nobody is listening.** A stock Flutter app sets no `UNUserNotificationCenter` delegate, so iOS reports the tap to nobody and the native SDK's swizzling has nothing to attach to. (Note `flutter_local_notifications` does *not* set it either — it registers as an application delegate and relies on `FlutterAppDelegate` forwarding.)
2. **We start too late.** On a cold launch from a tap, `didReceive` arrives ~150 ms in, about 90 ms *before* Dart reaches `Posthog().setup()`.

⏳ **Waiting on the posthog-ios release, not on review.** PostHog/posthog-ios#792 merged (`8566372`). `main` is at 3.71.6 with two pending changesets — `minor` for the prewarm API and `patch` for the missing-delegate warning — so the next release is **3.72.0**, which is exactly the floor declared here (`>= 3.72.0` in the podspec, `3.72.0 ..< 4.0.0` in `Package.swift`).

Until 3.72.0 is on CocoaPods trunk and tagged for SPM, **merging or releasing this fails `pod install` / SPM resolution for every iOS user** — a hard build break, not a degradation. Draft until the release lands, then this goes green without a code change.

## :green_heart: How did you test it?

On device — posthog-flutter example app, iPhone 17 Pro sim / iOS 26.4, built against a local posthog-ios with the native change:

- **4/4 notification taps captured**, one event each (1 warm start, 3 cold starts), each read out of the `/batch` payload the SDK sent. Before the fix, cold starts captured 0 and warm starts captured 0 for want of a delegate.
- Warm start captures exactly once — no double-counting from the new buffered path.
- With the delegate removed, the new native warning fires; with it set, it does not.

`flutter analyze` clean. The native unit tests live in the posthog-ios PR.

## Testing

Verified on an iPhone 17 Pro simulator (iOS 26.4) against a local `posthog-ios` build, with each event read out of the SDK's own `/batch` payload:

| Scenario | Result |
| --- | --- |
| Cold launch from a tap | captured (was 0 before this change) |
| Tap while the app is running (warm) | captured |
| Launch with no push payload | not captured |
| `capturePushNotificationOpened: false` | not captured, and the integration never installs |
| Example `AppDelegate` with the delegate line removed | the new debug warning fires |
| Delegate present | no warning |

Repeated across four rounds — 15 `$push_notification_opened` events in total, each carrying `$notification_title` and `$notification_body`.

**Re-verified 2026-09-08** on an iPhone 17 simulator (iOS 26.4), this branch built against posthog-ios#792:

- Cold-launch tap captured — and the event leaves in the *first* batch, at the same millisecond as the config request, which is the buffered-then-replayed path this PR exists for.
- Warm tap captured exactly once.
- Plain launch with no notification: nothing captured.
- `capturePushNotificationOpened: false`: nothing captured — and flipping it back on re-fires the same notification, so the negative is the flag and not a stale build.

⚠️ **CI has not compiled this branch's Swift yet.** All four `build-apple` jobs and `Analyze (swift)` die at dependency resolution on the not-yet-published `PostHog >= 3.72.0` floor, so the red checks say nothing about the code itself. It builds clean locally against the merged posthog-ios branch, and the red turns green on its own once 3.72.0 publishes — the same way PostHog/posthog-flutter#557 went from red to 27/27 the moment posthog-android 3.62.0 hit Maven Central.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code ([session](https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd)), driven by @turnipdabeets. Nearly all the logic lives in posthog-ios; this side is the trigger plus the example wiring.

Worth a reviewer's attention:

- `prewarmPushNotificationOpenCapture()` is called from `register(with:)` because that runs inside `didFinishLaunchingWithOptions`. `AUTO_INIT` would also win the race (verified), but it is mutually exclusive with `pushIdentityProvider`, so it isn't a usable answer for everyone.
- The Info.plist key is the only opt-out reachable that early — a Dart-side `capturePushNotificationOpened: false` isn't known yet. The native SDK releases an unwanted prewarm at `setup()`, so this only matters for one add-to-app ordering, documented at the call site. That widens the key's scope beyond `AUTO_INIT` apps, hence the second changeset.
- The example `AppDelegate` change is the fix for cause (1) and is the copy-pasteable bit for users hitting this.

Not done here, deliberately: a README/docs section (the SDK currently ships push with no iOS setup docs at all). The identical cold-start race exists in `@posthog/react-native-plugin` and needs a follow-up issue on posthog-js.





