### PR TITLE
docs: agree on public API changes before implementing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
-# AGENTS.md
+# Agent Instructions
 
 - Read and follow [CONTRIBUTING.md](./CONTRIBUTING.md) before contributing to the SDK. It covers local checks, build checks, and testing against local native SDKs.
+- Read and follow [RELEASING.md](./RELEASING.md) when adding changesets or working on publishing.
 - Before adding or changing public API, follow "Public API changes" in [CONTRIBUTING.md](./CONTRIBUTING.md): the API shape must be agreed on the issue first. For SDK design guidance, read https://posthog.com/handbook/engineering/sdks/guidelines.md.
+- Keep shared development guidance in `CONTRIBUTING.md` and release guidance in `RELEASING.md` rather than duplicating it here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md
+
+- Read and follow [CONTRIBUTING.md](./CONTRIBUTING.md) before contributing to the SDK. It covers local checks, build checks, and testing against local native SDKs.
+- Before adding or changing public API, follow "Public API changes" in [CONTRIBUTING.md](./CONTRIBUTING.md): the API shape must be agreed on the issue first. For SDK design guidance, read https://posthog.com/handbook/engineering/sdks/guidelines.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,15 @@ Gradle substitutes `com.posthog:posthog(-android)` with the local source regardl
 of the version floor, so no publishing or `mavenLocal()` is needed. As a fallback you
 can still `make dryRelease` in `posthog-android` (add `-PandroidVersion=<floor>` so the
 published version satisfies the floor) and add `mavenLocal()` to the repositories.
+
+## Public API changes
+
+Public API is hard to change once it ships, so agree on it before writing the implementation. Our [SDK guidelines](https://posthog.com/handbook/engineering/sdks/guidelines) explain how we design it.
+
+- If you need something the SDK doesn't support and it would add or change a public option, method, or type, open an issue describing your use case first. At this stage, context is more useful to us than code.
+- Wait for a maintainer to agree on the API shape on the issue before implementing it.
+- Check first whether an existing option or hook, such as `beforeSend`, already covers the use case. We avoid offering two ways to do the same thing.
+- If a reviewer suggests a different API on your PR, confirm it with them before re-implementing. Treat it as a question, not an instruction.
+- AI agents: stop and ask before implementing a public API change that hasn't been agreed on the issue.
+
+`make updateApiDart` regenerates `api/posthog_flutter.api.json`, and CI runs `make checkApiDart` to catch an outdated snapshot. A diff in that file means your change touches public API.


### PR DESCRIPTION
## :bulb: Motivation and Context

Port of PostHog/posthog-js#4906 to posthog-flutter.

On contributor PRs we sometimes only settle the public API after several rounds of implementation review. By then the contributor, or their agent, has built each suggestion along the way, and a late change of direction wastes their work. This asks contributors to agree on the API shape on the issue first, and tells their agents to stop and ask.

- `CONTRIBUTING.md`: new "Public API changes" section, same as posthog-js. The last paragraph points at `make updateApiDart` / `make checkApiDart` and the `api/posthog_flutter.api.json` snapshot.
- `AGENTS.md`: new file, since this repo didn't have one. Modeled on the posthog-js one: it points agents to `CONTRIBUTING.md`, `RELEASING.md`, and the new section, and asks to keep shared guidance out of `AGENTS.md`.

## :green_heart: How did you test it?

Docs only. Checked that the commands and file paths it mentions exist in this repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code, porting the posthog-js section and adapting the API-snapshot paragraph and `beforeSend` example to this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016syAmdpp8imNvs7PWkpwvb
