### PR TITLE
fix(replay): warn when PostHogWidget mounts before setup

### DIFF
--- a/.changeset/posthog-widget-setup-warning.md
+++ b/.changeset/posthog-widget-setup-warning.md
@@ -1,0 +1,5 @@
+---
+"posthog_flutter": patch
+---
+
+Warn when PostHogWidget mounts before Posthog().setup() on mobile, explaining that session replay requires setup before mounting or remounting the widget after setup.

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -56,6 +56,13 @@ class PostHogWidgetState extends State<PostHogWidget> {
 
     final config = Posthog().config;
     if (config == null) {
+      if (!kIsWeb) {
+        debugPrint(
+          '[PostHog] PostHogWidget mounted before Posthog().setup(). '
+          'Mobile session replay will not start for this widget instance. '
+          'Call setup() before runApp(), or remount PostHogWidget after setup().',
+        );
+      }
       return;
     }
 

--- a/posthog_flutter/lib/src/posthog_widget.dart
+++ b/posthog_flutter/lib/src/posthog_widget.dart
@@ -59,8 +59,9 @@ class PostHogWidgetState extends State<PostHogWidget> {
       if (!kIsWeb) {
         debugPrint(
           '[PostHog] PostHogWidget mounted before Posthog().setup(). '
-          'Mobile session replay will not start for this widget instance. '
-          'Call setup() before runApp(), or remount PostHogWidget after setup().',
+          'If you intend to use mobile session replay, call setup() before runApp(), '
+          'or remount PostHogWidget after setup(). '
+          'Otherwise, you can ignore this message.',
         );
       }
       return;

--- a/posthog_flutter/test/posthog_widget_test.dart
+++ b/posthog_flutter/test/posthog_widget_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+
+import 'posthog_flutter_platform_interface_fake.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('posthog_flutter');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  setUp(() async {
+    PosthogFlutterPlatformInterface.instance = PosthogFlutterPlatformFake();
+    await Posthog().close();
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getSessionReplayState') {
+        return {'isActive': false, 'sessionId': null};
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    await Posthog().close();
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  Future<List<String?>> recordDebugPrint(Future<void> Function() action) async {
+    final messages = <String?>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) => messages.add(message);
+    try {
+      await action();
+    } finally {
+      debugPrint = originalDebugPrint;
+    }
+    return messages;
+  }
+
+  testWidgets('mounting before setup warns once on native and not on web',
+      (tester) async {
+    final messages = await recordDebugPrint(() async {
+      await tester.pumpWidget(const PostHogWidget(child: SizedBox()));
+      final state = tester.state(find.byType(PostHogWidget));
+      await tester.pumpWidget(const PostHogWidget(child: SizedBox.expand()));
+      expect(tester.state(find.byType(PostHogWidget)), same(state));
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    expect(
+      messages,
+      kIsWeb
+          ? isEmpty
+          : equals([
+              '[PostHog] PostHogWidget mounted before Posthog().setup(). '
+                  'Mobile session replay will not start for this widget instance. '
+                  'Call setup() before runApp(), or remount PostHogWidget after setup().',
+            ]),
+    );
+  });
+
+  for (final sessionReplay in [false, true]) {
+    testWidgets('setup before mounting does not warn (replay: $sessionReplay)',
+        (tester) async {
+      await Posthog().setup(
+          PostHogConfig('test_project_token')..sessionReplay = sessionReplay);
+
+      final messages = await recordDebugPrint(() async {
+        await tester.pumpWidget(const PostHogWidget(child: SizedBox()));
+        await tester.pump(const Duration(milliseconds: 1));
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump(const Duration(milliseconds: 1));
+      });
+
+      expect(messages, isEmpty);
+    });
+  }
+}

--- a/posthog_flutter/test/posthog_widget_test.dart
+++ b/posthog_flutter/test/posthog_widget_test.dart
@@ -57,8 +57,9 @@ void main() {
           ? isEmpty
           : equals([
               '[PostHog] PostHogWidget mounted before Posthog().setup(). '
-                  'Mobile session replay will not start for this widget instance. '
-                  'Call setup() before runApp(), or remount PostHogWidget after setup().',
+                  'If you intend to use mobile session replay, call setup() before runApp(), '
+                  'or remount PostHogWidget after setup(). '
+                  'Otherwise, you can ignore this message.',
             ]),
     );
   });


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #571.

When `PostHogWidget` mounts before `Posthog().setup()`, it silently skips replay initialization and listener registration. Later setup or recording commands cannot start capture for that widget instance.

This adds a warning that explains the required setup order and the option to remount the widget after setup. Because replay intent is unknown before setup, the message makes this advice conditional and says it can be ignored when replay is not intended. The warning is not emitted on web, where replay uses posthog-js. Replay initialization behavior is unchanged.

## :green_heart: How did you test it?

- The new regression test failed before the fix because no warning was emitted, then passed after the fix. It also verifies that rebuilding does not repeat the warning.
- All 343 VM tests passed with `flutter test --no-pub --reporter expanded`.
- All 6 Chrome tests passed for `posthog_widget_test.dart` and `posthog_widget_web_test.dart`. These cover warning suppression on web and after setup with replay enabled or disabled.
- `dart analyze .`, formatting checks, and `git diff --check` passed.
- The updated message assertion failed against the original unconditional wording and passed after the review feedback change.
- Autoreview of commit `9301682` against `origin/main` reported no actionable findings.

No emulator run was needed for this Dart-only logging change. Widget tests exercise the affected mount path with a mocked native channel.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No documentation changes were needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a patch changeset file manually, equivalent to `pnpm changeset`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the issue and implemented the change in a dedicated worktree using Git, GitHub CLI, Flutter tests, Dart analysis, and the isolated autoreview helper. The session transcript is not published.

The change follows the issue's request for a diagnostic rather than adding support for late setup. Remounting after setup restores capture within the same app launch. Review feedback prompted conditional wording because mounting the widget does not prove that replay is intended. Human review is required.
