### PR TITLE
revert: undo 5.40.0 version bump

### DIFF
--- a/.changeset/fix-android-cold-start-push-open.md
+++ b/.changeset/fix-android-cold-start-push-open.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': minor
+---
+
+Capture `$push_notification_opened` on Android for every notification tap, both on a cold launch and while the app is already running. Remove any manual `capturePushNotificationOpened` call wired to `FirebaseMessaging.onMessageOpenedApp` or `getInitialMessage()` — that tap is now captured automatically and the manual call is not deduplicated against it. Requires posthog-android 3.62.0.

--- a/.changeset/fix-ios-cold-start-push-open.md
+++ b/.changeset/fix-ios-cold-start-push-open.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Fix `$push_notification_opened` not being captured on iOS when the app is cold-launched from a notification tap. Requires posthog-ios 3.72.0, and your app must set `UNUserNotificationCenter.current().delegate` — without one iOS reports the tap to nobody.

--- a/.changeset/push-open-plist-opt-out-scope.md
+++ b/.changeset/push-open-plist-opt-out-scope.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Change `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED` to also suppress the new iOS cold-start prewarm in apps that do not use `com.posthog.posthog.AUTO_INIT`.

--- a/posthog_flutter/CHANGELOG.md
+++ b/posthog_flutter/CHANGELOG.md
@@ -1,16 +1,5 @@
 ## Next
 
-## 5.40.0
-
-### Minor Changes
-
-- 1fdb54c: Capture `$push_notification_opened` on Android for every notification tap, both on a cold launch and while the app is already running. Remove any manual `capturePushNotificationOpened` call wired to `FirebaseMessaging.onMessageOpenedApp` or `getInitialMessage()` — that tap is now captured automatically and the manual call is not deduplicated against it. Requires posthog-android 3.62.0.
-
-### Patch Changes
-
-- 0ae26d5: Fix `$push_notification_opened` not being captured on iOS when the app is cold-launched from a notification tap. Requires posthog-ios 3.72.0, and your app must set `UNUserNotificationCenter.current().delegate` — without one iOS reports the tap to nobody.
-- 0ae26d5: Change `com.posthog.posthog.CAPTURE_PUSH_NOTIFICATION_OPENED` to also suppress the new iOS cold-start prewarm in apps that do not use `com.posthog.posthog.AUTO_INIT`.
-
 ## 5.39.0
 
 ### Minor Changes

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PostHogVersion.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PostHogVersion.kt
@@ -1,3 +1,3 @@
 package com.posthog.flutter
 
-internal val postHogVersion = "5.40.0"
+internal val postHogVersion = "5.39.0"

--- a/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PostHogFlutterVersion.swift
+++ b/posthog_flutter/darwin/posthog_flutter/Sources/posthog_flutter/PostHogFlutterVersion.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 // This property is internal only
-let postHogFlutterVersion = "5.40.0"
+let postHogFlutterVersion = "5.39.0"

--- a/posthog_flutter/lib/src/posthog_flutter_version.dart
+++ b/posthog_flutter/lib/src/posthog_flutter_version.dart
@@ -1,3 +1,3 @@
 // This file is auto-updated by scripts/bump-version.sh
-const postHogFlutterVersion = '5.40.0';
+const postHogFlutterVersion = '5.39.0';
 const postHogFlutterSdkName = 'posthog-flutter';

--- a/posthog_flutter/package.json
+++ b/posthog_flutter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog_flutter",
-  "version": "5.40.0",
+  "version": "5.39.0",
   "private": true,
   "description": "PostHog Flutter SDK - version tracking for changesets"
 }

--- a/posthog_flutter/pubspec.yaml
+++ b/posthog_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: posthog_flutter
 description: Flutter implementation of PostHog client for iOS, Android and Web
-version: 5.40.0
+version: 5.39.0
 homepage: https://www.posthog.com
 repository: https://github.com/posthog/posthog-flutter
 issue_tracker: https://github.com/posthog/posthog-flutter/issues


### PR DESCRIPTION
## :bulb: Motivation and Context

Revert [304d2b1](https://github.com/PostHog/posthog-flutter/commit/304d2b15b8055280bc3c93dbae98f8d5383ab22c), the 5.40.0 version bump, after the pub.dev publish job failed.

Restore version 5.39.0 in the package metadata and Dart, Android, and Apple version constants. Remove the generated 5.40.0 changelog section and restore its three changesets. The underlying SDK fixes and the publishing workflow fix from #565 remain unchanged.

This only reverts the commit. It does not delete or move the existing 5.40.0 tag. That tag must be handled separately before attempting to create another 5.40.0 release. Restoring changesets can trigger the approval-gated release workflow when this PR merges.

## :green_heart: How did you test it?

- Verified that all nine reverted files exactly match their contents in the parent of 304d2b1.
- Verified that the publishing workflow remains unchanged.
- `git diff --cached --check` passed before committing.
- Autoreview against `origin/main` passed for `ecc5db4265bc6e9bcf29769b8523f474ae862886` with no actionable findings.
- No SDK tests, local publishing, or live CI release were run.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. This is an exact revert of generated release metadata.
- [x] I updated the docs if needed. The generated changelog entry is reverted.
- [ ] No breaking change or entry added to the changelog. No new entry was added, but the 5.40.0 entry was removed.

### If releasing new changes

The original three changesets are restored. No new changeset was generated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using Git, GitHub CLI, Python, file tools, and the isolated Pi autoreview helper in a dedicated worktree. The scope is an exact revert of the requested release commit. Local changes in the original checkout and release tags were left untouched. No session transcript was published. Human review is required.
