### PR TITLE
ci: validate packages before pub.dev authentication

### DIFF
--- a/.github/workflows/publish-pub-dev.yml
+++ b/.github/workflows/publish-pub-dev.yml
@@ -50,9 +50,6 @@ jobs:
 
           echo "✓ Tag '${TAG_VERSION}' is valid: commit message and pubspec.yaml version match."
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
-
       - name: Setup Flutter
         # axi92/flutter-action is a fork of subosito/flutter-action that SHA-pins its internal
         # actions/cache calls; subosito itself uses tag refs which conflicts with our org-wide
@@ -64,6 +61,10 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Validate package
+        working-directory: ./posthog_flutter
+        run: flutter pub publish --dry-run
+
       - name: Get version from tag
         id: get-version
         run: |
@@ -71,9 +72,15 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
 
+      # setup-dart registers a pub.dev OIDC token that breaks public dependency downloads.
+      # Authenticate only after dependency resolution and package validation have succeeded.
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
+
       - name: Publish to pub.dev
         working-directory: ./posthog_flutter
-        run: flutter pub publish --force
+        # Validation above is mandatory; repeating it here would download with the OIDC token.
+        run: flutter pub publish --force --skip-validation
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
## :bulb: Motivation and Context

The [5.40.0 publish job](https://github.com/PostHog/posthog-flutter/actions/runs/34485128214/job/102903948051) fails while resolving Flutter dependencies. `setup-dart` registers a GitHub OIDC token for pub.dev before dependencies are downloaded. Public package metadata and archive requests return 200 anonymously but return 403 with a dummy bearer token. This supports an authentication-related download failure, although the job's actual OIDC token was not tested.

Install dependencies and run `flutter pub publish --dry-run` before `setup-dart` registers the publishing token. Authenticate immediately before uploading, then publish with `--force --skip-validation` so pub does not repeat dependency resolution with that token. The anonymous validation step must succeed before publishing can run.

SDK code, package contents, workflow permissions, and release triggers are unchanged. Rerunning the existing 5.40.0 tag will still use its original workflow. This PR does not move that tag or publish a release.

## :green_heart: How did you test it?

- A temporary YAML regression check failed on the original step order and passed after the change. It checks anonymous install and validation, authentication immediately before publishing, required success gates, and unchanged permissions and unrelated steps.
- `actionlint -shellcheck= -pyflakes= .github/workflows/publish-pub-dev.yml` and `git diff --check` passed.
- Checked the Dart 3.13.3 pub source to confirm `--skip-validation` skips both dependency resolution and client-side validation.
- Autoreview against `origin/main` passed for `5973a9395a1d3f6d66a0926bed26034f7dc4dad8` with no actionable findings.
- No local publish, publish dry run, or live CI release was executed. End-to-end publishing still needs verification in CI.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. The regression check was temporary, not committed.
- [x] I updated the docs if needed. No documentation update is needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

No changeset is needed for this CI-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using file tools, Git, GitHub CLI, curl, Python/PyYAML, actionlint, and the isolated Pi autoreview helper. Work was done in a dedicated worktree. The change keeps validation mandatory but separates it from authenticated uploading. No session transcript was published. Human review is required.
