### PR TITLE
chore: publish the 5.40.0 changes as 5.40.1

### DIFF
--- a/.changeset/republish-5-40-0.md
+++ b/.changeset/republish-5-40-0.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Publish the 5.40.0 changes to pub.dev, which the 5.40.0 release never reached.


### PR DESCRIPTION
## :bulb: Motivation and Context

5.40.0 was tagged but never reached pub.dev. Its publish job failed at `flutter pub get` on every attempt ([run](https://github.com/PostHog/posthog-flutter/actions/runs/34485128214)). pub.dev started rejecting dependency downloads that carry the GitHub OIDC token `setup-dart` registers: `403 AccessDenied` with the token, 200 without ([probe run](https://github.com/PostHog/posthog-flutter/actions/runs/34491148215)).

#565 fixed the workflow, but re-running the 5.40.0 run still uses the old workflow from the tag ([attempt 3](https://github.com/PostHog/posthog-flutter/actions/runs/34485128214/job/102920169141) failed the same way). The 5.40.0 bump already used up its changesets, so the Release workflow stops with "No changesets found" ([run](https://github.com/PostHog/posthog-flutter/actions/runs/34491557692/job/102919323713)).

This PR adds one patch changeset, so merging it releases 5.40.1: the 5.40.0 changes, published with the #565 workflow. No code changes.

## :green_heart: How did you test it?

- Changeset format matches the existing ones (`'posthog_flutter': patch`).
- Not run: the release itself. The first real proof that #565 works end to end is the 5.40.1 publish run.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code traced the failure through the publish logs and pub's source, reproduced the error locally on Flutter 3.47.3, and ran a temporary probe workflow (branch since deleted) that ruled out the setup-dart 1.8.1 bump and #562. The changeset was hand-written, not generated with `pnpm changeset`. The 5.40.0 section stays in the CHANGELOG, so pub.dev shows both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9Upf3VifyNDsVBZi8Sj4P
