### PR TITLE
fix(android): replay a notification tap that lands before setup

### DIFF
--- a/.changeset/replay-pre-setup-push-intent.md
+++ b/.changeset/replay-pre-setup-push-intent.md
@@ -2,4 +2,4 @@
 'posthog_flutter': patch
 ---
 
-Fix `$push_notification_opened` being lost on Android when a notification tap reaches the app before `Posthog().setup()` runs and the app's FCM layer does not refresh the Activity intent.
+Fix `$push_notification_opened` being lost on Android when a notification tap reaches the app before `Posthog().setup()` runs.

--- a/.changeset/replay-pre-setup-push-intent.md
+++ b/.changeset/replay-pre-setup-push-intent.md
@@ -1,0 +1,5 @@
+---
+'posthog_flutter': patch
+---
+
+Fix `$push_notification_opened` being lost on Android when a notification tap reaches the app before `Posthog().setup()` runs and the app's FCM layer does not refresh the Activity intent.

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -806,9 +806,6 @@ class PosthogFlutterPlugin :
      * not stay on `Activity.getIntent()` — Android only updates that if someone calls `setIntent`,
      * which is `firebase_messaging`'s doing, not the framework's. Without this the event survives
      * only by that accident, and any other FCM layer loses it.
-     *
-     * At most one: a newer tap supersedes an unreplayed older one, and an `Intent` retains its
-     * extras, not the Activity.
      */
     @VisibleForTesting
     internal var pendingPushIntent: Intent? = null

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -49,6 +49,9 @@ import kotlin.math.roundToInt
 private const val FLUTTER_VIEW_CLASS_PREFIX = "io.flutter"
 private const val OCCLUSION_TICK_MS = 1000L
 
+// The extra posthog-android reads a tray tap from, and dedupes it by.
+private const val GOOGLE_MESSAGE_ID = "google.message_id"
+
 // Ticks a not-occluded read must repeat before it ends an episode. Both the
 // active and the inactive path debounce, and they have to agree.
 private const val END_DEBOUNCE_TICKS = 1
@@ -798,6 +801,19 @@ class PosthogFlutterPlugin :
     }
 
     /**
+     * The last tray tap seen by [newIntentListener], kept so setup can replay it. A tap that lands
+     * before `Posthog().setup()` is dropped by `PostHogAndroid` (the SDK isn't set up yet) and does
+     * not stay on `Activity.getIntent()` — Android only updates that if someone calls `setIntent`,
+     * which is `firebase_messaging`'s doing, not the framework's. Without this the event survives
+     * only by that accident, and any other FCM layer loses it.
+     *
+     * At most one: a newer tap supersedes an unreplayed older one, and an `Intent` retains its
+     * extras, not the Activity.
+     */
+    @VisibleForTesting
+    internal var pendingPushIntent: Intent? = null
+
+    /**
      * The SDK reads a notification tap from the launch Activity's intent when that Activity is
      * created, which is long before Dart reaches `Posthog().setup()` — by then `onCreate`, `onStart`
      * and `onResume` have all run. The intent is still on the Activity, so hand it over once both the
@@ -808,9 +824,15 @@ class PosthogFlutterPlugin :
      * Activity yet, while on the Dart path the Activity is attached long before setup runs. Whichever
      * precondition is satisfied last does the work; `PostHogAndroid` dedupes by message id, so a
      * double call cannot double-count.
+     *
+     * A tap remembered by [newIntentListener] wins over the Activity's intent: it is the tap the user
+     * actually made, while `getIntent()` may still hold the stale launch intent.
      */
-    private fun capturePushNotificationOpenedFromLaunchIntent() {
-        PostHogAndroid.capturePushNotificationOpened(activity?.intent)
+    @VisibleForTesting
+    internal fun capturePushNotificationOpenedFromLaunchIntent() {
+        val intent = pendingPushIntent ?: activity?.intent
+        pendingPushIntent = null
+        PostHogAndroid.capturePushNotificationOpened(intent)
     }
 
     /**
@@ -820,9 +842,23 @@ class PosthogFlutterPlugin :
      */
     private val newIntentListener =
         PluginRegistry.NewIntentListener { intent ->
+            rememberPushIntent(intent)
             PostHogAndroid.capturePushNotificationOpened(intent)
             false
         }
+
+    /** Only a tray tap is worth replaying; anything else would just be a reference held for nothing. */
+    private fun rememberPushIntent(intent: Intent?) {
+        try {
+            if (intent?.getStringExtra(GOOGLE_MESSAGE_ID) != null) {
+                pendingPushIntent = intent
+            }
+        } catch (e: Throwable) {
+            // Reading an extra unmarshals the whole Bundle, which throws
+            // BadParcelableException for a class this app cannot load.
+            Log.w("PostHog", "Failed to read push notification intent: $e")
+        }
+    }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
@@ -862,6 +898,9 @@ class PosthogFlutterPlugin :
     private fun removeNewIntentListener() {
         activityBinding?.removeOnNewIntentListener(newIntentListener)
         activityBinding = null
+        // The tap belonged to the Activity going away. Replaying it into the next one — or into a
+        // second engine that sets up later — would attribute it to a launch the user never made.
+        pendingPushIntent = null
     }
 
     // Idempotent: registering the same callbacks twice makes them fire twice.

--- a/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
+++ b/posthog_flutter/android/src/main/kotlin/com/posthog/flutter/PosthogFlutterPlugin.kt
@@ -844,7 +844,10 @@ class PosthogFlutterPlugin :
             false
         }
 
-    /** Only a tray tap is worth replaying; anything else would just be a reference held for nothing. */
+    /**
+     * Only a tray tap is worth remembering: anything else kept here would shadow the
+     * `activity?.intent` fallback at setup, on top of being a reference held for nothing.
+     */
     private fun rememberPushIntent(intent: Intent?) {
         try {
             if (intent?.getStringExtra(GOOGLE_MESSAGE_ID) != null) {
@@ -895,8 +898,9 @@ class PosthogFlutterPlugin :
     private fun removeNewIntentListener() {
         activityBinding?.removeOnNewIntentListener(newIntentListener)
         activityBinding = null
-        // The tap belonged to the Activity going away. Replaying it into the next one — or into a
-        // second engine that sets up later — would attribute it to a launch the user never made.
+        // The tap belonged to the Activity going away; replaying it into the next one would
+        // attribute it to a launch the user never made. A configuration change between the tap and
+        // setup() therefore loses the event — a miss beats a wrong attribution.
         pendingPushIntent = null
     }
 

--- a/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
+++ b/posthog_flutter/android/src/test/kotlin/com/posthog/flutter/PosthogFlutterPluginTest.kt
@@ -2,12 +2,15 @@ package com.posthog.flutter
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
+import android.os.BadParcelableException
 import com.google.firebase.FirebaseApp
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.StandardMethodCodec
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
@@ -18,6 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /*
@@ -446,6 +450,86 @@ internal class PosthogFlutterPluginTest {
         plugin.onMethodCall(call, mockResult)
 
         Mockito.verify(mockResult).success(null)
+    }
+
+    @Test
+    fun onNewIntent_trayTap_isRememberedForSetupToReplay() {
+        val plugin = PosthogFlutterPlugin()
+        val listener = attachActivity(plugin)
+        val intent = trayIntent("m1")
+
+        assertFalse(listener.onNewIntent(intent))
+        assertSame(intent, plugin.pendingPushIntent)
+    }
+
+    @Test
+    fun onNewIntent_withoutMessageId_isNotRemembered() {
+        val plugin = PosthogFlutterPlugin()
+        val listener = attachActivity(plugin)
+
+        assertFalse(listener.onNewIntent(Mockito.mock(Intent::class.java)))
+        assertNull(plugin.pendingPushIntent)
+    }
+
+    @Test
+    fun onNewIntent_unreadableExtras_isNotRememberedAndDoesNotThrow() {
+        val plugin = PosthogFlutterPlugin()
+        val listener = attachActivity(plugin)
+        val intent = Mockito.mock(Intent::class.java)
+        Mockito
+            .`when`(intent.getStringExtra("google.message_id"))
+            .thenThrow(BadParcelableException("unknown extra class"))
+
+        assertFalse(listener.onNewIntent(intent))
+        assertNull(plugin.pendingPushIntent)
+    }
+
+    @Test
+    fun onNewIntent_secondTrayTap_supersedesTheFirst() {
+        val plugin = PosthogFlutterPlugin()
+        val listener = attachActivity(plugin)
+        val second = trayIntent("m2")
+
+        listener.onNewIntent(trayIntent("m1"))
+        listener.onNewIntent(second)
+
+        assertSame(second, plugin.pendingPushIntent)
+    }
+
+    @Test
+    fun launchIntentReplay_consumesTheRememberedTapOnce() {
+        val plugin = PosthogFlutterPlugin()
+        val listener = attachActivity(plugin)
+        listener.onNewIntent(trayIntent("m1"))
+
+        plugin.capturePushNotificationOpenedFromLaunchIntent()
+
+        assertNull(plugin.pendingPushIntent)
+    }
+
+    @Test
+    fun onDetachedFromActivity_dropsTheRememberedTap() {
+        val plugin = PosthogFlutterPlugin()
+        val listener = attachActivity(plugin)
+        listener.onNewIntent(trayIntent("m1"))
+
+        plugin.onDetachedFromActivity()
+
+        assertNull(plugin.pendingPushIntent)
+    }
+
+    private fun trayIntent(messageId: String): Intent =
+        Mockito.mock(Intent::class.java).also {
+            Mockito.`when`(it.getStringExtra("google.message_id")).thenReturn(messageId)
+        }
+
+    private fun attachActivity(plugin: PosthogFlutterPlugin): PluginRegistry.NewIntentListener {
+        val binding = Mockito.mock(ActivityPluginBinding::class.java)
+        Mockito.`when`(binding.activity).thenReturn(Mockito.mock(Activity::class.java))
+        plugin.onAttachedToActivity(binding)
+        val captor = ArgumentCaptor.forClass(PluginRegistry.NewIntentListener::class.java)
+        Mockito.verify(binding).addOnNewIntentListener(captor.capture())
+        return captor.value
     }
 
     // The stubbed test Looper makes runOnMainThread run inline (myLooper and


### PR DESCRIPTION
## :bulb: Motivation and Context

On Android, `$push_notification_opened` for a tap that arrives **before** `Posthog().setup()` runs is captured today only by accident — it depends on `firebase_messaging` doing us a favour.

The scenario (measured on a device):

1. Launch the app, press HOME.
2. Send an FCM tray notification.
3. `am kill` the process — the task stays in recents.
4. Tap the notification.

With `com.posthog.posthog.AUTO_INIT` **disabled** (what our own example ships), the plugin's `PluginRegistry.NewIntentListener` fires before Dart reaches `Posthog().setup()`, so `PostHogAndroid.capturePushNotificationOpened(intent)` no-ops — the SDK isn't set up yet. Android does **not** put that intent on `Activity.getIntent()` either, so the later read at setup finds the stale launch intent.

The event still lands today only because `firebase_messaging`'s own `NewIntentListener` runs first and calls `mainActivity.setIntent(intent)` ([`FlutterFirebaseMessagingPlugin.handleNotificationIntent`](https://github.com/firebase/flutterfire/blob/master/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java)), which makes our later `activity?.intent` read find the push intent. Suppressing that one `setIntent` call drops the captured count to **0**.

So any app whose FCM layer doesn't refresh the intent silently loses the tap: a hand-rolled `FirebaseMessagingService`, another push wrapper, or `firebase_messaging` itself when the message isn't in its store.

**The fix:** the listener remembers the tap, and setup prefers it over `activity?.intent`. Only an intent carrying `google.message_id` is kept, at most one, cleared on consume and on activity detach. The listener still calls `PostHogAndroid.capturePushNotificationOpened(intent)` exactly as before, so the AUTO_INIT-enabled path is untouched — and `PostHogAndroid` dedupes by `google.message_id`, so the two calls can't double-count.

Related:
- PostHog/posthog-flutter#557 — the original cold-start push-open issue this path came from.
- PostHog/posthog-android#783 — the native `capturePushNotificationOpened(intent)` entry point this uses.
- PostHog/posthog-js#4929 — the same scenario in React Native.
- Independent of PostHog/posthog-flutter#578, which only raises the posthog-android floor. This is based on `main`.

## :green_heart: How did you test it?

**Kotlin unit tests** (`PosthogFlutterPluginTest`, all 42 green via `./gradlew :posthog_flutter:testDebugUnitTest`): a tray tap is remembered, a non-push intent isn't, a second tap supersedes the first, an intent whose extras throw `BadParcelableException` is skipped without throwing, the replay consumes the remembered tap once, and detach drops it.

Also green: `flutter test` (351), `dart analyze`, `dart format`, ktlint, and the Dart public API snapshot.

**On an emulator** (API 34, `google_apis`), Flutter example app + real `firebase_messaging`, a real tray tap via `uiautomator`, counting `$push_notification_opened` in the `/batch` payloads posted to a local mock server. `setIntent` was suppressed with a temporary, uncommitted override in the example's `MainActivity`.

| firebase `setIntent` | `AUTO_INIT` | before | after |
| --- | --- | --- | --- |
| real | disabled | 1 | 1 |
| real | enabled | 1 | 1 |
| **suppressed** | **disabled** | **0** | **1** |
| suppressed | enabled | 1 | 1 |

No double counting anywhere: each run logged exactly one `Queued Event $push_notification_opened`. Also checked on the fixed build — an ordinary cold start (app not running, tap launches it): **1**; a warm tap (process alive, `onNewIntent`): **1**.

**Falsification:** with only the replay removed (`pendingPushIntent ?: activity?.intent` → `activity?.intent`, listener still remembering, detach still clearing), the third row goes back to **0**.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The bug was already localised in a prior investigation; this PR implements the agreed fix and re-confirms it on hardware.

Decisions along the way:

- **Remember the intent rather than call `setIntent` ourselves.** Writing to the host Activity's intent is a side effect other plugins observe, and it would make us the second plugin racing over the same field. Keeping our own reference changes nothing outside the plugin.
- **Only intents carrying `google.message_id` are kept**, so we never hold an arbitrary intent, and at most one — an `Intent` retains its extras, not the Activity.
- **Cleared on detach**, so a tap can't be replayed into a later activity. The cost is a lost capture if the activity is destroyed for a config change in the sub-second window between the tap and `setup()`; standard Flutter activities declare `configChanges` for orientation, so that path is rare, and losing an event is the safer failure direction than mis-attributing one.
- **Reading the extra is wrapped in `try`/`catch`** — unmarshalling the Bundle throws `BadParcelableException` when it carries a class this app can't load, which the native SDK already guards against on its own path.

## Related PRs

One push-open capture effort across the mobile SDKs: count every notification tap exactly once, and stop losing taps the SDK starts too late to see.

| PR | What it does | Blocked by |
| --- | --- | --- |
| PostHog/posthog-android#783 | Core: capture each PostHog push open once, whichever path reports it (ships as 3.65.0) | – |
| PostHog/posthog-ios#828 | Same rule on iOS, so both platforms behave identically (ships as 3.75.0) | – |
| PostHog/posthog-js#4921 | React Native on iOS: capture a tap that launches the app | – |
| PostHog/posthog-js#4929 | React Native on Android: capture a tap lost when the process was killed but the task stayed in recents | – |
| **PostHog/posthog-flutter#579** (this PR) | Flutter: replay a tap that arrives before the SDK is set up, instead of relying on `firebase_messaging` | – |
| PostHog/posthog-js#4919 | React Native plugin: take the core dedupe, drop the plugin-level copy | posthog-android 3.65.0 |
| PostHog/posthog-flutter#578 | Flutter plugin: take the core dedupe, drop the plugin-level copy | posthog-android 3.65.0 |
| PostHog/posthog.com#20114 | Docs corrections that are wrong today, independent of any release | – |
| PostHog/posthog.com#20102 | Docs for the release-dependent behavior changes | the SDK releases above |

**Merge order:** posthog-android#783 and posthog-ios#828 first, then their releases. #4921, #4929 and #579 are independent and can go any time. #4919 and #578 go green once posthog-android 3.65.0 is published. Docs: #20114 can go now; #20102 last, after the releases.

**Earlier work this builds on:** PostHog/posthog-android#753, PostHog/posthog-ios#792, PostHog/posthog-js#4858, PostHog/posthog-flutter#556, PostHog/posthog-flutter#557, PostHog/posthog.com#19905.
