### PR TITLE
fix(replay): mask the full height of auto-growing text fields

### DIFF
--- a/.changeset/multiline-editable-mask.md
+++ b/.changeset/multiline-editable-mask.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Fix session replay masking only the first line of an auto-growing text field (`maxLines: null` or `expands: true`); the mask now covers the field's full height.

--- a/example/lib/masking_tests_screen.dart
+++ b/example/lib/masking_tests_screen.dart
@@ -14,11 +14,15 @@ class MaskingTestsScreen extends StatefulWidget {
 class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
   final TextEditingController _singleLineController = TextEditingController();
   final TextEditingController _multiLineController = TextEditingController();
+  final TextEditingController _autoGrowController = TextEditingController(
+    text: 'Line one\nLine two\nLine three\nLine four',
+  );
 
   @override
   void dispose() {
     _singleLineController.dispose();
     _multiLineController.dispose();
+    _autoGrowController.dispose();
     super.dispose();
   }
 
@@ -212,6 +216,21 @@ class _MaskingTestsScreenState extends State<MaskingTestsScreen> {
                   style: const TextStyle(fontSize: 16),
                   decoration: const InputDecoration(
                     hintText: 'Enter multiline text...',
+                    border: OutlineInputBorder(),
+                    contentPadding: EdgeInsets.all(12),
+                  ),
+                ),
+              ),
+
+              // Test 11b: Auto-growing TextField
+              _buildTestSection(
+                'Test 11b: Auto-growing TextField (maxLines: null)',
+                TextField(
+                  controller: _autoGrowController,
+                  maxLines: null,
+                  style: const TextStyle(fontSize: 16),
+                  decoration: const InputDecoration(
+                    hintText: 'Enter text, the field grows with it...',
                     border: OutlineInputBorder(),
                     contentPadding: EdgeInsets.all(12),
                   ),

--- a/posthog_flutter/lib/src/replay/element_parsers/render_editable_parser.dart
+++ b/posthog_flutter/lib/src/replay/element_parsers/render_editable_parser.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:posthog_flutter/src/replay/element_parsers/element_parser.dart';
@@ -6,18 +8,18 @@ import 'package:posthog_flutter/src/replay/size_extension.dart';
 
 /// Parser for [RenderEditable] objects (TextField input text).
 ///
-/// Unlike [RenderParagraph] (used by Text widgets) where `size` and `paintBounds`
-/// reflect the actual rendered text dimensions including font scaling, [RenderEditable]
-/// only reports its layout bounds which can be very small (e.g., 1-2px height) when
-/// used with `isDense: true` or constrained layouts like `Expanded`.
+/// The mask height is the larger of two bounds, because neither is enough on
+/// its own:
 ///
-/// Example with ScreenUtil scaling:
-/// - RenderParagraph: size = 28px (actual text height) ✓
-/// - RenderEditable: size = 1.3px (layout bounds), preferredLineHeight = 39px (actual)
-///
-/// This parser uses [RenderEditable.preferredLineHeight] to determine the actual
-/// rendered text height, ensuring the mask properly covers the visible text regardless
-/// of the font scaling mechanism used (ScreenUtil, MediaQuery.textScaleFactor, etc.).
+/// - `size.height` is the layout height. Unlike [RenderParagraph], whose `size`
+///   reflects the rendered text, a [RenderEditable] can be laid out far smaller
+///   than the text it paints when the field is dense or constrained
+///   (`isDense: true`, `Expanded`, ScreenUtil scaling): 1.3px tall with a
+///   `preferredLineHeight` of 39px has been measured.
+/// - `preferredLineHeight * maxLines` estimates the painted text from the line
+///   count, but `maxLines` is null for an auto-growing field (`maxLines: null`,
+///   `expands: true`), whose real height grows with its content. Treated as a
+///   single line, only the first line of such a field would be masked.
 class RenderEditableParser extends ElementParser {
   @override
   ElementGeometry? buildElementData(Element element) {
@@ -28,14 +30,12 @@ class RenderEditableParser extends ElementParser {
       return null;
     }
 
-    // Use preferredLineHeight instead of size.height because RenderEditable's
-    // layout height can be much smaller than the actual rendered text height
-    final textHeight = renderObject.preferredLineHeight;
     final width = renderObject.size.width;
-
-    // Account for multiline TextFields
     final lines = renderObject.maxLines ?? 1;
-    final height = textHeight * lines;
+    final height = math.max(
+      renderObject.size.height,
+      renderObject.preferredLineHeight * lines,
+    );
 
     final localRect = Rect.fromLTWH(0, 0, width, height);
     final ancestor = PostHogMaskController.instance.containerKey.currentContext

--- a/posthog_flutter/test/render_editable_mask_test.dart
+++ b/posthog_flutter/test/render_editable_mask_test.dart
@@ -1,0 +1,242 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:posthog_flutter/src/posthog_flutter_platform_interface.dart';
+import 'package:posthog_flutter/src/replay/mask/image_mask_painter.dart';
+import 'package:posthog_flutter/src/replay/mask/posthog_mask_controller.dart';
+
+import 'posthog_flutter_platform_interface_fake.dart';
+
+const _fourLines = 'line one\nline two\nline three\nline four';
+const _black = Color(0xFF000000);
+
+Future<Color> _pixel(ui.Image image, int x, int y) async {
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  final bytes = data!.buffer.asUint8List();
+  final i = (y * image.width + x) * 4;
+  return Color.fromARGB(bytes[i + 3], bytes[i], bytes[i + 1], bytes[i + 2]);
+}
+
+void main() {
+  setUp(() async {
+    PosthogFlutterPlatformInterface.instance = PosthogFlutterPlatformFake();
+    final config = PostHogConfig('test_project_token');
+    config.sessionReplayConfig.maskAllTexts = true;
+    await Posthog().setup(config);
+    // the controller singleton may have been created before this setup
+    PostHogMaskController.instance.refreshParsers(config.sessionReplayConfig);
+  });
+
+  tearDown(() async {
+    PostHogMaskController.instance.refreshParsers(null);
+    await Posthog().close();
+  });
+
+  Future<void> pumpField(WidgetTester tester, Widget field) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RepaintBoundary(
+          key: PostHogMaskController.instance.containerKey,
+          child: Scaffold(
+            body: Center(child: SizedBox(width: 300, child: field)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  TextEditingController controller(String text) {
+    final controller = TextEditingController(text: text);
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  RenderObject container() =>
+      PostHogMaskController.instance.containerKey.currentContext!
+          .findRenderObject()!;
+
+  RenderEditable editable(WidgetTester tester) =>
+      tester.allRenderObjects.whereType<RenderEditable>().single;
+
+  /// The field's laid-out bounds in the screenshot container's coordinates.
+  Rect editableBounds(WidgetTester tester) {
+    final renderObject = editable(tester);
+    return MatrixUtils.transformRect(
+      renderObject.getTransformTo(container()),
+      Offset.zero & renderObject.size,
+    );
+  }
+
+  /// The `_Editable` mask in the screenshot container's coordinates.
+  Rect editableMask() {
+    final elements = PostHogMaskController.instance
+        .getMaskElements(includeAllWidgets: true)!;
+    final element = elements.singleWhere((e) => e.type == '_Editable');
+    return MatrixUtils.transformRect(element.transform!, element.rect);
+  }
+
+  testWidgets('TextField(maxLines: null) is masked over its full height',
+      (tester) async {
+    await pumpField(
+      tester,
+      TextField(maxLines: null, controller: controller(_fourLines)),
+    );
+
+    final renderObject = editable(tester);
+    expect(renderObject.maxLines, isNull);
+    expect(
+      renderObject.size.height,
+      moreOrLessEquals(4 * renderObject.preferredLineHeight, epsilon: 1),
+    );
+
+    final mask = editableMask();
+    expect(mask.height, moreOrLessEquals(renderObject.size.height));
+    expect(mask, rectMoreOrLessEquals(editableBounds(tester)));
+  });
+
+  testWidgets('TextField(expands: true) is masked over the box it fills',
+      (tester) async {
+    await pumpField(
+      tester,
+      SizedBox(
+        height: 200,
+        width: 300,
+        child: TextField(
+          maxLines: null,
+          expands: true,
+          decoration: null,
+          controller: controller('one line'),
+        ),
+      ),
+    );
+
+    final renderObject = editable(tester);
+    expect(renderObject.size.height, greaterThanOrEqualTo(200));
+
+    final mask = editableMask();
+    expect(mask.height, greaterThanOrEqualTo(200));
+    expect(mask, rectMoreOrLessEquals(editableBounds(tester)));
+  });
+
+  for (final (name, build)
+      in <(String, Widget Function(TextEditingController))>[
+    ('TextFormField', (c) => TextFormField(maxLines: null, controller: c)),
+    (
+      'CupertinoTextField',
+      (c) => CupertinoTextField(maxLines: null, controller: c)
+    ),
+  ]) {
+    testWidgets('$name(maxLines: null) is masked over its full height',
+        (tester) async {
+      await pumpField(tester, build(controller(_fourLines)));
+
+      final renderObject = editable(tester);
+      expect(
+        renderObject.size.height,
+        moreOrLessEquals(4 * renderObject.preferredLineHeight, epsilon: 1),
+      );
+      expect(
+        editableMask().height,
+        moreOrLessEquals(renderObject.size.height),
+      );
+    });
+  }
+
+  testWidgets('TextField(maxLines: 3) still masks three lines', (tester) async {
+    await pumpField(
+      tester,
+      TextField(maxLines: 3, controller: controller(_fourLines)),
+    );
+
+    final renderObject = editable(tester);
+    expect(
+      editableMask().height,
+      moreOrLessEquals(3 * renderObject.preferredLineHeight),
+    );
+  });
+
+  testWidgets('a dense single-line field still masks at least one line',
+      (tester) async {
+    await pumpField(
+      tester,
+      TextField(
+        decoration: const InputDecoration(isDense: true),
+        controller: controller('one line'),
+      ),
+    );
+
+    final renderObject = editable(tester);
+    expect(
+      editableMask().height,
+      greaterThanOrEqualTo(renderObject.preferredLineHeight),
+    );
+  });
+
+  testWidgets('a field laid out shorter than its text still masks one line',
+      (tester) async {
+    await pumpField(
+      tester,
+      SizedBox(
+        height: 4,
+        width: 300,
+        child: TextField(decoration: null, controller: controller('one line')),
+      ),
+    );
+
+    final renderObject = editable(tester);
+    expect(
+        renderObject.size.height, lessThan(renderObject.preferredLineHeight));
+    expect(
+      editableMask().height,
+      moreOrLessEquals(renderObject.preferredLineHeight),
+    );
+  });
+
+  testWidgets('the masked capture blacks out the fourth line of the field',
+      (tester) async {
+    const textColor = Color(0xFF1A237E);
+    await pumpField(
+      tester,
+      TextField(
+        maxLines: null,
+        decoration: null,
+        style: const TextStyle(fontSize: 24, height: 1, color: textColor),
+        controller: controller('XXXX\nXXXX\nXXXX\nXXXX'),
+      ),
+    );
+
+    final renderObject = editable(tester);
+    final bounds = editableBounds(tester);
+    // the middle of the first glyph on line four
+    final x = (bounds.left + 12).round();
+    final y = (bounds.top + 3.5 * renderObject.preferredLineHeight).round();
+
+    // The same three stages as ScreenshotCapturer: snapshot the container,
+    // walk the tree for mask rects, paint the masks over the snapshot.
+    final boundary = container() as RenderRepaintBoundary;
+    final elements = PostHogMaskController.instance
+        .getMaskElements(includeAllWidgets: true)!;
+    // real async work: it never completes inside the test's FakeAsync zone
+    final (unmasked, masked) = (await tester.runAsync(() async {
+      final image = await boundary.toImage(pixelRatio: 1);
+      final recorder = ui.PictureRecorder();
+      final canvas = Canvas(recorder);
+      canvas.drawImage(image, Offset.zero, Paint());
+      ImageMaskPainter().drawMaskedImage(canvas, elements, 1);
+      final maskedImage =
+          await recorder.endRecording().toImage(image.width, image.height);
+      final colors =
+          (await _pixel(image, x, y), await _pixel(maskedImage, x, y));
+      image.dispose();
+      maskedImage.dispose();
+      return colors;
+    }))!;
+
+    expect(unmasked, textColor);
+    expect(masked, _black);
+  });
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Session replay masks a text field's input by painting a black rectangle over its `RenderEditable`. `RenderEditableParser` sized that rectangle as `preferredLineHeight * (maxLines ?? 1)`, deliberately ignoring `size.height`, because a dense or constrained field (`isDense: true`, `Expanded`, ScreenUtil scaling) can be laid out far shorter than the text it paints — the file documents a 1.3px layout height against a 39px line.

An auto-growing field has `maxLines: null` (`TextField(maxLines: null)`, `TextFormField(maxLines: null)`, `CupertinoTextField(maxLines: null)`, and `expands: true`), so the estimate fell back to one line while the field's real height grew with its content. Every line after the first was recorded unmasked. "Notes", "address" and "message" fields are commonly built this way.

Measured on `main` with a 300px-wide `TextField(maxLines: null)` holding four lines (Material 3 default text style, `preferredLineHeight` 24):

| | `RenderEditable.size.height` | mask height on `main` | mask height, this PR |
|---|---|---|---|
| `TextField(maxLines: null)`, 4 lines | 96 | **24** | 96 |
| `CupertinoTextField(maxLines: null)`, 4 lines | 68 | **17** | 68 |
| `TextField(maxLines: null, expands: true)` in a 200px box | 200 | **24** | 200 |

The mask height is now the larger of the two bounds, `max(size.height, preferredLineHeight * (maxLines ?? 1))`. The line-count estimate still protects the dense and constrained cases, and `size.height` extends the mask to the field's real height when the field is taller than the estimate. No mask gets smaller than it is today.

| `main` | this PR |
|---|---|
| ![only the first line masked](https://raw.githubusercontent.com/lukas-roqqu/posthog-flutter/37227f6141627ef2a4b1deae1bcb6457735c6933/vm-before.png) | ![the whole field masked](https://raw.githubusercontent.com/lukas-roqqu/posthog-flutter/37227f6141627ef2a4b1deae1bcb6457735c6933/vm-after.png) |

The two frames above are produced by the same three stages the SDK uses (`RepaintBoundary.toImage` → `getMaskElements` → `ImageMaskPainter`) on a 300px-wide auto-growing field with four lines of content and an unmasked label below it. On `main` only the first line is covered; with this PR the mask stops at the field's border and the label is untouched.


### On device

The example app ran on an iOS 26 simulator (iPhone 17) against a local HTTP server standing in for PostHog, which served a real project's remote config (`sessionRecording` enabled) and stored every `/s/` upload. Nothing was sent to PostHog. The frames below are the `$snapshot` payloads the SDK actually shipped (402×874 WebP, decoded), with `maskAllTexts = true` and the new "Test 11b" case moved to the top of the masking tests screen for the run. Same build otherwise; only `render_editable_parser.dart` differs.

| `main` | this PR |
|---|---|
| ![shipped frame on main: lines two to four readable](https://raw.githubusercontent.com/lukas-roqqu/posthog-flutter/37227f6141627ef2a4b1deae1bcb6457735c6933/device-before.png) | ![shipped frame with the fix: the whole field is black](https://raw.githubusercontent.com/lukas-roqqu/posthog-flutter/37227f6141627ef2a4b1deae1bcb6457735c6933/device-after.png) |

On `main` the shipped frame shows "Line two", "Line three" and "Line four" in the clear; with the fix the field is black to its border and every other mask on the screen is unchanged.

### Scope

- The `RenderEditable` mask only. Text, images and platform views are not touched.
- A field with `maxLines: N` and fewer lines of content is still masked to `N` lines, as before — this PR never shrinks a mask.
- The public API is unchanged (`make checkApiDart` passes against the checked-in snapshot).

## :green_heart: How did you test it?

`posthog_flutter/test/render_editable_mask_test.dart` (new, 8 tests) pumps each field under the mask controller's `RepaintBoundary`, reads the `_Editable` mask from `getMaskElements(includeAllWidgets: true)`, maps it into container coordinates with the element's transform, and compares it with the `RenderEditable`'s laid-out bounds.

| # | test | on `main` | this PR |
|---|---|---|---|
| 1 | `TextField(maxLines: null)` is masked over its full height | fails — expected 96.0, actual 24.0 | passes |
| 2 | `TextField(expands: true)` is masked over the box it fills (200px `SizedBox`) | fails | passes |
| 3 | `TextFormField(maxLines: null)` is masked over its full height | fails | passes |
| 4 | `CupertinoTextField(maxLines: null)` is masked over its full height | fails — expected 68.0, actual 17.0 | passes |
| 5 | `TextField(maxLines: 3)` still masks three lines | passes | passes |
| 6 | a dense single-line field (`isDense: true`) still masks at least one line | passes | passes |
| 7 | a field laid out shorter than its text (4px `SizedBox`) still masks one line | passes | passes |
| 8 | the masked capture blacks out the fourth line of the field (pixel-level) | fails — pixel is the text colour, not black | passes |

Tests 5–7 are regression guards for the line-count estimate; 7 squeezes the `RenderEditable` to 4px and checks the mask stays `preferredLineHeight` tall, which is exactly what `size.height` on its own would break. Test 8 captures the frame with `RepaintBoundary.toImage`, paints the masks with `ImageMaskPainter().drawMaskedImage`, and asserts the pixel at the centre of line four is `0xFF000000` in the masked frame and the text colour in the unmasked one.

Full suite: **348 tests pass** (340 existing + 8 new).

The example app gains "Test 11b: Auto-growing TextField (maxLines: null)" on the masking tests screen, pre-filled with four lines, next to the existing three-line case.

Checks run from the repository root:

```
dart format --set-exit-if-changed ./   # Formatted 134 files (0 changed)
dart analyze .                          # No issues found!
make checkApiDart                       # posthog_flutter public API snapshot is up to date.
cd posthog_flutter && flutter test      # +348: All tests passed!
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. — no user-facing API change; the parser's doc comment is updated
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a patch changeset file manually, equivalent to `pnpm changeset`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The work was directed by the PR author (@lukas-roqqu, DRI), who found the leak while auditing session replay masks in a fintech app, and reviewed the diff, the tests and the device frames. It was implemented with Claude Code (Claude Fable 5.1) using file tools, git and `flutter test`. The one design decision was to keep the existing line-count estimate and take the larger of the two bounds rather than switch to `size.height`, so the dense and constrained cases the parser already handles stay protected; test 7 pins that down.
