### PR TITLE
fix(push): capture $push_notification_opened on Android cold and warm start

### DIFF
--- a/.changeset/android-warm-start-push-open.md
+++ b/.changeset/android-warm-start-push-open.md
@@ -1,5 +1,0 @@
----
-'posthog_flutter': patch
----
-
-Capture `$push_notification_opened` on Android when a notification is tapped while the app is already running.

--- a/.changeset/android-warm-start-push-open.md
+++ b/.changeset/android-warm-start-push-open.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Capture `$push_notification_opened` on Android when a notification is tapped while the app is already running.

--- a/.changeset/fix-android-cold-start-push-open.md
+++ b/.changeset/fix-android-cold-start-push-open.md
@@ -2,4 +2,4 @@
 'posthog_flutter': patch
 ---
 
-Fix `$push_notification_opened` not being captured on Android when the app is cold-launched from a notification tap. Requires posthog-android 3.62.0.
+Fix `$push_notification_opened` not being captured on Android, both on a cold launch from a notification tap and on a tap while the app is already running. Requires posthog-android 3.62.0.

--- a/.changeset/fix-android-cold-start-push-open.md
+++ b/.changeset/fix-android-cold-start-push-open.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Fix `$push_notification_opened` not being captured on Android when the app is cold-launched from a notification tap. Requires posthog-android 3.62.0.

--- a/.changeset/fix-android-cold-start-push-open.md
+++ b/.changeset/fix-android-cold-start-push-open.md
@@ -1,5 +1,5 @@
 ---
-'posthog_flutter': patch
+'posthog_flutter': minor
 ---
 
-Fix `$push_notification_opened` not being captured on Android, both on a cold launch from a notification tap and on a tap while the app is already running. Requires posthog-android 3.62.0.
+Capture `$push_notification_opened` on Android for every notification tap, both on a cold launch and while the app is already running. Remove any manual `capturePushNotificationOpened` call wired to `FirebaseMessaging.onMessageOpenedApp` — that tap is now captured automatically and the manual call is not deduplicated against it. Requires posthog-android 3.62.0.

--- a/.changeset/fix-android-cold-start-push-open.md
+++ b/.changeset/fix-android-cold-start-push-open.md
@@ -2,4 +2,4 @@
 'posthog_flutter': minor
 ---
 
-Capture `$push_notification_opened` on Android for every notification tap, both on a cold launch and while the app is already running. Remove any manual `capturePushNotificationOpened` call wired to `FirebaseMessaging.onMessageOpenedApp` — that tap is now captured automatically and the manual call is not deduplicated against it. Requires posthog-android 3.62.0.
+Capture `$push_notification_opened` on Android for every notification tap, both on a cold launch and while the app is already running. Remove any manual `capturePushNotificationOpened` call wired to `FirebaseMessaging.onMessageOpenedApp` or `getInitialMessage()` — that tap is now captured automatically and the manual call is not deduplicated against it. Requires posthog-android 3.62.0.

--- a/posthog_flutter/android/build.gradle
+++ b/posthog_flutter/android/build.gradle
@@ -64,7 +64,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.posthog:posthog-android:[3.61.0,4.0.0)'
+        implementation 'com.posthog:posthog-android:[3.62.0,4.0.0)'
     }
 
     testOptions {

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -38,6 +38,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import java.util.Date
@@ -67,6 +68,7 @@ class PosthogFlutterPlugin :
 
     private lateinit var applicationContext: Context
     private var activity: Activity? = null
+    private var activityBinding: ActivityPluginBinding? = null
     private var application: Application? = null
 
     private var postHogConfig: PostHogAndroidConfig? = null
@@ -810,9 +812,22 @@ class PosthogFlutterPlugin :
         PostHogAndroid.capturePushNotificationOpened(activity?.intent)
     }
 
+    /**
+     * A tap that arrives while the process is alive is delivered to `Activity.onNewIntent`, which
+     * `ActivityLifecycleCallbacks` does not expose — so the native SDK cannot see it and this plugin
+     * is the only layer that can. Returning false leaves the intent for other listeners.
+     */
+    private val newIntentListener =
+        PluginRegistry.NewIntentListener { intent ->
+            PostHogAndroid.capturePushNotificationOpened(intent)
+            false
+        }
+
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
         application = binding.activity.application
+        activityBinding = binding
+        binding.addOnNewIntentListener(newIntentListener)
         capturePushNotificationOpenedFromLaunchIntent()
         // Only if the detector is already running; else the setup path registers
         // it. Keeps a default-off feature from installing app-wide callbacks.
@@ -823,12 +838,15 @@ class PosthogFlutterPlugin :
 
     override fun onDetachedFromActivityForConfigChanges() {
         unregisterLifecycleTracking()
+        removeNewIntentListener()
         activity = null
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         activity = binding.activity
         application = binding.activity.application
+        activityBinding = binding
+        binding.addOnNewIntentListener(newIntentListener)
         if (occlusionDetectorRunning) {
             registerLifecycleTracking()
         }
@@ -836,7 +854,13 @@ class PosthogFlutterPlugin :
 
     override fun onDetachedFromActivity() {
         unregisterLifecycleTracking()
+        removeNewIntentListener()
         activity = null
+    }
+
+    private fun removeNewIntentListener() {
+        activityBinding?.removeOnNewIntentListener(newIntentListener)
+        activityBinding = null
     }
 
     // Idempotent: registering the same callbacks twice makes them fire twice.

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -38,9 +38,9 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry
 import java.util.Date
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -791,11 +791,29 @@ class PosthogFlutterPlugin :
         PostHogAndroid.setup(applicationContext, config)
         postHogConfig = config
         cachedReplayIntegration = null
+        capturePushNotificationOpenedFromLaunchIntent()
+    }
+
+    /**
+     * The SDK reads a notification tap from the launch Activity's intent when that Activity is
+     * created, which is long before Dart reaches `Posthog().setup()` — by then `onCreate`, `onStart`
+     * and `onResume` have all run. The intent is still on the Activity, so hand it over once both the
+     * SDK and the Activity exist.
+     *
+     * Called from both ends because neither alone covers both configurations: `onAttachedToEngine`
+     * (which runs `initPlugin`) always precedes `onAttachedToActivity`, so the AUTO_INIT path has no
+     * Activity yet, while on the Dart path the Activity is attached long before setup runs. Whichever
+     * precondition is satisfied last does the work; `PostHogAndroid` dedupes by message id, so a
+     * double call cannot double-count.
+     */
+    private fun capturePushNotificationOpenedFromLaunchIntent() {
+        PostHogAndroid.capturePushNotificationOpened(activity?.intent)
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
         application = binding.activity.application
+        capturePushNotificationOpenedFromLaunchIntent()
         // Only if the detector is already running; else the setup path registers
         // it. Keeps a default-off feature from installing app-wide callbacks.
         if (occlusionDetectorRunning) {

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -651,20 +651,21 @@ class Posthog {
   /// notification.
   ///
   /// Call this only for opens [PostHogConfig.capturePushNotificationOpened]
-  /// cannot see itself — local notifications on either platform, plus
-  /// warm-start and foreground taps on Android — or the tap is counted twice.
-  /// That doc has the full coverage matrix.
+  /// cannot see itself — local notifications on either platform, notifications
+  /// you display yourself from a foreground message, and push delivered outside
+  /// FCM on Android. That doc has the full coverage matrix.
+  ///
+  /// Do not wire this to `FirebaseMessaging.onMessageOpenedApp`: the SDK already
+  /// captures that tap, and this call is not deduplicated against it, so the open
+  /// would be counted twice.
   ///
   /// ```dart
-  /// if (Platform.isAndroid) {
-  ///   FirebaseMessaging.onMessageOpenedApp.listen((m) {
-  ///     Posthog().capturePushNotificationOpened(
-  ///       title: m.notification?.title,
-  ///       body: m.notification?.body,
-  ///       payload: m.data,
-  ///     );
-  ///   });
-  /// }
+  /// // A notification you built and displayed yourself.
+  /// Posthog().capturePushNotificationOpened(
+  ///   title: notification.title,
+  ///   body: notification.body,
+  ///   payload: notification.payload,
+  /// );
   /// ```
   ///
   /// The event is built natively, so [PostHogConfig.beforeSend] callbacks do

--- a/posthog_flutter/lib/src/posthog.dart
+++ b/posthog_flutter/lib/src/posthog.dart
@@ -655,16 +655,16 @@ class Posthog {
   /// you display yourself from a foreground message, and push delivered outside
   /// FCM on Android. That doc has the full coverage matrix.
   ///
-  /// Do not wire this to `FirebaseMessaging.onMessageOpenedApp`: the SDK already
-  /// captures that tap, and this call is not deduplicated against it, so the open
-  /// would be counted twice.
+  /// Do not wire this to `FirebaseMessaging.onMessageOpenedApp` or
+  /// `getInitialMessage()`: the SDK already captures those taps, and this call is
+  /// not deduplicated against them, so the open would be counted twice.
   ///
   /// ```dart
   /// // A notification you built and displayed yourself.
   /// Posthog().capturePushNotificationOpened(
-  ///   title: notification.title,
-  ///   body: notification.body,
-  ///   payload: notification.payload,
+  ///   title: 'Your order shipped',
+  ///   body: 'Track it in the app',
+  ///   payload: {'order_id': '1234'},
   /// );
   /// ```
   ///

--- a/posthog_flutter/lib/src/posthog_config.dart
+++ b/posthog_flutter/lib/src/posthog_config.dart
@@ -242,13 +242,12 @@ class PostHogConfig {
   /// Whether to automatically capture `$push_notification_opened` when a user
   /// taps a PostHog-delivered notification.
   ///
-  /// Coverage differs per platform. iOS hooks the notification-response
-  /// delegate, so every tap on a **remote** notification is captured whatever
-  /// the app state; locally-scheduled notifications are ignored. Android only
-  /// reads the launch intent, so it sees cold starts alone. Call
-  /// [Posthog.capturePushNotificationOpened] for the opens this misses —
-  /// local notifications on either platform, plus foreground messages and
-  /// warm-start taps on Android.
+  /// Every tap on a **remote** notification is captured on both platforms,
+  /// whether it cold-launched the app or the app was already running.
+  /// Locally-scheduled notifications are ignored. On Android a tap is
+  /// recognised by the `google.message_id` extra Firebase puts on the intent,
+  /// so push delivered outside FCM is not seen. Call
+  /// [Posthog.capturePushNotificationOpened] for the opens this misses.
   ///
   /// **Flutter web:** not supported. Defaults to `true`.
   bool capturePushNotificationOpened = true;


### PR DESCRIPTION
## :link: Related PRs

One fix, five PRs — three SDKs plus the docs. Each Flutter PR is gated on the native release it depends on.

| PR | What it does |
| --- | --- |
| PostHog/posthog-ios#792 | native iOS — hold a tap delivered before `setup()` |
| PostHog/posthog-android#753 | native Android — read a launch intent the SDK installed too late to see |
| PostHog/posthog-flutter#556 | Flutter iOS cold start · needs posthog-ios 3.72.0 · fixes PostHog/posthog-flutter#555 |
| **PostHog/posthog-flutter#557** | **Flutter Android cold + warm start · posthog-android 3.62.0 released ✅ · fixes PostHog/posthog-flutter#558** — ← this PR |
| PostHog/posthog.com#19905 | docs for all of the above |

**Order:** PostHog/posthog-ios#792 and PostHog/posthog-android#753 merge and release first → PostHog/posthog-flutter#556 and PostHog/posthog-flutter#557 leave draft and go green on their own once the floors publish → PostHog/posthog.com#19905 last, since posthog.com deploys on merge.

## :bulb: Motivation and Context

Fixes #558 — `$push_notification_opened` is never captured on a cold launch from a notification tap. (#556 fixes the iOS half, #555; the two have separate native release gates, so they ship separately.)

The native SDK reads the tray intent in `onActivityCreated`, but plugin registration happens inside `Activity.onCreate`, after the framework has already dispatched that callback. Measured in the example app:

```
17:54:27.516  MainActivity.onCreate
17:54:27.939  onCreate END / onStart / onResume   ← all three complete
17:54:28.582  first PostHog event                 ← SDK installs ~640ms later
```

Every lifecycle callback for the launch Activity is missed. `AUTO_INIT` does **not** rescue it either — registration is still inside `onCreate` — which is where this differs from iOS, where `AUTO_INIT` does win the race.

✅ **Unblocked.** PostHog/posthog-android#753 merged and `posthog-android` 3.62.0 published to Maven Central on 2026-09-08, so the `[3.62.0,4.0.0)` floor resolves. Verified against the released artifact, not a local build — `:app:dependencies` resolves `com.posthog:posthog-android:[3.62.0,4.0.0) -> 3.62.0` and `com.posthog:posthog:6.35.0`.

## Changes

- **Captures warm-start taps too.** A tap that arrives while the app is running goes to `Activity.onNewIntent`, which `ActivityLifecycleCallbacks` does not expose — so the native SDK cannot see it and this plugin is the only layer that can. A `NewIntentListener` is registered on attach and re-attach, removed on both detach paths.
- **Obsoletes the previously documented manual wiring.** The Dart docs no longer tell users to call `capturePushNotificationOpened` from `FirebaseMessaging.onMessageOpenedApp` / `getInitialMessage()`; that call is not deduplicated against the automatic capture, so keeping it now double-counts. Hence the `minor` bump.
- Hands the Activity's launch intent to the native SDK once both the SDK and the Activity exist.
- Called from **both** `setupPostHog()` and `onAttachedToActivity`, because neither alone covers both configurations: `onAttachedToEngine` (which runs `initPlugin`) always precedes `onAttachedToActivity`, so the `AUTO_INIT` path has no Activity yet, while on the Dart path the Activity is attached long before `setup()` runs. Whichever precondition is satisfied last does the work; the native message-id dedupe makes the double call safe.
- Raises the `posthog-android` floor to `[3.62.0,4.0.0)`.

## :green_heart: How did you test it?

On device (Pixel 9 emulator, example app against a local `posthog-android` build):

- Cold start with a `google.message_id` extra → **1 capture** (was 0).
- Same id in a new process → 0 (persisted dedupe); a new id → 1; no push extra → 0.
- **Pure `AUTO_INIT` app** (Dart `setup()` commented out) — 0 captures without the `onAttachedToActivity` hook, 1 with it. This is why the hook is called from both places; an earlier test that left the Dart `setup()` in place passed either way and masked the gap.

`flutter analyze` clean. The unit tests live in PostHog/posthog-android#753.

## Testing

Verified on a Pixel 9 emulator against a local `posthog-android` build, with each event read out of the SDK's own `/batch` payload, not just device logs:

| Scenario | Result |
| --- | --- |
| Cold launch from a tap | captured |
| Tap while the app is running (warm) | captured |
| Same message id again, warm | not captured |
| Same message id in a new process | not captured |
| Original cold id after a warm tap of a different id | not captured |
| Launch with no push payload | not captured |
| Tap, then two device rotations | one event, not three |
| Pure `AUTO_INIT` app, no Dart `setup()` | captured — 0 without the `onAttachedToActivity` hook, 1 with it |

The `AUTO_INIT` row is why the hand-over is called from two places: an earlier test that left the Dart `setup()` in place passed either way and masked the gap.

**Re-verified 2026-09-08** on a Pixel 9 emulator, this branch built against posthog-android#753:

- Cold launch carrying `google.message_id`: captured.
- Warm tap through `onNewIntent`: captured, once.
- Same id again while running: nothing.
- Force-stop, then relaunch on the same launch intent (the process-death restore): nothing — the persisted history holds.
- Plain launch, no push extra: nothing.
- `capturePushNotificationOpened: false`: nothing — and re-enabling it re-fires the *same* id, so the negative is the flag, not the dedupe and not a stale build.

**Re-verified 2026-09-08 against the released `posthog-android` 3.62.0** (Maven Central, no local override), on a Pixel 9 emulator with the app's storage cleared first:

- Cold launch carrying `google.message_id`: captured.
- Warm tap through `onNewIntent`: captured, once.
- Same id again: nothing.

Earlier CI red on this branch was purely the unreleased floor — every Kotlin job died at dependency resolution and said nothing about the code. That gate is gone; the checks were re-run on the published artifact.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code ([session](https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd)), driven by @turnipdabeets. Nearly all the logic is in PostHog/posthog-android#753; this side is the trigger.

No unit test here: `PostHogAndroid.capturePushNotificationOpened` is a companion function without `@JvmStatic`, so `mockStatic` cannot intercept it and asserting the hand-over would need a new production test seam. The `AUTO_INIT` device run above is the honest verification.

Also closes the warm-start gap: a tap that arrives while the app is running goes to `Activity.onNewIntent`, which `ActivityLifecycleCallbacks` does not expose — so the native SDK cannot see it and this plugin is the only layer that can. A `NewIntentListener` is registered on attach and re-attach and removed on both detach paths.

⚠️ **Behaviour change, hence `minor`:** apps following the previously documented `FirebaseMessaging.onMessageOpenedApp` → `capturePushNotificationOpened(...)` pattern must remove that call. The plugin now captures that tap and the manual API is not deduplicated against it, so it would count twice. The changeset and the Dart docs both say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd







